### PR TITLE
Set number of threads to 1

### DIFF
--- a/hivemind/runtime/task_pool.py
+++ b/hivemind/runtime/task_pool.py
@@ -125,6 +125,7 @@ class TaskPool(TaskPoolBase):
                 total_size += task_size
 
     def run(self, *args, **kwargs):
+        torch.set_num_threads(1)
         logger.info(f'{self.uid} starting, pid={os.getpid()}')
         pending_batches = {}  # Dict[batch uuid, List[SharedFuture]] for each batch currently in runtime
         output_thread = threading.Thread(target=self._pool_output_loop, args=[pending_batches],

--- a/hivemind/server/__init__.py
+++ b/hivemind/server/__init__.py
@@ -3,6 +3,7 @@ import os
 import threading
 from socket import socket, AF_INET, SOCK_STREAM, SO_REUSEADDR, SOL_SOCKET, timeout
 from typing import Dict, Optional
+import torch
 
 from .connection_handler import handle_connection
 from .dht_handler import DHTHandlerThread
@@ -121,6 +122,7 @@ class Server(threading.Thread):
 
 def socket_loop(sock, experts):
     """ catch connections, send tasks to processing, respond with results """
+    torch.set_num_threads(1)
     print(f'Spawned connection handler pid={os.getpid()}')
     while True:
         try:

--- a/tests/benchmark_throughput.py
+++ b/tests/benchmark_throughput.py
@@ -13,6 +13,7 @@ import hivemind
 
 
 def client_process(can_start, benchmarking_failed, port, num_experts, batch_size, hid_dim, num_batches, backprop=True):
+    torch.set_num_threads(1)
     can_start.wait()
     experts = [hivemind.RemoteExpert(f"expert{i}", port=port) for i in range(num_experts)]
 

--- a/tests/benchmark_throughput.py
+++ b/tests/benchmark_throughput.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
         benchmark_throughput(backprop=False, num_experts=4, batch_size=32, max_batch_size=8192,
                              num_batches_per_client=args.num_batches_per_client)
     elif args.preset == 'ffn_small_batch_many_clients':
-        benchmark_throughput(backprop=True, num_experts=16, batch_size=1, max_batch_size=8192,
+        benchmark_throughput(backprop=True, num_experts=1, batch_size=1, max_batch_size=8192,
                              num_clients=512, num_batches_per_client=args.num_batches_per_client)
     elif args.preset == 'ffn_massive':
         soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)

--- a/tests/benchmark_throughput.py
+++ b/tests/benchmark_throughput.py
@@ -132,6 +132,9 @@ if __name__ == "__main__":
     elif args.preset == 'ffn_small_batch':
         benchmark_throughput(backprop=False, num_experts=4, batch_size=32, max_batch_size=8192,
                              num_batches_per_client=args.num_batches_per_client)
+    elif args.preset == 'ffn_small_batch_many_clients':
+        benchmark_throughput(backprop=True, num_experts=16, batch_size=1, max_batch_size=8192,
+                             num_clients=512, num_batches_per_client=args.num_batches_per_client)
     elif args.preset == 'ffn_massive':
         soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
         try:

--- a/tests/benchmark_throughput.py
+++ b/tests/benchmark_throughput.py
@@ -132,8 +132,11 @@ if __name__ == "__main__":
     elif args.preset == 'ffn_small_batch':
         benchmark_throughput(backprop=False, num_experts=4, batch_size=32, max_batch_size=8192,
                              num_batches_per_client=args.num_batches_per_client)
-    elif args.preset == 'ffn_small_batch_many_clients':
+    elif args.preset == 'ffn_small_batch_512clients':
         benchmark_throughput(backprop=True, num_experts=1, batch_size=1, max_batch_size=8192,
+                             num_clients=512, num_batches_per_client=args.num_batches_per_client)
+    elif args.preset == 'ffn_small_batch_512clients_32handlers':
+        benchmark_throughput(backprop=True, num_experts=1, batch_size=1, max_batch_size=8192, num_handlers=32,
                              num_clients=512, num_batches_per_client=args.num_batches_per_client)
     elif args.preset == 'ffn_massive':
         soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)


### PR DESCRIPTION
Before:
```
Server parameters: num_experts=16, num_handlers=64, max_batch_size=8192, expert_cls=ffn, hid_dim=1024, device=cuda
Client parameters: num_clients=128, num_batches_per_client=16, batch_size=2048, backprop=True
Results:
        Server startup took 6.825 s. (2.159 s. experts + 4.665 s. networking)
        Processed 4194304 examples in 160.663
        Throughput for forward + backward passes: 26106.234 samples / s.
        Benchmarking took 167.689 s.
```
```
Server parameters: num_experts=4, num_handlers=64, max_batch_size=8192, expert_cls=ffn, hid_dim=1024, device=cuda
Client parameters: num_clients=128, num_batches_per_client=64, batch_size=32, backprop=False
Results:
        Server startup took 2.998 s. (0.549 s. experts + 2.449 s. networking)
        Processed 262144 examples in 9.480
        Throughput for forward passes: 27652.515 samples / s.
        Benchmarking took 12.663 s.
```
After:
```
Server parameters: num_experts=16, num_handlers=64, max_batch_size=8192, expert_cls=ffn, hid_dim=1024, device=cuda
Client parameters: num_clients=128, num_batches_per_client=16, batch_size=2048, backprop=True
Results:
        Server startup took 6.827 s. (2.157 s. experts + 4.671 s. networking)
        Processed 4194304 examples in 96.610
        Throughput for forward + backward passes: 43414.985 samples / s.
        Benchmarking took 103.814 s.
```
```
Server parameters: num_experts=4, num_handlers=64, max_batch_size=8192, expert_cls=ffn, hid_dim=1024, device=cuda
Client parameters: num_clients=128, num_batches_per_client=64, batch_size=32, backprop=False
Results:
        Server startup took 2.996 s. (0.551 s. experts + 2.445 s. networking)
        Processed 262144 examples in 9.483
        Throughput for forward passes: 27642.687 samples / s.
        Benchmarking took 12.692 s.
```