### PR TITLE
Deterministic dropout layer

### DIFF
--- a/hivemind/runtime/expert_backend.py
+++ b/hivemind/runtime/expert_backend.py
@@ -22,7 +22,7 @@ class ExpertBackend(nn.Module):
         - All \*args, \*\*kwargs and outputs must be **tensors** where 0-th dimension represents to batch size
         - We recommend using experts that are ~invariant to the order in which they process batches
         - Using randomness (e.g. Dropout) leads to different samples at forward and backward. If you want to ensure consistency,
-            you should register these samples as model outputs, so that they are sent back to the client.
+            you should explicitly register these random variables as model outputs, so that they are sent back to the client.
             See hivemind.utils.custom_layers.DeterministicDropout for an example
 
     :param opt: torch optimizer to be applied on every backward call

--- a/hivemind/runtime/expert_backend.py
+++ b/hivemind/runtime/expert_backend.py
@@ -68,8 +68,8 @@ class ExpertBackend(nn.Module):
 
            It should return gradients w.r.t. inputs that follow ``nested_flatten(self.outputs_schema)``;
 
-           TODO we handle layer states (e.g. batchnorm stats) incorrectly, updating them twice.
-           For now, either register all buffers as outputs or avoid stateful experts
+           .. todo we handle layer states (e.g. batchnorm stats) incorrectly, updating them twice.
+           .. For now, either register all buffers as outputs or avoid stateful experts
 
         """
         args, kwargs = nested_pack(inputs, structure=self.forward_schema)
@@ -93,7 +93,7 @@ class ExpertBackend(nn.Module):
            Runtime doesn't guarantee that backward will be performed in the same order and for the same data
            as forward, so we recommend stateless backward pass that re-runs expert forward pass inside backward.
 
-           TODO correct state handling (see forward)
+           .. todo correct state handling (see forward)
 
            Please make sure to call ``ExpertBackend.apply_gradients`` **within** this method, otherwise the expert will not train
         """

--- a/hivemind/utils/custom_layers.py
+++ b/hivemind/utils/custom_layers.py
@@ -11,7 +11,7 @@ class DeterministicDropoutFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        return ctx.mask * grad_output / ctx.keep_prob, None, None
+        return ctx.saved_tensors[0] * grad_output / ctx.keep_prob, None, None
 
 
 class DeterministicDropout(nn.Module):

--- a/hivemind/utils/custom_layers.py
+++ b/hivemind/utils/custom_layers.py
@@ -6,7 +6,7 @@ class DeterministicDropoutFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x, keep_prob, mask):
         ctx.keep_prob = keep_prob
-        ctx.mask = mask
+        ctx.save_for_backward(mask)
         return x * mask / keep_prob
 
     @staticmethod

--- a/hivemind/utils/custom_layers.py
+++ b/hivemind/utils/custom_layers.py
@@ -1,0 +1,26 @@
+import torch.autograd
+import torch.nn as nn
+
+
+class DeterministicDropoutFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, keep_prob, mask):
+        ctx.keep_prob = keep_prob
+        ctx.mask = mask
+        return x * mask / keep_prob
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return ctx.mask * grad_output / ctx.keep_prob, None, None
+
+
+class DeterministicDropout(nn.Module):
+    def __init__(self, drop_prob):
+        super().__init__()
+        self.keep_prob = 1 - drop_prob
+
+    def forward(self, x, mask):
+        if self.training:
+            return DeterministicDropoutFunction.apply(x, self.keep_prob, mask)
+        else:
+            return x

--- a/hivemind/utils/custom_layers.py
+++ b/hivemind/utils/custom_layers.py
@@ -15,6 +15,11 @@ class DeterministicDropoutFunction(torch.autograd.Function):
 
 
 class DeterministicDropout(nn.Module):
+    """
+    Custom dropout layer which accepts dropout mask as an input (drop_prob is only used for scaling input activations).
+    Can be used with RemoteExpert/ExpertBackend to ensure that dropout mask is the same at forward and backward steps
+    """
+
     def __init__(self, drop_prob):
         super().__init__()
         self.keep_prob = 1 - drop_prob

--- a/hivemind/utils/proto.py
+++ b/hivemind/utils/proto.py
@@ -45,7 +45,7 @@ class BatchTensorProto(TensorProto):
     @classmethod
     def from_tensor(cls, tensor: torch.Tensor):
         return cls(*tensor.shape[1:], dtype=tensor.dtype, layout=tensor.layout,
-                   device=tensor.device, requires_grad=tensor.requires_grad, pin_memory=tensor.is_pinned())
+                   device=tensor.device, requires_grad=tensor.requires_grad, pin_memory=torch.cuda.is_available() and tensor.is_pinned())
 
     def make_empty(self, batch_size, **kwargs):
         assert self.shape[0] is None, "Make sure 0-th dimension is not specified (set to None)"

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -59,6 +59,7 @@ def test_determinism():
 
         grad, = torch.autograd.grad(out.sum(), xx, retain_graph=True)
         grad_rerun, = torch.autograd.grad(out_rerun.sum(), xx, retain_graph=True)
+        grad += 1
 
     assert torch.allclose(out, out_rerun, rtol, atol), "Dropout layer outputs are non-deterministic."
     assert torch.allclose(grad, grad_rerun, rtol, atol), "Gradients are non-deterministic."

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -57,8 +57,8 @@ def test_determinism():
         out = expert(xx, mask)
         out_rerun = expert(xx, mask)
 
-        grad = torch.autograd.grad(out.sum(), xx, retain_graph=True)
-        grad_rerun = torch.autograd.grad(out_rerun.sum(), xx, retain_graph=True)
+        grad, = torch.autograd.grad(out.sum(), xx, retain_graph=True)
+        grad_rerun, = torch.autograd.grad(out_rerun.sum(), xx, retain_graph=True)
 
     assert torch.allclose(out, out_rerun, rtol, atol), "Dropout layer outputs are non-deterministic."
     assert torch.allclose(grad, grad_rerun, rtol, atol), "Gradients are non-deterministic."

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -91,3 +91,4 @@ def test_compute_expert_scores():
 if __name__ == '__main__':
     test_remote_module_call()
     test_compute_expert_scores()
+    test_determinism()

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -59,7 +59,6 @@ def test_determinism():
 
         grad, = torch.autograd.grad(out.sum(), xx, retain_graph=True)
         grad_rerun, = torch.autograd.grad(out_rerun.sum(), xx, retain_graph=True)
-        grad += 1
 
     assert torch.allclose(out, out_rerun, rtol, atol), "Dropout layer outputs are non-deterministic."
     assert torch.allclose(grad, grad_rerun, rtol, atol), "Gradients are non-deterministic."

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -43,6 +43,27 @@ def test_remote_module_call():
     assert torch.allclose(grad_logits_moe, grad_logits_manual, rtol, atol), "incorrect gradient w.r.t. logits"
 
 
+def test_determinism():
+    rtol = 0
+    atol = 1e-6
+
+    xx = torch.randn(32, 1024, requires_grad=True)
+    mask = torch.randint(0, 1, (32, 1024))
+
+    with background_server(num_experts=1, device='cpu', expert_cls='det_dropout',
+                           no_optimizer=True, no_dht=True) as (localhost, server_port, dht_port):
+        expert = hivemind.RemoteExpert(uid=f'expert.0', port=server_port)
+
+        out = expert(xx, mask)
+        out_rerun = expert(xx, mask)
+
+        grad = torch.autograd.grad(out.sum(), xx, retain_graph=True)
+        grad_rerun = torch.autograd.grad(out_rerun.sum(), xx, retain_graph=True)
+
+    assert torch.allclose(out, out_rerun, rtol, atol), "Dropout layer outputs are non-deterministic."
+    assert torch.allclose(grad, grad_rerun, rtol, atol), "Gradients are non-deterministic."
+
+
 def test_compute_expert_scores():
     try:
         dht = hivemind.DHTNode(port=hivemind.find_open_port(), start=True)

--- a/tests/test_utils/layers.py
+++ b/tests/test_utils/layers.py
@@ -64,7 +64,7 @@ class NopExpert(nn.Sequential):
 
 class DeterministicDropoutNetwork(nn.Module):
     def __init__(self, hid_dim, dropout_prob):
-        super().__init__(self)
+        super().__init__()
         self.linear_in = nn.Linear(hid_dim, 2 * hid_dim)
         self.activation = nn.ReLU()
         self.dropout = DeterministicDropout(dropout_prob)

--- a/tests/test_utils/layers.py
+++ b/tests/test_utils/layers.py
@@ -71,7 +71,7 @@ class DeterministicDropoutNetwork(nn.Module):
         self.linear_out = nn.Linear(2 * hid_dim, hid_dim)
 
     def forward(self, x, mask):
-        x = self.linear_in(self.dropout(x), mask)
+        x = self.linear_in(self.dropout(x, mask))
         return self.linear_out(self.activation(x))
 
 

--- a/tests/test_utils/layers.py
+++ b/tests/test_utils/layers.py
@@ -71,7 +71,7 @@ class DeterministicDropoutNetwork(nn.Module):
         self.linear_out = nn.Linear(2 * hid_dim, hid_dim)
 
     def forward(self, x, mask):
-        x = self.dropout(self.linear_in(x), mask)
+        x = self.linear_in(self.dropout(x), mask)
         return self.linear_out(self.activation(x))
 
 

--- a/tests/test_utils/run_server.py
+++ b/tests/test_utils/run_server.py
@@ -41,7 +41,7 @@ def make_dummy_server(host='0.0.0.0', port=None, num_experts=1, expert_cls='ffn'
     # initialize experts
     experts = {}
     for i in range(num_experts):
-        expert = torch.jit.script(name_to_block[expert_cls](hidden_dim))
+        expert = name_to_block[expert_cls](hidden_dim)
         opt = torch.optim.SGD(expert.parameters(), 0.0) if no_optimizer else torch.optim.Adam(expert.parameters())
         expert_uid = f'{expert_prefix}{UID_DELIMETER}{i + expert_offset}'
         experts[expert_uid] = hivemind.ExpertBackend(name=expert_uid, expert=expert, opt=opt,

--- a/tests/test_utils/run_server.py
+++ b/tests/test_utils/run_server.py
@@ -39,7 +39,7 @@ def make_dummy_server(host='0.0.0.0', port=None, num_experts=1, expert_cls='ffn'
             print(f"Running dht node on port {dht.port}")
 
     sample_input = name_to_input[expert_cls](4, hidden_dim)
-    if isinstance(input, tuple):
+    if isinstance(sample_input, tuple):
         args_schema = tuple(hivemind.BatchTensorProto.from_tensor(arg) for arg in sample_input)
     else:
         args_schema = (hivemind.BatchTensorProto.from_tensor(sample_input),)

--- a/tests/test_utils/run_server.py
+++ b/tests/test_utils/run_server.py
@@ -38,7 +38,7 @@ def make_dummy_server(host='0.0.0.0', port=None, num_experts=1, expert_cls='ffn'
         if verbose:
             print(f"Running dht node on port {dht.port}")
 
-    sample_input = name_to_input[expert_cls]
+    sample_input = name_to_input[expert_cls](4, hidden_dim)
     if isinstance(input, tuple):
         args_schema = tuple(hivemind.BatchTensorProto.from_tensor(arg) for arg in sample_input)
     else:

--- a/tests/test_utils/run_server.py
+++ b/tests/test_utils/run_server.py
@@ -10,7 +10,7 @@ from .layers import name_to_block
 
 def make_dummy_server(host='0.0.0.0', port=None, num_experts=1, expert_cls='ffn', hidden_dim=1024, num_handlers=None,
                       expert_prefix='expert', expert_offset=0, max_batch_size=16384, device=None, no_optimizer=False,
-                      no_dht=False, initial_peers=(), dht_port=None, root_port=None, verbose=True, start=False,
+                      no_dht=False, initial_peers=(), dht_port=None, root_port=None, verbose=True,
                       UID_DELIMETER=hivemind.DHTNode.UID_DELIMETER, **kwargs) -> hivemind.Server:
     """ A context manager that creates server in a background thread, awaits .ready on entry and shutdowns on exit """
     if verbose and len(kwargs) != 0:
@@ -27,7 +27,7 @@ def make_dummy_server(host='0.0.0.0', port=None, num_experts=1, expert_cls='ffn'
             dht_root = hivemind.DHTNode(
                 *initial_peers, port=root_port or hivemind.find_open_port(), start=True)
             print(f"Initializing DHT with port {dht_root.port}")
-            initial_peers = (('localhost', dht_root.port), )
+            initial_peers = (('localhost', dht_root.port),)
         else:
             print("Bootstrapping dht with peers:", initial_peers)
             if root_port is not None:
@@ -54,11 +54,10 @@ def make_dummy_server(host='0.0.0.0', port=None, num_experts=1, expert_cls='ffn'
         dht, experts, addr=host, port=port or hivemind.find_open_port(),
         conn_handler_processes=num_handlers, device=device)
 
-    if start:
-        server.run_in_background(await_ready=True)
-        if verbose:
-            print(f"Server started at {server.addr}:{server.port}")
-            print(f"Got {num_experts} active experts of type {expert_cls}: {list(experts.keys())}")
+    if verbose:
+        print(f"Server created at {server.addr}:{server.port}")
+        print(f"Got {num_experts} active experts of type {expert_cls}: {list(experts.keys())}")
+
     return server
 
 
@@ -125,8 +124,10 @@ if __name__ == '__main__':
 
     args['initial_peers'] = eval(args['initial_peers'])
 
+    server = make_dummy_server(**args, start=True, verbose=True)
+
     try:
-        server = make_dummy_server(**args, start=True, verbose=True)
+        server.run_in_background(await_ready=True)
         server.join()
     finally:
         server.shutdown()

--- a/tests/test_utils/run_server.py
+++ b/tests/test_utils/run_server.py
@@ -10,7 +10,7 @@ from .layers import name_to_block
 
 def make_dummy_server(host='0.0.0.0', port=None, num_experts=1, expert_cls='ffn', hidden_dim=1024, num_handlers=None,
                       expert_prefix='expert', expert_offset=0, max_batch_size=16384, device=None, no_optimizer=False,
-                      no_dht=False, initial_peers=(), dht_port=None, root_port=None, verbose=True,
+                      no_dht=False, initial_peers=(), dht_port=None, root_port=None, verbose=True, start=False,
                       UID_DELIMETER=hivemind.DHTNode.UID_DELIMETER, **kwargs) -> hivemind.Server:
     """ A context manager that creates server in a background thread, awaits .ready on entry and shutdowns on exit """
     if verbose and len(kwargs) != 0:
@@ -27,7 +27,7 @@ def make_dummy_server(host='0.0.0.0', port=None, num_experts=1, expert_cls='ffn'
             dht_root = hivemind.DHTNode(
                 *initial_peers, port=root_port or hivemind.find_open_port(), start=True)
             print(f"Initializing DHT with port {dht_root.port}")
-            initial_peers = (('localhost', dht_root.port),)
+            initial_peers = (('localhost', dht_root.port), )
         else:
             print("Bootstrapping dht with peers:", initial_peers)
             if root_port is not None:
@@ -54,10 +54,11 @@ def make_dummy_server(host='0.0.0.0', port=None, num_experts=1, expert_cls='ffn'
         dht, experts, addr=host, port=port or hivemind.find_open_port(),
         conn_handler_processes=num_handlers, device=device)
 
-    if verbose:
-        print(f"Server created at {server.addr}:{server.port}")
-        print(f"Got {num_experts} active experts of type {expert_cls}: {list(experts.keys())}")
-
+    if start:
+        server.run_in_background(await_ready=True)
+        if verbose:
+            print(f"Server started at {server.addr}:{server.port}")
+            print(f"Got {num_experts} active experts of type {expert_cls}: {list(experts.keys())}")
     return server
 
 
@@ -124,10 +125,8 @@ if __name__ == '__main__':
 
     args['initial_peers'] = eval(args['initial_peers'])
 
-    server = make_dummy_server(**args, start=True, verbose=True)
-
     try:
-        server.run_in_background(await_ready=True)
+        server = make_dummy_server(**args, start=True, verbose=True)
         server.join()
     finally:
         server.shutdown()


### PR DESCRIPTION
Implements custom dropout layer accepting precomputed dropout mask as an input, tests its determinism (although it can't fail in any conceivable situation). Also fixed some bugs/inconsistencies in backend/utils/test_utils which I faced when writing a test.

Hopefully solves https://github.com/learning-at-home/hivemind/issues/21.

TODO:
- [x] Custom DeterministicDropout function and layer
- [x] Tests for forward/backward determinism
- [x] Add docstrings for DeterministicDropout
- [x] Rewrite all docstrings hinting at non-determinism (e.g. [here](https://github.com/learning-at-home/hivemind/blob/master/hivemind/runtime/expert_backend.py#L68) and [here](https://github.com/learning-at-home/hivemind/blob/master/hivemind/runtime/expert_backend.py#L92)). From now, users will have to implement custom layers with no state other than parameters and explicitly track all buffers/RNG outputs if they want complete determinism.