### PR TITLE
Fix source links in RTFD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -209,14 +209,11 @@ todo_include_todos = True
 
 def setup(app):
     app.add_stylesheet("fix_rtd.css")
-    github_doc_root = 'https://github.com/rtfd/recommonmark/tree/master/doc/'  # TODO
     app.add_config_value('recommonmark_config', {
-        'url_resolver': lambda url: github_doc_root + url,
         'auto_toc_tree_section': 'Contents',
         'enable_math': True,
         'enable_inline_math': True,
         'enable_eval_rst': True,
-        # 'enable_auto_doc_ref': True,
     }, True)
     app.add_transform(AutoStructify)
     app.add_source_suffix('.md', 'markdown')
@@ -247,4 +244,5 @@ def linkcode_resolve(domain, info):
     except Exception:
         filename = info['module'].replace('.', '/') + '.py'
 
-    return "https://github.com/learning-at-home/hivemind/blob/%s/%s" % (branch, filename)
+    relative_filename = filename[filename.rindex('hivemind'):]
+    return "https://github.com/learning-at-home/hivemind/blob/%s/%s" % (branch, relative_filename)


### PR DESCRIPTION
There's a __[source]__ link after every class/method in RTFD
![image](https://user-images.githubusercontent.com/3491902/95004507-adbdfa80-05f4-11eb-904f-f1c93dae3689.png)
![image](https://user-images.githubusercontent.com/3491902/95004509-b31b4500-05f4-11eb-8483-0bed6bfa59ee.png)

In master, this source link is broken since we switched from python setup.py develop to python setup.py install with this flag:
![image](https://user-images.githubusercontent.com/3491902/95004512-c7f7d880-05f4-11eb-80e2-c20ae4b0eb8c.png)

As a result, source links point to non-existant locations like
`https://github.com/learning-at-home/hivemind/envs/latest/lib/python3.7/site-packages/hivemind/dht/__init__.py#L131-L142`

This PR fixes the source link generator so that it works regardless of package installation path.