### PR TITLE
run_server update

### DIFF
--- a/hivemind/runtime/task_pool.py
+++ b/hivemind/runtime/task_pool.py
@@ -22,8 +22,8 @@ Task = namedtuple("Task", ("future", "args"))
 class TaskPoolBase(mp.Process):
     """ A pool that accepts tasks and forms batches for parallel processing, interacts with Runtime """
 
-    def __init__(self, process_func: callable):
-        super().__init__()
+    def __init__(self, process_func: callable, daemon=True):
+        super().__init__(daemon=daemon)
         self.process_func = process_func
         self._priority = mp.Value(ctypes.c_double, 1.0)  # higher priority = the more urgent to process this pool
 
@@ -66,9 +66,8 @@ class TaskPool(TaskPoolBase):
     """
 
     def __init__(self, process_func: callable, max_batch_size: int, min_batch_size=1,
-                 timeout=None, pool_size=None, prefetch_batches=1, uid=None, start=False):
-
-        super().__init__(process_func)
+                 timeout=None, pool_size=None, prefetch_batches=1, uid=None, daemon=True, start=False):
+        super().__init__(process_func, daemon=daemon)
         self.min_batch_size, self.max_batch_size, self.timeout = min_batch_size, max_batch_size, timeout
         self.uid = uid or uuid.uuid4()
         self.prefetch_batches = prefetch_batches

--- a/hivemind/runtime/task_pool.py
+++ b/hivemind/runtime/task_pool.py
@@ -19,7 +19,7 @@ from ..utils import SharedFuture
 Task = namedtuple("Task", ("future", "args"))
 
 
-class TaskPoolBase(mp.Process):
+class TaskPoolBase(mp.context.ForkProcess):
     """ A pool that accepts tasks and forms batches for parallel processing, interacts with Runtime """
 
     def __init__(self, process_func: callable, daemon=True):

--- a/hivemind/server/__init__.py
+++ b/hivemind/server/__init__.py
@@ -99,7 +99,7 @@ class Server(threading.Thread):
         sock.settimeout(self.update_period)
 
         ctx = mp.get_context('fork')
-        processes = [ctx.Process(target=socket_loop, name=f"socket_loop-{i}", args=(sock, self.experts))
+        processes = [ctx.Process(target=socket_loop, name=f"socket_loop-{i}", args=(sock, self.experts), daemon=True)
                      for i in range(num_handlers)]
         return processes
 

--- a/hivemind/server/__init__.py
+++ b/hivemind/server/__init__.py
@@ -98,8 +98,8 @@ class Server(threading.Thread):
         sock.listen()
         sock.settimeout(self.update_period)
 
-        ctx = mp.get_context('fork')
-        processes = [ctx.Process(target=socket_loop, name=f"socket_loop-{i}", args=(sock, self.experts), daemon=True)
+        processes = [mp.context.ForkProcess(
+            target=socket_loop, name=f"socket_loop-{i}", args=(sock, self.experts), daemon=True)
                      for i in range(num_handlers)]
         return processes
 

--- a/hivemind/server/__init__.py
+++ b/hivemind/server/__init__.py
@@ -98,7 +98,8 @@ class Server(threading.Thread):
         sock.listen()
         sock.settimeout(self.update_period)
 
-        processes = [mp.Process(target=socket_loop, name=f"socket_loop-{i}", args=(sock, self.experts))
+        ctx = mp.get_context('fork')
+        processes = [ctx.Process(target=socket_loop, name=f"socket_loop-{i}", args=(sock, self.experts))
                      for i in range(num_handlers)]
         return processes
 

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -87,3 +87,8 @@ def test_compute_expert_scores():
                     "compute_expert_scores returned incorrect score"
     finally:
         dht.shutdown()
+
+
+if __name__ == '__main__':
+    test_determinism()
+    test_determinism() #TODO remove

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -87,8 +87,3 @@ def test_compute_expert_scores():
                     "compute_expert_scores returned incorrect score"
     finally:
         dht.shutdown()
-
-
-if __name__ == '__main__':
-    test_determinism()
-    test_determinism() #TODO remove

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -74,16 +74,17 @@ def test_compute_expert_scores():
         ii = [[4, 0, 2], [3, 1, 1, 1, 3], [0], [3, 2]]
         jj = [[2, 2, 1], [0, 1, 2, 0, 1], [0], [1, 2]]
         batch_experts = [
-            [hivemind.RemoteExpert(uid=f'expert.{ii[b][e]}.{jj[b][e]}') for e in range(len(ii[b]))]
+            [hivemind.RemoteExpert(uid=f'expert.{ii[batch_i][e]}.{jj[batch_i][e]}') for e in range(len(ii[batch_i]))]
             for b in range(len(ii))
         ]  # note: these experts do not exists on server, we use them only to test moe compute_expert_scores
         logits = moe.compute_expert_scores([gx, gy], batch_experts)
         torch.softmax(logits, dim=-1).norm(dim=-1).mean().backward()
         assert gx.grad.norm().item() > 0 and gy.grad.norm().item(), "compute_expert_scores didn't backprop"
 
-        for b in range(len(ii)):
-            for e in range(len(ii[b])):
-                assert torch.allclose(logits[b, e], gx[b, ii[b][e]] + gy[b, jj[b][e]]), \
+        for batch_i in range(len(ii)):
+            for expert_i in range(len(ii[batch_i])):
+                assert torch.allclose(logits[batch_i, expert_i],
+                                      gx[batch_i, ii[batch_i][expert_i]] + gy[batch_i, jj[batch_i][expert_i]]), \
                     "compute_expert_scores returned incorrect score"
     finally:
         dht.shutdown()

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -74,8 +74,9 @@ def test_compute_expert_scores():
         ii = [[4, 0, 2], [3, 1, 1, 1, 3], [0], [3, 2]]
         jj = [[2, 2, 1], [0, 1, 2, 0, 1], [0], [1, 2]]
         batch_experts = [
-            [hivemind.RemoteExpert(uid=f'expert.{ii[batch_i][e]}.{jj[batch_i][e]}') for e in range(len(ii[batch_i]))]
-            for b in range(len(ii))
+            [hivemind.RemoteExpert(uid=f'expert.{ii[batch_i][expert_i]}.{jj[batch_i][expert_i]}')
+             for expert_i in range(len(ii[batch_i]))]
+            for batch_i in range(len(ii))
         ]  # note: these experts do not exists on server, we use them only to test moe compute_expert_scores
         logits = moe.compute_expert_scores([gx, gy], batch_experts)
         torch.softmax(logits, dim=-1).norm(dim=-1).mean().backward()

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -51,7 +51,7 @@ def test_determinism():
     mask = torch.randint(0, 1, (32, 1024))
 
     with background_server(num_experts=1, device='cpu', expert_cls='det_dropout',
-                           no_optimizer=True, no_dht=True) as (localhost, server_port, dht_port):
+                           no_optimizer=True, no_dht=True) as (interface, server_port, dht_port):
         expert = hivemind.RemoteExpert(uid=f'expert.0', port=server_port)
 
         out = expert(xx, mask)
@@ -68,7 +68,7 @@ def test_compute_expert_scores():
     try:
         dht = hivemind.DHTNode(port=hivemind.find_open_port(), start=True)
         moe = hivemind.client.moe.RemoteMixtureOfExperts(
-            dht=dht, in_features=1024, grid_size=[40], k_best=4, k_min=1, timeout_after_k_min=1,
+            dht=dht, in_features=1024, grid_size=(40,), k_best=4, k_min=1, timeout_after_k_min=1,
             uid_prefix='expert')
         gx, gy = torch.randn(4, 5, requires_grad=True), torch.torch.randn(4, 3, requires_grad=True)
         ii = [[4, 0, 2], [3, 1, 1, 1, 3], [0], [3, 2]]
@@ -83,12 +83,7 @@ def test_compute_expert_scores():
 
         for b in range(len(ii)):
             for e in range(len(ii[b])):
-                assert torch.allclose(logits[b, e], gx[b, ii[b][e]] + gy[b, jj[b][e]]), "compute_expert_scores returned incorrect score"
+                assert torch.allclose(logits[b, e], gx[b, ii[b][e]] + gy[b, jj[b][e]]), \
+                    "compute_expert_scores returned incorrect score"
     finally:
         dht.shutdown()
-
-
-if __name__ == '__main__':
-    test_remote_module_call()
-    test_compute_expert_scores()
-    test_determinism()

--- a/tests/test_utils/run_server.py
+++ b/tests/test_utils/run_server.py
@@ -79,6 +79,7 @@ def background_server(*args, shutdown_timeout=5, verbose=True, **kwargs):
             target=_server_runner, args=(trigger_shutdown, sender, *args), kwargs=dict(verbose=verbose, **kwargs))
         runner.start()
 
+        # TODO <debugprint>
         def foo():
             import time
             while True:
@@ -86,6 +87,7 @@ def background_server(*args, shutdown_timeout=5, verbose=True, **kwargs):
                 time.sleep(1)
 
         hivemind.run_in_background(foo)
+        # TODO </debugprint>
         yield recv.recv()  # receives a tuple(hostname, port, dht port)
 
     finally:

--- a/tests/test_utils/run_server.py
+++ b/tests/test_utils/run_server.py
@@ -12,7 +12,28 @@ def make_dummy_server(interface='0.0.0.0', port=None, num_experts=1, expert_cls=
                       num_handlers=None, expert_prefix='expert', expert_offset=0, max_batch_size=16384, device=None,
                       no_optimizer=False, no_dht=False, initial_peers=(), dht_port=None, root_port=None, verbose=True,
                       UID_DELIMETER=hivemind.DHTNode.UID_DELIMETER, start=False, **kwargs) -> hivemind.Server:
-    """ Instantiate a server with several identical experts. See argparse comments below for details """
+    """
+    Instantiate a server with several identical experts. See argparse comments below for details
+    :param interface: 'localhost' for local connections only, '0.0.0.0' for ipv4 '::' for ipv6
+    :param port: main server will listen to this port, default = find open port
+    :param num_experts: run this many identical experts
+    :param expert_cls: expert type from test_utils.layers, e.g. 'ffn', 'transformer', 'det_dropout' or 'nop';
+    :param hidden_dim: main dimension for expert_cls
+    :param num_handlers: server will use this many parallel processes to handle incoming requests
+    :param expert_prefix: all expert uids will be {expert_prefix}.{index}
+    :param expert_offset: expert uid will use indices in range(expert_offset, expert_offset + num_experts)
+    :param max_batch_size: total num examples in the same batch will not exceed this value
+    :param device: all experts will use this device in torch notation; default: cuda if available else cpu
+    :param no_optimizer: if specified, all optimizers use learning rate=0
+    :param no_dht: if specified, the server will not be attached to a dht
+    :param initial_peers: a list of peers that will introduce this node to the dht,
+      e.g. [("1.2.3.4", 1337), ("127.0.0.1", 4321)]'), default = no peers
+    :param dht_port:  DHT node will listen on this port, default = find open port
+    :param root_port: if this server does not have initial_peers, it will create a virtual dht node on this port.
+        You can then use this node as initial peer for subsequent servers.
+    :param verbose: whether to print server started / finished / terminated events
+    :param start: if True, starts server right away and returns when server is ready for requests
+    """
     if verbose and len(kwargs) != 0:
         print("Ignored kwargs:", kwargs)
     assert expert_cls in name_to_block


### PR DESCRIPTION
* torch1.5 support - fixed this bug https://circleci.com/gh/learning-at-home/hivemind/437
* better documentation for python test_utils.run_server --help
* TaskPool and connection handlers are now always ForkProcess
  - this fixes a bug that causes obscure torch errors after mp.set_start_method(other_than_fork)
* TaskPool and connections handlers are now daemons unless otherwise specified
  - this fixes a rare bug where failed background_server sometimes caused zombie processes
* minor code style fixes (line breaks, spaces)