### PR TITLE
Remove TODO SIMD

### DIFF
--- a/hivemind/dht/routing.py
+++ b/hivemind/dht/routing.py
@@ -245,7 +245,7 @@ class DHTID(int):
         :return: a number or a list of numbers whose binary representations equal bitwise xor between DHTIDs.
         """
         if isinstance(other, Iterable):
-            return list(map(self.xor_distance, other))  # TODO make some SIMD
+            return list(map(self.xor_distance, other))
         return int(self) ^ int(other)
 
     @classmethod


### PR DESCRIPTION
TL;DR i've tried several things, but they all gave no performance benefits or those benefits were limited to few edge cases. This PR removes TODO but leaves one-to-many xor for convenience.

* (default) pythonic int, xor via "id1 ^ id2", no array operations - arguably the best i found
* ndarray of bytes, distance is int - slower both 1-to-1 and 1-to-many
* ndarray of bytes, distances are bytes - slower one-to-one, faster one-to-many, need to use byte buffers everywhere, can give WA due to null termination
* numba/cython integers - neither of them support ints larger than 64-bit, using bytes gave no speed-up
* numba in bytes - same as numpy in bytes but a bit slower
* using uint64 dht ids - fastest by a huge margin, probability of collision for 10^7 keys << 10^-4. 
    * I would argue that in our case the extra performance is not worth giving up the peace of mind, but we may switch to int64 (or tuples of int64) if it ever becomes necessary. Which i hope it never will.

![image](https://user-images.githubusercontent.com/3491902/85304923-fe31a200-b4b4-11ea-80ae-c2b21f959d53.png)

![image](https://user-images.githubusercontent.com/3491902/85305917-65038b00-b4b6-11ea-9da4-39bfca384082.png)

