### PR TITLE
set circleci python version to 3.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ orbs:
 jobs:
   build-and-test:
     executor: python/default
+    docker:
+      - image: circleci/python:3.8.1
     steps:
       - checkout
       - python/load-cache


### PR DESCRIPTION
CircleCI default python version is not 3.9. Some of our dependencies do not work with 3.9 yet, so we should explicitly switch to python v3.8.1 for now.