### PR TITLE
Faster beam search part2/2

### DIFF
--- a/hivemind/dht/__init__.py
+++ b/hivemind/dht/__init__.py
@@ -12,6 +12,7 @@ The code is organized as follows:
 - [1] Maymounkov P., Mazieres D. (2002) Kademlia: A Peer-to-Peer Information System Based on the XOR Metric.
 - [2] https://github.com/bmuller/kademlia , Brian, if you're reading this: THANK YOU! you're awesome :)
 """
+import time
 import asyncio
 import ctypes
 import multiprocessing as mp
@@ -21,6 +22,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import List, Tuple, Optional, Sequence, OrderedDict as TOrderedDict, Union, Awaitable
 
 import uvloop
+import torch
 
 from hivemind.client import RemoteExpert
 from hivemind.dht.node import DHTNode, DHTID, DHTExpiration
@@ -239,3 +241,107 @@ class DHT(mp.Process):
 
         # return k active prefixes or as many as we could find
         future.set_result(OrderedDict(found))
+
+    def find_best_experts(self, prefix: str, grid_scores: List[torch.Tensor], k_best: int, *,
+                          time_budget: float = float('inf'), grid_indices: Optional[List[torch.Tensor]] = None,
+                          return_future=False, **kwargs) -> Union[List[RemoteExpert], MPFuture[List[RemoteExpert]]]:
+        """
+        Find and return k active experts with highest scores, use both local cache and DHT
+
+
+        :param prefix: common prefix for all expert uids in grid
+        :param grid_scores: scores predicted for each dimension in the grid,
+        :type grid_scores: a sequence of tensors of shape[batch_size, grid_size[i]]
+        :param grid_indices: optional, indices for each grid dimension. Default = 0, 1, ... len(grid_scores[i]) - 1
+
+        :param k_best: how many best experts should beam search return
+        :param time_budget: how much time beam_search is can spend on queries to other peers (default = unlimited)
+         After time_budget is reached, beam search won't search for more experts and instead fall back on local cache
+         Please note that any queries that fall outside the budget will still be performed in background and cached
+         for subsequent iterations as long as DHTNode.cache_locally is True
+        :param return_future: if set to True, returns MPFuture that can be awaited to get the actual result
+        :param kwargs: extra keyword parameters passed to self.dht.first_k_active
+        :returns: a list that contains *up to* k_best RemoteExpert instances
+        """
+        if grid_indices is None:
+            grid_indices = [torch.arange(len(dim_scores)) for dim_scores in grid_scores]
+        grid_scores = [dim_scores.cpu().detach() for dim_scores in grid_scores]
+        grid_indices = [dim_indices.cpu() for dim_indices in grid_indices]
+        assert len(grid_indices) == len(grid_scores), "grid_indices (if provided) must be of same length as grid_scores"
+        assert all(dim_scores.ndim == 1 and dim_scores.shape == dim_indices.shape
+                   for dim, dim_scores, dim_indices in enumerate(zip(grid_scores, grid_indices)))
+
+        future, _future = MPFuture.make_pair()
+        self.pipe.send(('_find_best_experts', [],
+                        dict(prefix=prefix, grid_scores=grid_scores, grid_indices=grid_indices, k_best=k_best,
+                             time_budget=time_budget, future=_future, **kwargs)))
+        return future if return_future else future.result()
+
+    async def _find_best_experts(self, node: DHTNode, prefix: str, grid_scores: List[torch.Tensor],
+                                 grid_indices: List[torch.Tensor], k_best: int, time_budget: float = float('inf'),
+                                 future: Optional[MPFuture] = None, **kwargs) -> List[RemoteExpert]:
+        deadline_time = time.perf_counter() + time_budget
+        beam_experts: List[RemoteExpert] = []
+        beam: List[str] = [prefix]
+        beam_scores = torch.zeros(1)
+
+        for dim_index, dim_scores, dim_indices in enumerate(zip(grid_scores, grid_indices)):
+            # create all possible successors from current beam and sort them by total score
+            expanded_scores = beam_scores[:, None] + dim_scores[None, :]
+            sorted_indices = [(flat_i // len(dim_scores), flat_i % len(dim_scores))
+                              for flat_i in (-expanded_scores).flatten().argsort().numpy()]
+
+            sorted_candidates = [f"{beam[row]}{self.UID_DELIMITER}{dim_indices[col]:d}" for row, col in sorted_indices]
+            candidate_to_sorted_indices = dict(zip(sorted_candidates, sorted_indices))
+
+            # select k best candidates according to scores but only those that are still active
+            best_alive_prefixes: TOrderedDict[str, RemoteExpert] = await self._first_k_active(
+                node, sorted_candidates, k=k_best, time_budget=deadline_time - time.perf_counter(), **kwargs)
+
+            if not best_alive_prefixes:
+                logger.warning(f"Grid is empty: found neither of {sorted_candidates}")
+                break
+
+            beam = list(best_alive_prefixes.keys())
+            beam_scores = expanded_scores[tuple(zip(*map(candidate_to_sorted_indices.get, beam)))]
+            beam_experts = list(best_alive_prefixes.values())
+
+        if future:
+            future.set_result(beam_experts)
+        return beam_experts
+
+    def batch_find_best_experts(self, prefix: str, grid_scores: List[torch.Tensor], k_best: int, *,
+                                time_budget: float = float('inf'), grid_indices: Optional[List[torch.Tensor]],
+                                return_future=False, **kwargs) -> List[RemoteExpert]:
+        """
+        Batch-parallel version of find_best_experts (see find_best_experts docstring for details)
+        The only exception is that grid_scores must now be a list of 2d tensors [batch_size, grid_size[i]]
+        :returns: a list of batch_size lists, each contains *up to* k_best RemoteExpert instances
+        """
+        if grid_indices is None:
+            grid_indices = [torch.arange(len(dim_scores)) for dim_scores in grid_scores]
+        grid_scores = [dim_scores.cpu().detach() for dim_scores in grid_scores]
+        grid_indices = [dim_indices.cpu() for dim_indices in grid_indices]
+        assert len(grid_indices) == len(grid_scores), "grid_indices (if provided) must be of same length as grid_scores"
+        batch_size = len(grid_scores[0])
+        assert all(dim_scores.ndim == 2 and dim_indices.ndim == 1 and len(dim_scores) == len(dim_indices) == batch_size
+                   for dim, dim_scores, dim_indices in enumerate(zip(grid_scores, grid_indices)))
+        future, _future = MPFuture.make_pair()
+        self.pipe.send(('_batch_find_best_experts', [],
+                        dict(prefix=prefix, grid_scores=grid_scores, grid_indices=grid_indices, k_best=k_best,
+                             time_budget=time_budget, future=_future, **kwargs)))
+        return future if return_future else future.result()
+
+    async def _batch_find_best_experts(self, node: DHTNode, prefix: str, grid_scores: List[torch.Tensor],
+                                       grid_indices: List[torch.Tensor], k_best: int, time_budget: float = float('inf'),
+                                       future: Optional[MPFuture] = None, **kwargs) -> List[List[RemoteExpert]]:
+        results = await asyncio.gather(*[
+            asyncio.create_task(
+                self._find_best_experts(node, prefix, grid_scores=grid_scores_i, grid_indices=grid_indices,
+                                        k_best=k_best, time_budget=time_budget, **kwargs)
+            ) for grid_scores_i in map(list, zip(*grid_scores))
+        ])
+        if future:
+            future.set_result(results)
+        return results
+

--- a/hivemind/dht/__init__.py
+++ b/hivemind/dht/__init__.py
@@ -291,7 +291,7 @@ class DHT(mp.Process):
                 # check for remaining uids in node's local storage/cache
                 while len(found) < k and unattempted_uids_reversed:
                     uid_prefix = unattempted_uids_reversed.pop()
-                    maybe_expert_data, maybe_expiration_time = node.local_get(uid_prefix)
+                    maybe_expert_data, maybe_expiration_time = node.get_locally(uid_prefix)
                     if maybe_expiration_time is not None:  # found active expert
                         found[uid_prefix] = RemoteExpert(**maybe_expert_data)
 

--- a/hivemind/dht/__init__.py
+++ b/hivemind/dht/__init__.py
@@ -242,12 +242,12 @@ class DHT(mp.Process):
         future.set_result(beam_experts)
         return beam_experts
 
-    def first_k_active(self, uid_prefixes: List[str], k: int, **kwargs):
+    def first_k_active(self, uid_prefixes: List[str], k: int, return_future=False, **kwargs):
         """ TODO(jheuristic) remove this, also remove future arg from _first_k_active """
         future, _future = MPFuture.make_pair()
         self.pipe.send(('_first_k_active', [], dict(uid_prefixes=uid_prefixes, k=k, future=_future,
                                                     max_pending=k, time_budget=float('inf'), **kwargs)))
-        return future.result()
+        return future if return_future else future.result()
 
     async def _first_k_active(self, node: DHTNode, uid_prefixes: List[str], k: int, max_pending: int,
                               time_budget: float, future=None, **kwargs) -> TOrderedDict[str, RemoteExpert]:

--- a/hivemind/dht/__init__.py
+++ b/hivemind/dht/__init__.py
@@ -291,7 +291,7 @@ class DHT(mp.Process):
                 # check for remaining uids in node's local storage/cache
                 while len(found) < k and unattempted_uids_reversed:
                     uid_prefix = unattempted_uids_reversed.pop()
-                    maybe_expert_data, maybe_expiration_time = node.get_local(uid_prefix)
+                    maybe_expert_data, maybe_expiration_time = node.local_get(uid_prefix)
                     if maybe_expiration_time is not None:  # found active expert
                         found[uid_prefix] = RemoteExpert(**maybe_expert_data)
 

--- a/hivemind/dht/__init__.py
+++ b/hivemind/dht/__init__.py
@@ -19,7 +19,7 @@ import multiprocessing as mp
 import warnings
 from collections import deque, OrderedDict
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Tuple, Optional, Sequence, OrderedDict as TOrderedDict, Union, Awaitable, Dict, Deque
+from typing import List, Tuple, Optional, Sequence, OrderedDict as TOrderedDict, Union, Awaitable, Dict, Deque, Set
 
 import uvloop
 import numpy as np
@@ -213,8 +213,7 @@ class DHT(mp.Process):
 
     async def _find_best_experts(
             self, node: DHTNode, prefix: str, grid_scores: List[np.ndarray], k_best: int, time_budget: float,
-            max_prefetch: Optional[int] = None, future: MPFuture = None, **kwargs) -> List[RemoteExpert]:
-        max_prefetch = max_prefetch or k_best
+            prefetch_rate: int = 1, future: MPFuture = None, **kwargs) -> List[RemoteExpert]:
         deadline_time = time.perf_counter() + time_budget
         beam_experts: List[RemoteExpert] = []
         beam: List[str] = [prefix]
@@ -231,7 +230,7 @@ class DHT(mp.Process):
 
             # select k best candidates according to scores but only those that are still active
             best_alive_prefixes: TOrderedDict[str, RemoteExpert] = await self._first_k_active(
-                node, sorted_prefix_uids, k=k_best, max_prefetch=max_prefetch,
+                node, sorted_prefix_uids, k=k_best, prefetch_rate=prefetch_rate,
                 time_budget=deadline_time - time.perf_counter(), **kwargs)
 
             if not best_alive_prefixes:

--- a/hivemind/dht/node.py
+++ b/hivemind/dht/node.py
@@ -443,7 +443,7 @@ class DHTNode:
     def _reuse_finished_search_result(self, finished: _IntermediateResult):
         expiration_time_threshold = max(finished.expiration_time or -float('inf'), finished.sufficient_expiration_time)
         concurrent_requests: SortedList[_IntermediateResult] = self.pending_get_requests[finished.key_id]
-        # note: concurrent_requests is sorded in the order of descending sufficient_expiration_time
+        # note: concurrent_requests is sorted in the order of descending sufficient_expiration_time
         while concurrent_requests and expiration_time_threshold >= concurrent_requests[-1].sufficient_expiration_time:
             concurrent_requests[-1].add_candidate(finished.binary_value, finished.expiration_time,
                                                   source_node_id=finished.source_node_id)

--- a/hivemind/dht/node.py
+++ b/hivemind/dht/node.py
@@ -212,7 +212,10 @@ class DHTNode:
         return nearest_nodes_with_endpoints
 
     def store_locally(self, key: DHTKey, value: DHTValue, expiration_time: DHTExpiration, in_cache=False) -> bool:
-        """ (synchronous) Add key->value pair to this node's local storage or cache until expiration_time """
+        """
+        (synchronous) Add key->value pair to this node's local storage or cache until expiration_time
+        Note: this does NOT guarantee that the key will be available to other peers. Use DHTNode.store for that.
+        """
         chosen_storage = self.protocol.cache if in_cache else self.protocol.storage
         return chosen_storage.store(DHTID.generate(key), self.serializer.dumps(value), expiration_time)
 

--- a/hivemind/dht/node.py
+++ b/hivemind/dht/node.py
@@ -54,7 +54,7 @@ class DHTNode:
     node_id: DHTID; is_alive: bool; port: int; num_replicas: int; num_workers: int; protocol: DHTProtocol
     refresh_timeout: float; cache_locally: bool; cache_nearest: int; cache_refresh_before_expiry: float
     cache_refresh_available: asyncio.Event; cache_refresh_queue: LocalStorage
-    reuse_get_requests: bool; pending_get_requests: DefaultDict[DHTID, SortedList[_IntermediateResult]]
+    reuse_get_requests: bool; pending_get_requests: DefaultDict[DHTID, SortedList[_SearchState]]
     serializer = MSGPackSerializer  # used to pack/unpack DHT Values for transfer over network
     # fmt:on
 
@@ -336,7 +336,7 @@ class DHTNode:
         :param keys: traverse the DHT and find the value for each of these keys (or (None, None) if not key found)
         :param sufficient_expiration_time: if the search finds a value that expires after this time,
             default = time of call, find any value that did not expire by the time of call
-            If min_expiration_time=float('inf'), this method will find a value with _latest_ expiration
+            If min_expiration_time == float('inf'), this method will find a value with _latest_ expiration
         :param kwargs: for full list of parameters, see DHTNode.get_many_by_id
         :returns: for each key: value and its expiration time. If nothing is found, returns (None, None) for that key
         :note: in order to check if get returned a value, please check if (expiration_time is None)
@@ -371,30 +371,50 @@ class DHTNode:
         :note: in order to check if get returned a value, please check (expiration_time is None)
         """
         sufficient_expiration_time = sufficient_expiration_time or get_dht_time()
-        beam_size = beam_size if beam_size is not None else self.protocol.bucket_size
-        num_workers = num_workers if num_workers is not None else self.num_workers
-        search_results: Dict[DHTID, _IntermediateResult] = {key_id: _IntermediateResult(
+        search_states: Dict[DHTID, _SearchState] = {key_id: _SearchState(
             key_id, sufficient_expiration_time, serializer=self.serializer) for key_id in key_ids}
 
         if _refresh_cache:
             for key_id in key_ids:
-                search_results[key_id].add_done_callback(self._trigger_cache_refresh)
+                search_states[key_id].add_done_callback(self._trigger_cache_refresh)
 
         # if we have concurrent get request for some of the same keys, subscribe to their results
         if self.reuse_get_requests:
-            for key_id, search_result in search_results.items():
-                self.pending_get_requests[key_id].add(search_result)
-                search_result.add_done_callback(self._reuse_finished_search_result)
+            for key_id, search_state in search_states.items():
+                self.pending_get_requests[key_id].add(search_state)
+                search_state.add_done_callback(self._reuse_finished_search_result)
 
         # stage 1: check for value in this node's local storage and cache
         for key_id in key_ids:
-            search_results[key_id].add_candidate(*self.protocol.storage.get(key_id), source_node_id=self.node_id)
-            search_results[key_id].add_candidate(*self.protocol.cache.get(key_id), source_node_id=self.node_id)
+            search_states[key_id].add_candidate(*self.protocol.storage.get(key_id), source_node_id=self.node_id)
+            search_states[key_id].add_candidate(*self.protocol.cache.get(key_id), source_node_id=self.node_id)
 
         # stage 2: traverse the DHT to get the remaining keys from remote peers
-        unfinished_key_ids = [key_id for key_id in key_ids if not search_results[key_id].finished]
+        unfinished_search_results = {key_id: search for key_id, search in search_states.items() if not search.finished}
+        if not local_only:
+            asyncio.create_task(self._get_from_other_peers(unfinished_search_results, num_workers, beam_size))
+        else:  # if we're not allowed to traverse DHT, finish search right now
+            for key_id, search_state in unfinished_search_results.items():
+                search_state.finish_search()
+
+        if return_futures:
+            return {key_id: search_state.future for key_id, search_state in search_states.items()}
+        else:
+            try:
+                # note: this should be first time when we await something, there's no need to "try" the entire function
+                return {key_id: await search_state.future for key_id, search_state in search_states.items()}
+            except asyncio.CancelledError as e:  # terminate remaining tasks ASAP
+                for key_id, search_state in search_states.items():
+                    search_state.future.cancel()
+                raise e
+
+    async def _get_from_other_peers(self, search_states: Dict[DHTID, _SearchState], num_workers: Optional[int],
+                                    beam_size: Optional[int]) -> Awaitable:
+        """ Internal method: call traverse_dht to get keys from across DHT, add results to search_states """
+        beam_size = beam_size if beam_size is not None else self.protocol.bucket_size
+        num_workers = num_workers if num_workers is not None else self.num_workers
         node_to_endpoint: Dict[DHTID, Endpoint] = dict()  # global routing table for all keys
-        for key_id in unfinished_key_ids:
+        for key_id in search_states.keys():
             node_to_endpoint.update(self.protocol.routing_table.get_nearest_neighbors(
                 key_id, self.protocol.bucket_size, exclude=self.node_id))
 
@@ -408,41 +428,25 @@ class DHTNode:
             output: Dict[DHTID, Tuple[Tuple[DHTID], bool]] = {}
             for key_id, (maybe_value_bytes, maybe_expiration_time, peers) in response.items():
                 node_to_endpoint.update(peers)
-                search_results[key_id].add_candidate(maybe_value_bytes, maybe_expiration_time, source_node_id=peer)
-                output[key_id] = tuple(peers.keys()), search_results[key_id].finished
+                search_states[key_id].add_candidate(maybe_value_bytes, maybe_expiration_time, source_node_id=peer)
+                output[key_id] = tuple(peers.keys()), search_states[key_id].finished
                 # note: we interrupt search either if key is either found or finished otherwise (e.g. cancelled by user)
             return output
 
         # V-- this function will be called exactly once when traverse_dht finishes search for a given key
         async def found_callback(key_id: DHTID, nearest_nodes: List[DHTID], _visited: Set[DHTID]):
-            search_results[key_id].finish_search()  # finish search whether or we found something
-            self._cache_new_result(search_results[key_id], nearest_nodes, node_to_endpoint)
+            search_states[key_id].finish_search()  # finish search whether or we found something
+            self._cache_new_result(search_states[key_id], nearest_nodes, node_to_endpoint)
 
-        if not local_only:
-            asyncio.create_task(traverse_dht(
-                queries=list(unfinished_key_ids), initial_nodes=list(node_to_endpoint),
-                beam_size=beam_size, num_workers=num_workers, queries_per_call=int(len(unfinished_key_ids) ** 0.5),
-                get_neighbors=get_neighbors, visited_nodes={key_id: {self.node_id} for key_id in unfinished_key_ids},
-                found_callback=found_callback, await_all_tasks=False))
-        else:
-            for key_id in unfinished_key_ids:
-                search_results[key_id].finish_search()
+        return traverse_dht(
+            queries=list(search_states.keys()), initial_nodes=list(node_to_endpoint),
+            beam_size=beam_size, num_workers=num_workers, queries_per_call=int(len(search_states) ** 0.5),
+            get_neighbors=get_neighbors, visited_nodes={key_id: {self.node_id} for key_id in search_states.keys()},
+            found_callback=found_callback, await_all_tasks=False)
 
-
-        if return_futures:
-            return {key_id: search_result.future for key_id, search_result in search_results.items()}
-        else:
-            try:
-                # note: this should be first time when we await something, there's no need to "try" the entire function
-                return {key_id: await search_result.future for key_id, search_result in search_results.items()}
-            except asyncio.CancelledError as e:  # terminate remaining tasks ASAP
-                for key_id, search_result in search_results.items():
-                    search_result.future.cancel()
-                raise e
-
-    def _reuse_finished_search_result(self, finished: _IntermediateResult):
+    def _reuse_finished_search_result(self, finished: _SearchState):
         expiration_time_threshold = max(finished.expiration_time or -float('inf'), finished.sufficient_expiration_time)
-        concurrent_requests: SortedList[_IntermediateResult] = self.pending_get_requests[finished.key_id]
+        concurrent_requests: SortedList[_SearchState] = self.pending_get_requests[finished.key_id]
         # note: concurrent_requests is sorted in the order of descending sufficient_expiration_time
         while concurrent_requests and expiration_time_threshold >= concurrent_requests[-1].sufficient_expiration_time:
             concurrent_requests[-1].add_candidate(finished.binary_value, finished.expiration_time,
@@ -450,14 +454,14 @@ class DHTNode:
             concurrent_requests[-1].finish_search()
             concurrent_requests.pop(-1)
 
-    def _trigger_cache_refresh(self, result: _IntermediateResult):
+    def _trigger_cache_refresh(self, search: _SearchState):
         """ Called after get request is finished (whether it was found, not found, hit cache, cancelled, or reused) """
-        if result.found_something and result.source_node_id == self.node_id:
+        if search.found_something and search.source_node_id == self.node_id:
             with self.protocol.cache.freeze():  # do not clear outdated cache for now...
-                if self.cache_refresh_before_expiry and result.key_id in self.protocol.cache:
+                if self.cache_refresh_before_expiry and search.key_id in self.protocol.cache:
                     previous_earliest_item: Tuple[DHTID, BinaryDHTValue, DHTExpiration] = self.cache_refresh_queue.top()
-                    self.cache_refresh_queue.store(result.key_id, result.binary_value, result.expiration_time)
-                    if previous_earliest_item is None or result.expiration_time < previous_earliest_item[-1]:
+                    self.cache_refresh_queue.store(search.key_id, search.binary_value, search.expiration_time)
+                    if previous_earliest_item is None or search.expiration_time < previous_earliest_item[-1]:
                         self.cache_refresh_available.set()  # if we new element is now earliest, notify the cache queue
 
     async def _refresh_stale_cache_entries(self):
@@ -494,22 +498,22 @@ class DHTNode:
                     keys_to_refresh, sufficient_expiration_time=nearest_expiration + self.cache_refresh_before_expiry,
                     _refresh_cache=False)  # if we found value locally, we shouldn't trigger another refresh
 
-    def _cache_new_result(self, result: _IntermediateResult, nearest_nodes: List[DHTID],
+    def _cache_new_result(self, search: _SearchState, nearest_nodes: List[DHTID],
                           node_to_endpoint: Dict[DHTID, Endpoint]):
         """ after key_id is found, update cache according to caching policy. used internally in get and get_many """
-        if result.found_something:
-            previous_expiration_time = max(self.protocol.storage.get(result.key_id)[1] or -float('inf'),
-                                           self.protocol.cache.get(result.key_id)[1] or -float('inf'))
-            if result.expiration_time > previous_expiration_time:  # if this value has better expiration
+        if search.found_something:
+            previous_expiration_time = max(self.protocol.storage.get(search.key_id)[1] or -float('inf'),
+                                           self.protocol.cache.get(search.key_id)[1] or -float('inf'))
+            if search.expiration_time > previous_expiration_time:  # if this value has better expiration
                 if self.cache_locally:
-                    self.protocol.cache.store(result.key_id, result.binary_value, result.expiration_time)
+                    self.protocol.cache.store(search.key_id, search.binary_value, search.expiration_time)
                 if self.cache_nearest:
                     num_cached_nodes = 0
                     for node_id in nearest_nodes:
-                        if node_id == result.source_node_id:
+                        if node_id == search.source_node_id:
                             continue
                         asyncio.create_task(self.protocol.call_store(
-                            node_to_endpoint[node_id], [result.key_id], [result.binary_value], [result.expiration_time],
+                            node_to_endpoint[node_id], [search.key_id], [search.binary_value], [search.expiration_time],
                             in_cache=True))
                         num_cached_nodes += 1
                         if num_cached_nodes >= self.cache_nearest:
@@ -530,8 +534,8 @@ class DHTNode:
 
 
 @dataclass(init=True, repr=True, frozen=False, order=False)
-class _IntermediateResult:
-    """ A helper class that stores current-best GET results with metadata """
+class _SearchState:
+    """ A helper class that stores current-best GET results and all search metadata """
     key_id: DHTID
     sufficient_expiration_time: DHTExpiration
     binary_value: Optional[BinaryDHTValue] = None
@@ -547,13 +551,13 @@ class _IntermediateResult:
             if self.expiration_time >= self.sufficient_expiration_time:
                 self.finish_search()
 
-    def add_done_callback(self, callback: Callable[[_IntermediateResult], Any]):
-        """ Add callback that will be called when _IntermediateSearchResult is done (found OR cancelled by user) """
+    def add_done_callback(self, callback: Callable[[_SearchState], Any]):
+        """ Add callback that will be called when _SearchState is done (found OR cancelled by user) """
         self.future.add_done_callback(lambda _future: callback(self))
 
     def finish_search(self):
         if self.future.done():
-            return  # either user cancelled our result or someone sent it before us. Nothing more to do here.
+            return  # either user cancelled our search or someone sent it before us. Nothing more to do here.
         deserialized_value = self.serializer.loads(self.binary_value) if self.found_something else None
         self.future.set_result((deserialized_value, self.expiration_time))
 
@@ -566,6 +570,6 @@ class _IntermediateResult:
     def finished(self) -> bool:
         return self.future.done()
 
-    def __lt__(self, other: _IntermediateResult):
-        """ _IntermediateResult instances will be sorted by their target expiration time """
+    def __lt__(self, other: _SearchState):
+        """ _SearchState instances will be sorted by their target expiration time """
         return self.sufficient_expiration_time < other.sufficient_expiration_time

--- a/hivemind/dht/node.py
+++ b/hivemind/dht/node.py
@@ -327,9 +327,17 @@ class DHTNode:
         result = await self.get_many([key])
         return result[key]
 
+    def get_local(self, key: DHTKey) -> Tuple[Optional[DHTValue], Optional[DHTExpiration]]:
+        """ Like DHTNode.get, but only search for key in node's local storage and cache """
+        key_id = DHTID.generate(source=key)
+        maybe_value_bytes, maybe_expiration = self.protocol.storage.get(key_id)
+        maybe_cached_value, maybe_cache_expiration = self.protocol.cache.get(key_id)
+        if (maybe_cache_expiration or -float('inf')) > (maybe_expiration or -float('inf')):
+            maybe_value_bytes, maybe_expiration = maybe_cached_value, maybe_cache_expiration
+        return maybe_value_bytes, maybe_expiration
+
     async def get_many(self, keys: Collection[DHTKey], sufficient_expiration_time: Optional[DHTExpiration] = None,
-                       **kwargs) -> Dict[DHTKey, Union[Tuple[Optional[DHTValue], Optional[DHTExpiration]],
-                                                       Awaitable[Tuple[Optional[DHTValue], Optional[DHTExpiration]]]]]:
+                       **kwargs) -> Dict[DHTKey, Tuple[Optional[DHTValue], Optional[DHTExpiration]]]:
         """
         Traverse DHT to find a list of keys. For each key, return latest (value, expiration) or None if not found.
 
@@ -349,9 +357,8 @@ class DHTNode:
 
     async def get_many_by_id(
             self, key_ids: Collection[DHTID], sufficient_expiration_time: Optional[DHTExpiration] = None,
-            num_workers: Optional[int] = None, beam_size: Optional[int] = None, return_futures: bool = False,
-            _refresh_cache=True) -> Dict[DHTID, Union[Tuple[Optional[DHTValue], Optional[DHTExpiration]],
-                                                      Awaitable[Tuple[Optional[DHTValue], Optional[DHTExpiration]]]]]:
+            num_workers: Optional[int] = None, beam_size: Optional[int] = None, _refresh_cache=True
+    ) -> Dict[DHTID, Tuple[Optional[DHTValue], Optional[DHTExpiration]]]:
         """
         Traverse DHT to find a list of DHTIDs. For each key, return latest (value, expiration) or None if not found.
 
@@ -361,9 +368,6 @@ class DHTNode:
             If min_expiration_time=float('inf'), this method will find a value with _latest_ expiration
         :param beam_size: maintains up to this many nearest nodes when crawling dht, default beam_size = bucket_size
         :param num_workers: override for default num_workers, see traverse_dht num_workers param
-        :param return_futures: if True, immediately return asyncio.Future for every before interacting with the nework.
-         The algorithm will populate these futures with (value, expiration) when it finds the corresponding key
-         Note: canceling a future will stop search for the corresponding key
         :param _refresh_cache: internal flag, whether or not to self._trigger_cache_refresh
         :returns: for each key: value and its expiration time. If nothing is found, returns (None, None) for that key
         :note: in order to check if get returned a value, please check (expiration_time is None)
@@ -422,16 +426,13 @@ class DHTNode:
             get_neighbors=get_neighbors, visited_nodes={key_id: {self.node_id} for key_id in unfinished_key_ids},
             found_callback=found_callback, await_all_tasks=False))
 
-        if return_futures:
-            return {key_id: search_result.future for key_id, search_result in search_results.items()}
-        else:
-            try:
-                # note: this should be first time when we await something, there's no need to "try" the entire function
-                return {key_id: await search_result.future for key_id, search_result in search_results.items()}
-            except asyncio.CancelledError as e:  # terminate remaining tasks ASAP
-                for key_id, search_result in search_results.items():
-                    search_result.future.cancel()
-                raise e
+        try:
+            # note: this should be first time when we await something, there's no need to "try" the entire function
+            return {key_id: await search_result for key_id, search_result in search_results.items()}
+        except asyncio.CancelledError as e:  # terminate remaining tasks ASAP
+            for key_id, search_result in search_results.items():
+                search_result.finish_search()
+            raise e
 
     def _reuse_finished_search_result(self, finished: _IntermediateResult):
         expiration_time_threshold = max(finished.expiration_time or -float('inf'), finished.sufficient_expiration_time)
@@ -562,3 +563,6 @@ class _IntermediateResult:
     def __lt__(self, other: _IntermediateResult):
         """ _IntermediateResult instances will be sorted by their target expiration time """
         return self.sufficient_expiration_time < other.sufficient_expiration_time
+
+    def __await__(self):
+        return self.future.__await__()

--- a/hivemind/dht/protocol.py
+++ b/hivemind/dht/protocol.py
@@ -282,7 +282,7 @@ class LocalStorage:
     def store(self, key: DHTID, value: BinaryDHTValue, expiration_time: DHTExpiration) -> bool:
         """
         Store a (key, value) pair locally at least until expiration_time. See class docstring for details.
-        :returns: True if new value was stored, False it was rejected (current value is newer)
+        :returns: True if new value was stored, False it was rejected (e.g. if there is a newer value for that key)
         """
         if expiration_time < get_dht_time() and not self.frozen:
             return False


### PR DESCRIPTION
__we're currently trying alternative solution in #103, this PR will not receive updates for several days__


* [ ] add beam search function to hivemind.dht.DHT (rationale: reduce inter-process communication)
* [ ] add batch-parallel beam search
* [ ] add option for limited time_budget in beam search
* [x] DHT, DHTNode: shutdown on `__del__` (LATER)
* [ ] CircleCI: rollback changes from part1 (was: temporary failure on their side) 
* [ ] remove beam search from moe.py
* [ ] add tests for all new functionality
  * [ ] get/store locally
  * [ ] find_best_experts
  * [ ] batch_find_best_experts
* [ ] add beam search benchmark to benchmark_dht

__On time budget:__ if time_budget != float('inf'), beam search will send requests to peers only within this budget and return best experts it could find in cache