### PR TITLE
[DONOTMERGE] [CLOSE_WHEN_READY] add example of transformer layer with mask

### DIFF
--- a/tests/test_utils/layers.py
+++ b/tests/test_utils/layers.py
@@ -57,7 +57,6 @@ class MaskedTransformerEncoderLayer(TransformerEncoderLayer):
     def forward(self, src, mask):
         assert mask.ndim == 2 and mask.dtype == torch.bool and tuple(mask.shape) == tuple(src.shape)[:2]
         src.transpose_(0, 1)
-        mask = (~mask).transpose(0, 1)
         src2 = self.self_attn(src, src, src, mask)[0]
         src = src + self.dropout1(src2)
         src = self.norm1(src)


### PR DESCRIPTION
start server:
```
python -m test_utils.run_server --expert_cls masked_transformer --listen_on localhost:1337
```

call expert:
```
import torch
import hivemind

expert = hivemind.RemoteExpert('expert.0', 'localhost:1337')

inp = torch.randn(3, 512, 1024)
mask = torch.arange(512) <= torch.as_tensor([128, 322, 9999]).view(-1, 1)
out = expert(inp, mask)

# note: for some forking reason, mask==1 means "ignore" and 0 means "attend".
# also, someone thought it is a good idea to set mask.shape is (b, t) while src.shape is (t, b, ...)
```

Please do not merge this pull. Instead, close it after reproducing. I will merge a unit test with two inputs after @Vsevolod-pl 's PR converges.