### PR TITLE
Fix issue 71: DHT.declare_experts hangs without peers

### DIFF
--- a/hivemind/dht/node.py
+++ b/hivemind/dht/node.py
@@ -171,7 +171,7 @@ class DHTNode:
         nearest_nodes, visited_nodes = await traverse_dht(
             queries, initial_nodes=list(node_to_endpoint), beam_size=beam_size, num_workers=num_workers,
             queries_per_call=int(len(queries) ** 0.5), get_neighbors=get_neighbors,
-            visited_nodes={query: {self.node_id} for query in queries}, **kwargs)
+            visited_nodes={query: {self.node_id} for query in queries} if exclude_self else None, **kwargs)
 
         nearest_nodes_per_query = {}
         for query, nearest_nodes in nearest_nodes.items():

--- a/hivemind/dht/node.py
+++ b/hivemind/dht/node.py
@@ -168,13 +168,13 @@ class DHTNode:
                 output[query] = list(peers.keys()), False  # False means "do not interrupt search"
             return output
 
-        nearest_nodes, visited_nodes = await traverse_dht(
+        nearest_nodes_per_query, visited_nodes = await traverse_dht(
             queries, initial_nodes=list(node_to_endpoint), beam_size=beam_size, num_workers=num_workers,
             queries_per_call=int(len(queries) ** 0.5), get_neighbors=get_neighbors,
             visited_nodes={query: {self.node_id} for query in queries} if exclude_self else None, **kwargs)
 
-        return {node: node_to_endpoint[node] for node in nearest_nodes
-                for query, nearest_nodes in nearest_nodes.items()}
+        return {query: {node: node_to_endpoint[node] for node in nearest_nodes}
+                for query, nearest_nodes in nearest_nodes_per_query.items()}
 
     async def store(self, key: DHTKey, value: DHTValue, expiration_time: DHTExpiration, **kwargs) -> bool:
         """

--- a/hivemind/dht/node.py
+++ b/hivemind/dht/node.py
@@ -233,28 +233,43 @@ class DHTNode:
             """ This will be called once per key when find_nearest_nodes is done for a particular node """
             # note: we use callbacks instead of returned values to call store immediately without waiting for stragglers
             assert key_id in unfinished_key_ids, "Internal error: traverse_dht finished the same query twice"
+            assert self.node_id not in nearest_nodes
             unfinished_key_ids.remove(key_id)
 
-            # ensure k nodes and (optionally) exclude self
-            nearest_nodes = [node_id for node_id in nearest_nodes if (not exclude_self or node_id != self.node_id)]
-            store_args = [key_id], [binary_values_by_key_id[key_id]], [expiration_by_key_id[key_id]]
-            store_tasks = {asyncio.create_task(self.protocol.call_store(node_to_endpoint[nearest_node_id], *store_args))
-                           for nearest_node_id in nearest_nodes[:self.num_replicas]}
-            backup_nodes = nearest_nodes[self.num_replicas:]  # used in case previous nodes didn't respond
+            # ensure k nodes stored the value, optionally include self.node_id as a candidate
+            num_successful_stores = 0
+            pending_store_tasks = set()
+            store_candidates = sorted(nearest_nodes + ([] if exclude_self else [self.node_id]),
+                                      key=key_id.xor_distance, reverse=True)  # ordered so that .pop() returns nearest
 
-            # parse responses and issue additional stores if someone fails
-            while store_tasks:
-                finished_store_tasks, store_tasks = await asyncio.wait(store_tasks, return_when=asyncio.FIRST_COMPLETED)
+            while num_successful_stores < self.num_replicas and (store_candidates or pending_store_tasks):
+                # spawn enough tasks to cover all replicas
+                while store_candidates and num_successful_stores + len(pending_store_tasks) < self.num_replicas:
+                    peer: DHTID = store_candidates.pop()  # nearest untried candidate
+                    if peer == self.node_id:
+                        self.protocol.storage.store(key_id, binary_values_by_key_id[key_id],
+                                                    expiration_by_key_id[key_id])
+                        store_ok[id_to_original_key[key_id]] = True
+                        num_successful_stores += 1
+                        if not await_all_replicas:
+                            store_finished_events[id_to_original_key[key_id]].set()
+
+                    else:
+                        pending_store_tasks.add(asyncio.create_task(self.protocol.call_store(
+                            node_to_endpoint[peer], [key_id], [binary_values_by_key_id[key_id]],
+                            [expiration_by_key_id[key_id]])))
+
+                # await nearest task. If it fails, dispatch more on the next iteration
+                finished_store_tasks, pending_store_tasks = await asyncio.wait(
+                    pending_store_tasks, return_when=asyncio.FIRST_COMPLETED)
                 for task in finished_store_tasks:
                     if task.result()[0]:  # if store succeeded
                         store_ok[id_to_original_key[key_id]] = True
+                        num_successful_stores += 1
                         if not await_all_replicas:
                             store_finished_events[id_to_original_key[key_id]].set()
-                    elif backup_nodes:
-                        store_tasks.add(asyncio.create_task(
-                            self.protocol.call_store(node_to_endpoint[backup_nodes.pop(0)], *store_args)))
 
-                store_finished_events[id_to_original_key[key_id]].set()
+            store_finished_events[id_to_original_key[key_id]].set()
 
         asyncio.create_task(self.find_nearest_nodes(
             queries=set(key_ids), k_nearest=self.num_replicas, node_to_endpoint=node_to_endpoint,

--- a/hivemind/dht/node.py
+++ b/hivemind/dht/node.py
@@ -173,12 +173,13 @@ class DHTNode:
             queries_per_call=int(len(queries) ** 0.5), get_neighbors=get_neighbors,
             visited_nodes={query: {self.node_id} for query in queries}, **kwargs)
 
+        nearest_nodes_with_endpoints = {}
         for query, nearest_nodes in nearest_nodes_per_query.items():
             if not exclude_self:
                 nearest_nodes = sorted(nearest_nodes + [self.node_id], key=query.xor_distance)
                 node_to_endpoint[self.node_id] = f"{LOCALHOST}:{self.port}"
-            nearest_nodes_per_query[query] = {node: node_to_endpoint[node] for node in nearest_nodes[:k_nearest]}
-        return nearest_nodes_per_query
+            nearest_nodes_with_endpoints[query] = {node: node_to_endpoint[node] for node in nearest_nodes[:k_nearest]}
+        return nearest_nodes_with_endpoints
 
     async def store(self, key: DHTKey, value: DHTValue, expiration_time: DHTExpiration, **kwargs) -> bool:
         """

--- a/hivemind/dht/node.py
+++ b/hivemind/dht/node.py
@@ -249,7 +249,7 @@ class DHTNode:
                         store_tasks.add(asyncio.create_task(
                             self.protocol.call_store(node_to_endpoint[backup_nodes.pop(0)], *store_args)))
 
-                store_finished_events[id_to_original_key[key_id]].set()
+            store_finished_events[id_to_original_key[key_id]].set()
 
         asyncio.create_task(self.find_nearest_nodes(
             queries=set(key_ids), k_nearest=self.num_replicas, node_to_endpoint=node_to_endpoint,

--- a/hivemind/dht/protocol.py
+++ b/hivemind/dht/protocol.py
@@ -12,7 +12,7 @@ import grpc
 import grpc.experimental.aio
 
 from hivemind.dht.routing import RoutingTable, DHTID, BinaryDHTValue, DHTExpiration, get_dht_time
-from hivemind.utils import Endpoint, compile_grpc, get_logger, LOCALHOST
+from hivemind.utils import Endpoint, compile_grpc, get_logger
 
 logger = get_logger(__name__)
 

--- a/hivemind/dht/protocol.py
+++ b/hivemind/dht/protocol.py
@@ -12,7 +12,7 @@ import grpc
 import grpc.experimental.aio
 
 from hivemind.dht.routing import RoutingTable, DHTID, BinaryDHTValue, DHTExpiration, get_dht_time
-from hivemind.utils import Endpoint, compile_grpc, get_logger
+from hivemind.utils import Endpoint, compile_grpc, get_logger, LOCALHOST
 
 logger = get_logger(__name__)
 
@@ -58,6 +58,7 @@ class DHTProtocol(dht_grpc.DHTServicer):
 
             found_port = self.server.add_insecure_port(listen_on)
             assert found_port != 0, f"Failed to listen to {listen_on}"
+            self.routing_table.add_or_update_node(self.node_id, f"{LOCALHOST}:{found_port}")
             self.node_info = dht_pb2.NodeInfo(node_id=node_id.to_bytes(), rpc_port=found_port)
             self.port = found_port
             await self.server.start()

--- a/hivemind/dht/protocol.py
+++ b/hivemind/dht/protocol.py
@@ -58,7 +58,6 @@ class DHTProtocol(dht_grpc.DHTServicer):
 
             found_port = self.server.add_insecure_port(listen_on)
             assert found_port != 0, f"Failed to listen to {listen_on}"
-            self.routing_table.add_or_update_node(self.node_id, f"{LOCALHOST}:{found_port}")
             self.node_info = dht_pb2.NodeInfo(node_id=node_id.to_bytes(), rpc_port=found_port)
             self.port = found_port
             await self.server.start()

--- a/hivemind/dht/traverse.py
+++ b/hivemind/dht/traverse.py
@@ -149,7 +149,7 @@ async def traverse_dht(
             search_finished_event.set()
         if found_callback:
             nearest_neighbors = [peer for _, peer in heapq.nlargest(beam_size, nearest_nodes[query])]
-            pending_tasks.add(asyncio.create_task(found_callback(query, nearest_neighbors, set(visited_nodes)[query])))
+            pending_tasks.add(asyncio.create_task(found_callback(query, nearest_neighbors, set(visited_nodes[query]))))
 
     async def worker():
         while unfinished_queries:

--- a/tests/test_dht.py
+++ b/tests/test_dht.py
@@ -300,6 +300,14 @@ def test_hivemind_dht():
         peer.shutdown()
 
 
+def test_dht_single_node():
+    node = hivemind.DHT(start=True)
+    assert all(node.declare_experts(['e1', 'e2', 'e3'], hivemind.LOCALHOST, 1337))
+    for expert in node.get_experts(['e3', 'e2']):
+        assert expert.host == hivemind.LOCALHOST and expert.port == 1337
+    assert node.first_k_active(['e0', 'e1', 'e3', 'e5', 'e2'], k=2) == ['e1', 'e3']
+
+
 def test_store():
     d = LocalStorage()
     d.store(DHTID.generate("key"), b"val", get_dht_time() + 0.5)


### PR DESCRIPTION
* fixed the issue in question
* fixed minor bug where visited_nodes returned by traverse_dht was not formed correctly
* store_many will now correctly handle exclude_self=False
* checked no performance/accuracy degradation in benchmark_dht.py (below)

master:
![image](https://user-images.githubusercontent.com/3491902/87231429-d6e93900-c3bf-11ea-9c2e-d3085f289758.png)

fix_lonely_dht:
![image](https://user-images.githubusercontent.com/3491902/87232442-cccb3880-c3c7-11ea-916c-2eb30e475656.png)
