### PR TITLE
Enforce max_batch_size

### DIFF
--- a/hivemind/runtime/task_pool.py
+++ b/hivemind/runtime/task_pool.py
@@ -102,6 +102,10 @@ class TaskPool(TaskPoolBase):
         total_size = 0
 
         while True:
+            if total_size >= self.min_batch_size and self.tasks.empty():
+                yield batch
+                batch = []
+                total_size = 0
             try:
                 task = self.tasks.get(timeout=self.timeout)
             except Empty:
@@ -112,7 +116,7 @@ class TaskPool(TaskPoolBase):
 
             task_size = self.get_task_size(task)
 
-            if total_size + task_size > self.max_batch_size or total_size >= self.min_batch_size and self.tasks.empty():
+            if total_size + task_size > self.max_batch_size:
                 yield batch
                 batch = []
                 total_size = 0

--- a/hivemind/runtime/task_pool.py
+++ b/hivemind/runtime/task_pool.py
@@ -94,7 +94,7 @@ class TaskPool(TaskPoolBase):
         future1, future2 = SharedFuture.make_pair()
         task = Task(future1, args)
         if self.get_task_size(task) > self.max_batch_size:
-            exc = ValueError("Task size greater than max_batch_size, it will never be finished")
+            exc = ValueError(f"Task size greater than max_batch_size ({self.max_batch_size}), it will never be finished")
             future2.set_exception(exc)
         else:
             self.tasks.put(task)


### PR DESCRIPTION
Solves https://github.com/learning-at-home/hivemind/issues/22. We don't need to add tasks exceeding max_batch_size to the queue, so they can fail during submission. 

Also not entirely sure if the logic for `undispatched_task_timestamps` is done correctly (right now it is assumed that the timestamp put into the queue corresponds to the task being put back). Given that this queue is used only for priority computation, perhaps we can even leave it as is (without adding L124)? If we process a batch of tasks in the pool, its priority will strictly decrease