### PR TITLE
[rfc] gating function averaging

### DIFF
--- a/docs/modules/client.rst
+++ b/docs/modules/client.rst
@@ -17,3 +17,9 @@
 .. autoclass:: RemoteMixtureOfExperts
    :members:
    :member-order: bysource
+
+.. autoclass:: DecentralizedOptimizer
+   :members:
+
+.. autoclass:: DecentralizedAverager
+   :members:

--- a/docs/modules/client.rst
+++ b/docs/modules/client.rst
@@ -20,6 +20,8 @@
 
 .. autoclass:: DecentralizedOptimizer
    :members:
+   :member-order: bysource
 
 .. autoclass:: DecentralizedAverager
    :members:
+   :member-order: bysource

--- a/hivemind/client/__init__.py
+++ b/hivemind/client/__init__.py
@@ -1,2 +1,3 @@
 from hivemind.client.expert import RemoteExpert
 from hivemind.client.moe import RemoteMixtureOfExperts
+from hivemind.client.averaging import DecentralizedAverager, DecentralizedOptimizer

--- a/hivemind/client/__init__.py
+++ b/hivemind/client/__init__.py
@@ -1,3 +1,4 @@
 from hivemind.client.expert import RemoteExpert
 from hivemind.client.moe import RemoteMixtureOfExperts
-from hivemind.client.averaging import DecentralizedAverager, DecentralizedOptimizer
+from hivemind.client.averaging import DecentralizedAverager
+from hivemind.client.optimizer import DecentralizedOptimizer

--- a/hivemind/client/averaging.py
+++ b/hivemind/client/averaging.py
@@ -176,7 +176,6 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
 
     def _get(self, peer: Endpoint) -> averaging_pb2_grpc.DecentralizedAveragingStub:
         """ get a GatingFunctionAveragingStub that sends requests to a given peer """
-        #TODO
         channel = grpc.aio.insecure_channel(peer, options=self.channel_options)
         return averaging_pb2_grpc.DecentralizedAveragingStub(channel)
 

--- a/hivemind/client/averaging.py
+++ b/hivemind/client/averaging.py
@@ -328,7 +328,7 @@ class LookingForGroup(ProtocolState):
     """ i am currently looking for group in a dht """
     my_endpoint: Endpoint
     my_expiration: DHTExpiration
-    one_request_at_a_time: asyncio.Lock = field(default=asyncio.Lock(), init=False)
+    one_request_at_a_time: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
 
 
 @dataclass
@@ -358,7 +358,7 @@ class RunningAllReduce(ProtocolState):
     accumulator: Optional[torch.Tensor] = field(default=None, init=False)  # the sum of incoming vector parts
     average_tensor: Optional[torch.Tensor] = field(default=None, init=False)  # accumulator / group size
     received_from: Set[Endpoint] = field(default_factory=set, init=False)  # peers that have sent me their chunk
-    finished_accumulating: asyncio.Event = field(default=asyncio.Event(), init=False)
+    finished_accumulating: asyncio.Event = field(default_factory=asyncio.Event, init=False)
 
     async def accumulate(self, source: Endpoint, part: torch.Tensor) -> torch.Tensor:
         """ Add your vector to accumulator, wait for all other vectors to be added, return the average """

--- a/hivemind/client/averaging.py
+++ b/hivemind/client/averaging.py
@@ -26,7 +26,6 @@ from hivemind.proto import averaging_pb2, averaging_pb2_grpc
 logger = get_logger(__file__)
 
 
-
 class DecentralizedAverager(mp.Process, averaging_pb2_grpc.GatingFunctionAveragingServicer):
     """
     Gating function averaging service. A trainer can run this service in background to periodically average his gating

--- a/hivemind/client/averaging.py
+++ b/hivemind/client/averaging.py
@@ -1,0 +1,306 @@
+""" Utilities for averaging common layers in decentralized training """
+# TODO implement some test to verify that averaged params are the same as latest model params, warn if not
+# TODO check for unused statuses! and hopefully remove them.
+# TODO on shutdown: gracefully send notifications to current group, remove keys from DHT, etc.
+# TODO allow specifying target allreduce frequency in DecentralizedOptimizer
+
+
+from __future__ import annotations
+
+import ctypes
+from enum import Enum, auto
+from typing import Sequence, Iterable, Optional, Tuple, Any, Set, Collection, Iterator
+from concurrent.futures.thread import ThreadPoolExecutor
+import multiprocessing as mp
+import asyncio
+
+import torch
+import uvloop
+import grpc
+
+import hivemind
+from hivemind.dht import get_dht_time, DHTExpiration
+from hivemind.utils import nested_flatten, get_logger, Endpoint, deserialize_torch_tensor, serialize_torch_tensor, Port
+from hivemind.proto import averaging_pb2, averaging_pb2_grpc
+
+logger = get_logger(__file__)
+
+
+
+class DecentralizedAverager(mp.Process, averaging_pb2_grpc.GatingFunctionAveragingServicer):
+    """
+    Gating function averaging service. A trainer can run this service in background to periodically average his gating
+    function with other trainers. The averaging pattern is chosen so that (1) you only need to average with a small
+    group of peers at a time, but (2) all trainers will converge to global average in a logarithmic number of steps.
+
+    Why averaging is valid: see https://github.com/learning-at-home/hivemind/issues/95#issuecomment-688806705
+    On global convergence: see https://github.com/learning-at-home/hivemind/issues/95#issuecomment-717719400
+
+    :param averaged_tensors: a sequence of pytorch tensors that will be averaged in each all-reduce
+    :param dht: a DHT node that will be used to find groups
+    :param start: if True, starts the background process immediately
+    :param target_group_size: averager will try to form groups of approximately this size
+    :param num_buckets_base: the total number will be num_buckets_base ^ D for some D \in 1, 2, ...
+    :param initial_ndim: the averager will initially consider num_buckets_base ^ initial_ndim buckets ,
+      but it may change this value based on target_group_size and the number of peers in each bucket
+    :param max_freeloaders: peer will accept at most this many freeloaders per one averaging run
+    :param listen: if True (default), this averager will accept incoming requests from other peers and perform allreduce
+            if False, the averager will register as a freeloader and attempt to fetch vectors from other averagers
+    :param listen_on: network interface, e.g. "0.0.0.0:1337" or "localhost:*" (* means pick any port) or "[::]:7654"
+    :param receiver_threads: uses this many threads to await on input pipe. Default = 1 should be enough in most cases
+    :param channel_options: options for grpc.aio.insecure_channel, e.g. [('grpc.enable_retries', 0)]
+          see https://grpc.github.io/grpc/core/group__grpc__arg__keys.html for a list of all options
+    :param kwargs: extra parameters forwarded to in grpc.aio.server
+
+    You can perform averaging using DecentralizedOptimizer (see above) or by manually running each step as such:
+
+    >>> model = create_my_model()
+    >>> averaging = DecentralizedAverager(model.parameters(), dht, start=True)
+    >>> averaging.look_for_group()
+    >>> for i in range(num_training_steps):
+    >>>     train_on_batch(model)
+    >>>     if averaging.found_group:
+    >>>          averaged_parameters = averaging.all_reduce(inplace=False)
+    >>>          with torch.no_grad():
+    >>>              for param, averaged_param in zip(model.parameters(), averaged_parameters):
+    >>>                  param[...] = averaged_param
+    >>>          averaging.look_for_group()
+    """
+
+    def __init__(self, averaged_tensors: Sequence[torch.Tensor], dht: hivemind.dht.DHT, *, start: bool,
+                 target_group_size: int, num_buckets_base: int = 4, initial_ndim: int = 2, max_freeloaders: int = 0,
+                 listen: bool = True, listen_on: Endpoint = '0.0.0.0:*', receiver_threads: int = 1,
+                 channel_options: Optional[Sequence[Tuple[str, Any]]] = None, allreduce_timeout: float = 5, **kwargs):
+        # TODO check that all params are actually used. Main suspect: max_freeloaders
+        super().__init__()
+        self.dht, self.target_group_size, self.allreduce_timeout = dht, target_group_size, allreduce_timeout
+        self.num_buckets_base, self.initial_ndim, self.max_freeloaders = num_buckets_base, initial_ndim, max_freeloaders
+        self.server_opts = listen, listen_on, receiver_threads, kwargs
+        self.channel_options = channel_options
+        self._pipe, self.pipe = mp.Pipe(duplex=True)  # a control pipe used to communicate with a background process
+        self._port = mp.Value(ctypes.c_int32, 0)  # assigned when averager starts
+        self._found_group = mp.Value(ctypes.c_bool, False)
+        self.ready = mp.Event()
+
+        self.averaged_tensors = averaged_tensors
+        self.total_size = sum(tensor.numel() for tensor in averaged_tensors)
+        logger.debug(f"Total size of averaged tensors: {self.total_size} elements")
+
+        # internal protocol state variables, only available from inside a running averager process
+        self._state: DecentralizedAverager.State = self.State.NOT_VISIBLE  # looking for group / averaging / ...
+
+        # FOLLOWER_WAITING_FOR_LEADER
+        self._leader_endpoint: Optional[Endpoint] = None  # group leader's endpoint, None = not in a group
+
+        # LEADER_WAITING_FOR_PEERS
+        self._my_endpoint: Optional[Endpoint] = None  # my public endpoint, None = not running accepting requests
+        self._my_group_id: Optional[bytes] = None  # a unique identifier of my group, None = not in a group
+        self._my_group: Set[Endpoint] = set()  # a set of peer endpoints in my group
+        self._my_expiration: Optional[DHTExpiration] = None  # i want to average by this time
+
+        # RUNNING_ALLREDUCE
+        self._my_part_accumulator: Optional[torch.Tensor] = None  # the sum of vectors
+        self._received_data_from: Optional[Set[Endpoint]] = None  # peers that have sent me their chunk
+        self._my_part_after_averaging: Optional[torch.Tensor] = None  # final average for my part
+        self._finished_accumulating = asyncio.Event()  # triggered if we finished averaging our chunk or failed trying
+
+        for tensor in self.averaged_tensors:
+            tensor.share_memory_()
+
+        if start:
+            self.run_in_background(await_ready=True)
+
+    class State(Enum):
+        NOT_VISIBLE = auto()                 # a placeholder: the actual state is visible from inside averager process
+        IDLE = auto()                        # not interested in averaging at this time
+        LOOKING_FOR_GROUP = auto()           # placing requests for group in a DHT
+        LEADER_WAITING_FOR_PEERS = auto()    # i am a leader of a group, waiting for more peers (or timeout)
+        FOLLOWER_WAITING_FOR_LEADER = auto() # i am in a group, but not a leader; waiting for leader to begin allreduce
+        RUNNING_ALLREDUCE = auto()           # i am a leader or member, i currently perform averaging with my group
+
+    def run(self):
+        """ Serve DecentralizedAverager forever. This function will not return until the averager is shut down """
+        self._state = averaging_pb2.GroupStatus.IDLE
+        if asyncio.get_event_loop().is_running():
+            asyncio.get_event_loop().stop()  # if we're in jupyter, get rid of its built-in event loop
+        uvloop.install()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        listen, listen_on, receiver_threads, channel_options, server_kwargs = self.server_opts
+        pipe_awaiter = ThreadPoolExecutor(receiver_threads)
+
+        async def _run():
+            if listen:
+                grpc.experimental.aio.init_grpc_aio()
+                server = grpc.experimental.aio.server(**server_kwargs)
+                averaging_pb2_grpc.add_GatingFunctionAveragingServicer_to_server(self, server)
+                found_port = server.add_insecure_port(listen_on)
+                assert found_port != 0, f"Failed to listen to {listen_on}"
+                self._port.value = found_port
+                await server.start()
+                self.ready.set()
+            else:
+                self.ready.set()
+                raise NotImplementedError("Client-only averaging is not implemented yet.")
+
+            while True:
+                method, args, kwargs = await loop.run_in_executor(pipe_awaiter, self._pipe.recv)
+                asyncio.create_task(getattr(self, method)(*args, **kwargs))
+
+        loop.run_until_complete(_run())
+
+    def run_in_background(self, await_ready=True, timeout=None):
+        """
+        Starts averager in a background process. if await_ready, this method will wait until background dht
+        is ready to process incoming requests or for :timeout: seconds max.
+        """
+        self.start()
+        if await_ready and not self.ready.wait(timeout=timeout):
+            raise TimeoutError("Server didn't notify .ready in {timeout} seconds")
+
+    def shutdown(self) -> None:
+        """ Shut down the averager process """
+        if self.is_alive():
+            self.terminate()
+        else:
+            logger.warning("DHT shutdown has no effect: the process is not alive")
+
+    def _get(self, peer: Endpoint) -> averaging_pb2_grpc.GatingFunctionAveragingStub:
+        """ get a DHTStub that sends requests to a given peer """
+        channel = grpc.experimental.aio.insecure_channel(peer, options=self.channel_options)
+        return averaging_pb2_grpc.GatingFunctionAveragingStub(channel)
+
+
+    # @property
+    # def found_group(self) -> bool:
+    #     raise NotImplementedError()
+    #
+    # @property
+    # def looking_for_group(self) -> bool:
+    #     raise NotImplementedError()
+    #
+    # def look_for_group(self) -> bool:
+    #     raise NotImplementedError()
+    #
+    # def all_reduce(self, inplace: bool) -> bool:
+    #     raise NotImplementedError()
+
+    @property
+    def port(self) -> Port:
+        return self._port.value if self._port.value != 0 else None
+
+    async def call_join_group(self, TODO):
+        raise NotImplementedError()
+
+    async def rpc_join_group(self, request: averaging_pb2.MessageToLeader, context: grpc.ServicerContext):
+        """ A peer wants me to be his leader. I will coordinate his actions with the rest of my group. Maybe. """
+        if self._state == self.State.LOOKING_FOR_GROUP or self._state == self.State.LEADER_WAITING_FOR_PEERS:
+            if self._state == self.State.LOOKING_FOR_GROUP:
+                logger.debug(f"Starting a new group as a leader.")
+                self._state = self.State.LEADER_WAITING_FOR_PEERS
+                self._my_group = set()
+
+            peer: Endpoint = context.peer()
+            logger.debug(f"Adding {peer} to my group, new size = {len(self._my_group)}")
+
+
+
+    async def rpc_part_averaging(self, request: averaging_pb2.AveragingData, context: grpc.ServicerContext):
+        """ A peer sent me his local tensor part. I'll use it to compute the average and return that average to him """
+        can_recover_from_error = True
+        try:
+            assert self._state == self.State.RUNNING_ALLREDUCE, "currently not running allreduce"
+            assert not self._finished_accumulating.is_set(), "I already finished accumulating"
+            assert request.group_id == self._my_group_id, "group_id doesn't match"
+            peer: Endpoint = context.peer()
+            assert peer in self._my_group, "You're not in my group"
+            assert peer not in self._received_data_from, "I already received a chunk from you"
+
+            can_recover_from_error = False
+            self._received_data_from.add(peer)
+            self._my_part_accumulator += deserialize_torch_tensor(request.tensor)
+
+            if len(self._received_data_from) >= len(self._my_group):
+                assert self._received_data_from == self._my_group, f"Group endpoints ({self._my_group}) do not match " \
+                                                                   f"actual peer endpoints ({self._received_data_from})"
+                self._my_part_after_averaging = self._my_part_accumulator / len(self._my_group)
+                self._status = averaging_pb2.ALLREDUCE_FINISHED
+                self._finished_accumulating.set()
+
+            await asyncio.wait_for(self._finished_accumulating.wait(), timeout=self._my_expiration - get_dht_time())
+            assert self._my_part_after_averaging is not None, "Internal error: averaged vector not found"
+
+            return serialize_torch_tensor(self._my_part_after_averaging, request.tensor.compression, allow_inplace=False)
+
+        except Exception as e:
+            if not can_recover_from_error:
+                logger.warning(f"DecentralizedAverager failed all-reduce due to {e}")
+                self._status = averaging_pb2.ALLREDUCE_FAILED
+            else:
+                logger.warning(f"DecentralizedAverager encountered a correctable error during all-reduce: {e}")
+            return averaging_pb2.AveragingData(error=repr(e))
+
+
+
+
+class DecentralizedOptimizer:
+    def __init__(self, optimizer: torch.optim.optimizer.Optimizer, *, dht: hivemind.dht.DHT,
+                 average_optimizer: bool = False, averaged_tensors: Optional[Iterable[torch.Tensor]] = None, **kwargs):
+        """
+        A wrapper for torch optimizer that will periodically average model parameters with other peers.
+        :param optimizer: an normal pytorch optimizer to be wrapped
+        :param dht: a DHT node that will be used to find groups
+        :param average_optimizer: if True, all-reduce will aggregate both model parameters and optimizer,
+           otherwise average only model parameters (or averaged_tensors, if specified)
+        :param averaged_tensors: manually specify all tensors that should be averaged
+        :param kwargs: see DecentralizedAverager parameters
+        """
+        self.optimizer, self.dht, self._averager, self._called_step = optimizer, dht, None, False
+        assert not average_optimizer or (averaged_tensors is None), "Please use either average_optimizer=True or" \
+                                                                    " averaged_tensors, but not both."
+        self.averager_opts = average_optimizer, averaged_tensors, kwargs
+
+    @property
+    def averager(self) -> DecentralizedAverager:
+        if not self._called_step:
+            raise ValueError("DecentralizedOptimizer.averager will be created when you call .step() for the first time")
+        if self._averager is not None:
+            return self._averager
+
+        average_optimizer, averaged_tensors, kwargs = self.averager_opts
+        if averaged_tensors is None:
+            averaged_tensors = [param for param_group in self.optimizer.param_groups for param in param_group['params']]
+            if average_optimizer:
+                found_optimizer_stats = False
+                for value in nested_flatten(self.optimizer.state_dict()):
+                    if isinstance(value, torch.Tensor) and value not in averaged_tensors:
+                        averaged_tensors.append(value)
+                        found_optimizer_stats = True
+                if not found_optimizer_stats:
+                    logger.warning("Using average_optimizer=True, but found no optimizer statistics. Make sure your "
+                                   "optimizer has tensors in its .state_dict().")
+        else:
+            averaged_tensors = list(averaged_tensors)
+
+        self._averager = DecentralizedAverager(averaged_tensors, dht=self.dht, start=True, **kwargs)
+        return self._averager
+
+    def step(self, *args, **kwargs):
+        step_result = self.optimizer.step(*args, **kwargs)
+        if self.averager.found_group:
+            self.averager.all_reduce(inplace=True)  # TODO background averaging a-la hogwild
+        if not self.averager.looking_for_group:
+            self.averager.look_for_group()
+        return step_result
+
+    def zero_grad(self):
+        return self.optimizer.zero_grad()
+
+    def __repr__(self):
+        return f"DecentralizedOptimizer({repr(self.optimizer)})"
+
+    def __del__(self):
+        logger.info("Deleting DecentralizedOptimizer, shutting down background averaging process")
+        if self._averager is not None:
+            self._averager.shutdown()

--- a/hivemind/client/averaging.py
+++ b/hivemind/client/averaging.py
@@ -22,221 +22,6 @@ from hivemind.proto import averaging_pb2, averaging_pb2_grpc
 logger = get_logger(__file__)
 
 
-class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragingServicer):
-    """
-    Gating function averaging service. A trainer can run this service in background to periodically average his gating
-    function with other trainers. The averaging pattern is chosen so that (1) you only need to average with a small
-    group of peers at a time, but (2) all trainers will converge to global average in a logarithmic number of steps.
-
-    Why averaging is valid: see https://github.com/learning-at-home/hivemind/issues/95#issuecomment-688806705
-    On global convergence: see https://github.com/learning-at-home/hivemind/issues/95#issuecomment-717719400
-
-    :param averaged_tensors: a sequence of pytorch tensors that will be averaged in each all-reduce
-    :param dht: a DHT node that will be used to find groups
-    :param start: if True, starts the background process immediately
-    :param bucket_size: averager will try to form groups of approximately this size
-    :param initial_ndim: the averager will initially consider bucket_size ^ initial_ndim buckets
-      but it may change this value based on target_group_size and the number of peers in each bucket
-    :param timeout: consider allreduce failed if there was no activity for this many **seconds**
-    :param listen: if True (default), this averager will accept incoming requests from other peers and perform allreduce
-            if False, the averager will register as a freeloader and attempt to fetch vectors from other averagers
-    :param listen_on: network interface, e.g. "0.0.0.0:1337" or "localhost:*" (* means pick any port) or "[::]:7654"
-    :param receiver_threads: uses this many threads to await on input pipe. Default = 1 should be enough in most cases
-    :param channel_options: options for grpc.aio.insecure_channel, e.g. [('grpc.enable_retries', 0)]
-          see https://grpc.github.io/grpc/core/group__grpc__arg__keys.html for a list of all options
-    :param kwargs: extra parameters forwarded to in grpc.aio.server
-
-    You can perform averaging using DecentralizedOptimizer (see below) or by manually running each step as such:
-
-    >>> model = create_my_model()
-    >>> averaging = DecentralizedAverager(model.parameters(), dht, start=True)
-    >>> averaging.look_for_group()
-    >>> for i in range(num_training_steps):
-    >>>     train_on_batch(model)
-    >>>     if averaging.found_group:
-    >>>          averaged_parameters = averaging.all_reduce(inplace=False)
-    >>>          with torch.no_grad():
-    >>>              for param, averaged_param in zip(model.parameters(), averaged_parameters):
-    >>>                  param[...] = averaged_param
-    >>>          averaging.look_for_group()
-    """
-
-    def __init__(self, averaged_tensors: Sequence[torch.Tensor], dht: hivemind.dht.DHT, *, start: bool,
-                 bucket_size: int = 16, initial_ndim: int = 2, timeout: float = 15,
-                 listen: bool = True, listen_on: Endpoint = '0.0.0.0:*', receiver_threads: int = 1,
-                 channel_options: Optional[Sequence[Tuple[str, Any]]] = None, **kwargs):
-        super().__init__()
-        self.dht = dht
-        self.bucket_size, self.initial_ndim, self.timeout = bucket_size, initial_ndim, timeout
-        self.server_opts = listen, listen_on, receiver_threads, kwargs
-        self.channel_options = channel_options
-        self._pipe, self.pipe = mp.Pipe(duplex=True)  # a control pipe used to communicate with a background process
-        self._port = mp.Value(ctypes.c_uint32, 0)  # assigned when averager starts, accessible via self.port
-        self._state = mp.Value(ctypes.c_uint16, self.State.NOT_RUNNING.value)
-        self.ready = mp.Event()
-
-        self.averaged_tensors = list(averaged_tensors)
-        for tensor in self.averaged_tensors:
-            assert tensor.grad_fn is None, "averaged_tensors must be either parameters or leaf tensors"
-            tensor.share_memory_()
-
-        self.total_size = sum(tensor.numel() for tensor in self.averaged_tensors)
-        logger.debug(f"Total size of averaged tensors: {self.total_size} elements")
-
-        # internal protocol state variables, only available from inside a running averager process
-        # state=LEADER_WAITING_FOR_PEERS
-        self._my_endpoint: Optional[Endpoint] = None  # my public endpoint, None = not running accepting requests
-        self._my_group_id: Optional[bytes] = None  # a unique identifier of my group, None = not in a group
-        self._my_group: Set[Endpoint] = set()  # a set of peer endpoints in my group
-        self._my_expiration: Optional[DHTExpiration] = None  # i want to average by this time
-
-        # state=FOLLOWER_WAITING_FOR_LEADER
-        self._leader_endpoint: Optional[Endpoint] = None  # group leader's endpoint, None = i'm not a follower
-
-        # state=RUNNING_ALLREDUCE
-        self._my_part_accumulator: Optional[torch.Tensor] = None  # the sum of vectors
-        self._received_data_from: Optional[Set[Endpoint]] = None  # peers that have sent me their chunk
-        self._my_part_after_averaging: Optional[torch.Tensor] = None  # final average for my part
-        self._finished_accumulating = asyncio.Event()  # triggered if we finished averaging our chunk or failed trying
-
-        if start:
-            self.run_in_background(await_ready=True)
-
-    class State(Enum):
-        NOT_RUNNING = auto()                  # server not running yet
-        IDLE = auto()                         # server running, not interested in averaging at this time
-        LOOKING_FOR_GROUP = auto()            # placing requests for group in a DHT
-        LEADER_WAITING_FOR_PEERS = auto()     # i am a leader of a group, waiting for more peers (or timeout)
-        FOLLOWER_WAITING_FOR_LEADER = auto()  # i am in a group, but not a leader; waiting for leader to begin allreduce
-        RUNNING_ALLREDUCE = auto()            # i am a leader or member, i currently perform averaging with my group
-
-    def run(self):
-        """ Serve DecentralizedAverager forever. This function will not return until the averager is shut down """
-        if asyncio.get_event_loop().is_running():
-            asyncio.get_event_loop().stop()  # if we're in jupyter, get rid of its built-in event loop
-
-        uvloop.install()
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-        listen, listen_on, receiver_threads, server_kwargs = self.server_opts
-        pipe_awaiter = ThreadPoolExecutor(receiver_threads)
-
-        async def _run():
-            if listen:
-                grpc.aio.init_grpc_aio()
-                server = grpc.aio.server(**server_kwargs)
-                averaging_pb2_grpc.add_DecentralizedAveragingServicer_to_server(self, server)
-                found_port = server.add_insecure_port(listen_on)
-                assert found_port != 0, f"Failed to listen to {listen_on}"
-                self._port.value = found_port
-                await server.start()
-                self.state = self.State.IDLE
-                self.ready.set()
-            else:
-                self.ready.set()
-                raise NotImplementedError("Client-only averaging is not implemented yet.")
-
-            while True:
-                method, args, kwargs = await loop.run_in_executor(pipe_awaiter, self._pipe.recv)
-                asyncio.create_task(getattr(self, method)(*args, **kwargs))
-
-        loop.run_until_complete(_run())
-
-    def run_in_background(self, await_ready=True, timeout=None):
-        """
-        Starts averager in a background process. if await_ready, this method will wait until background dht
-        is ready to process incoming requests or for :timeout: seconds max.
-        """
-        self.start()
-        if await_ready and not self.ready.wait(timeout=timeout):
-            raise TimeoutError("Server didn't notify .ready in {timeout} seconds")
-
-    def shutdown(self) -> None:
-        """ Shut down the averager process """
-        if self.is_alive():
-            self.terminate()
-        else:
-            logger.warning("DHT shutdown has no effect: the process is not alive")
-
-    @property
-    def port(self) -> Optional[Port]:
-        return self._port.value if self._port.value != 0 else None
-
-    @property
-    def state(self) -> DecentralizedAverager.State:
-        if not self.is_alive():
-            self._state.value = self.State.NOT_RUNNING.value
-        return self.State(self._state.value)
-
-    @state.setter
-    def state(self, new_state: DecentralizedAverager.State):
-        assert os.getpid() == self.pid, "Averager state can only be changed from inside the averager process"
-        self._state.value = new_state.value
-
-    def _get(self, peer: Endpoint) -> averaging_pb2_grpc.DecentralizedAveragingStub:
-        """ get a GatingFunctionAveragingStub that sends requests to a given peer """
-        channel = grpc.aio.insecure_channel(peer, options=self.channel_options)
-        return averaging_pb2_grpc.DecentralizedAveragingStub(channel)
-
-    def step(self) -> bool:
-        """ Run the averaging protocol: look for group, then run allreduce inside that """
-        raise NotImplementedError()
-
-    async def call_join_group(self, TODO):
-        raise NotImplementedError()
-
-    async def rpc_join_group(self, request: averaging_pb2.MessageToLeader, context: grpc.ServicerContext):
-        """ A peer wants me to be his leader. I will coordinate his actions with the rest of my group. Maybe. """
-        if self._state == self.State.LOOKING_FOR_GROUP or self._state == self.State.LEADER_WAITING_FOR_PEERS:
-            if self._state == self.State.LOOKING_FOR_GROUP:
-                logger.debug(f"Starting a new group as a leader.")
-                self._state = self.State.LEADER_WAITING_FOR_PEERS
-                self._my_group = set()
-
-            peer: Endpoint = context.peer()
-            logger.debug(f"Adding {peer} to my group, new size = {len(self._my_group)}")
-
-
-
-    async def rpc_part_averaging(self, request: averaging_pb2.AveragingData, context: grpc.ServicerContext):
-        """ A peer sent me his local tensor part. I'll use it to compute the average and return that average to him """
-        can_recover_from_error = True
-        try:
-            assert self._state == self.State.RUNNING_ALLREDUCE, "currently not running allreduce"
-            assert not self._finished_accumulating.is_set(), "I already finished accumulating"
-            assert request.group_id == self._my_group_id, "group_id doesn't match"
-            peer: Endpoint = context.peer()
-            assert peer in self._my_group, "You're not in my group"
-            assert peer not in self._received_data_from, "I already received a chunk from you"
-
-            can_recover_from_error = False
-            self._received_data_from.add(peer)
-            self._my_part_accumulator += deserialize_torch_tensor(request.tensor)
-
-            if len(self._received_data_from) >= len(self._my_group):
-                assert self._received_data_from == self._my_group, f"Group endpoints ({self._my_group}) do not match " \
-                                                                   f"actual peer endpoints ({self._received_data_from})"
-                self._my_part_after_averaging = self._my_part_accumulator / len(self._my_group)
-                self._status = averaging_pb2.ALLREDUCE_FINISHED
-                self._finished_accumulating.set()
-
-            await asyncio.wait_for(self._finished_accumulating.wait(), timeout=self._my_expiration - get_dht_time())
-            assert self._my_part_after_averaging is not None, "Internal error: averaged vector not found"
-
-            return serialize_torch_tensor(self._my_part_after_averaging, request.tensor.compression, allow_inplace=False)
-
-        except Exception as e:
-            if not can_recover_from_error:
-                logger.warning(f"DecentralizedAverager failed all-reduce due to {e}")
-                self._status = averaging_pb2.ALLREDUCE_FAILED
-            else:
-                logger.warning(f"DecentralizedAverager encountered a correctable error during all-reduce: {e}")
-            return averaging_pb2.AveragingData(error=repr(e))
-
-
-
-
 class DecentralizedOptimizer:
     def __init__(self, optimizer: torch.optim.optimizer.Optimizer, *, dht: hivemind.dht.DHT,
                  average_optimizer: bool = False, averaged_tensors: Optional[Iterable[torch.Tensor]] = None, **kwargs):
@@ -297,3 +82,223 @@ class DecentralizedOptimizer:
         logger.info("Deleting DecentralizedOptimizer, shutting down background averaging process")
         if self._averager is not None:
             self._averager.shutdown()
+
+
+class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragingServicer):
+    """
+    Gating function averaging service. A trainer can run this service in background to periodically average his gating
+    function with other trainers. The averaging pattern is chosen so that (1) you only need to average with a small
+    group of peers at a time, but (2) all trainers will converge to global average in a logarithmic number of steps.
+
+    Why averaging is valid: see https://github.com/learning-at-home/hivemind/issues/95#issuecomment-688806705
+    On global convergence: see https://github.com/learning-at-home/hivemind/issues/95#issuecomment-717719400
+
+    :param averaged_tensors: a sequence of pytorch tensors that will be averaged in each all-reduce
+    :param dht: a DHT node that will be used to find groups
+    :param start: if True, starts the background process immediately
+    :param bucket_size: averager will try to form groups of approximately this size
+    :param initial_ndim: the averager will initially consider bucket_size ^ initial_ndim buckets
+      but it may change this value based on target_group_size and the number of peers in each bucket
+    :param timeout: consider allreduce failed if there was no activity for this many **seconds**
+    :param listen: if True (default), this averager will accept incoming requests from other peers and perform allreduce
+            if False, the averager will register as a freeloader and attempt to fetch vectors from other averagers
+    :param listen_on: network interface, e.g. "0.0.0.0:1337" or "localhost:*" (* means pick any port) or "[::]:7654"
+    :param receiver_threads: uses this many threads to await on input pipe. Default = 1 should be enough in most cases
+    :param channel_options: options for grpc.aio.insecure_channel, e.g. [('grpc.enable_retries', 0)]
+          see https://grpc.github.io/grpc/core/group__grpc__arg__keys.html for a list of all options
+    :param kwargs: extra parameters forwarded to in grpc.aio.server
+
+    You can perform averaging using DecentralizedOptimizer (see below) or by manually running each step as such:
+
+    >>> model = create_my_model()
+    >>> averaging = DecentralizedAverager(model.parameters(), dht, start=True)
+    >>> averaging.look_for_group()
+    >>> for i in range(num_training_steps):
+    >>>     train_on_batch(model)
+    >>>     if averaging.found_group:
+    >>>          averaged_parameters = averaging.all_reduce(inplace=False)
+    >>>          with torch.no_grad():
+    >>>              for param, averaged_param in zip(model.parameters(), averaged_parameters):
+    >>>                  param[...] = averaged_param
+    >>>          averaging.look_for_group()
+    """
+
+    def __init__(self, averaged_tensors: Sequence[torch.Tensor], dht: hivemind.dht.DHT, *, start: bool,
+                 bucket_size: int = 16, initial_ndim: int = 2, timeout: float = 15,
+                 listen: bool = True, listen_on: Endpoint = '0.0.0.0:*', receiver_threads: int = 1,
+                 channel_options: Optional[Sequence[Tuple[str, Any]]] = None, **kwargs):
+        super().__init__()
+        self.dht = dht
+        self.bucket_size, self.initial_ndim, self.timeout = bucket_size, initial_ndim, timeout
+        self.server_opts = listen, listen_on, receiver_threads, kwargs
+        self.channel_options = channel_options
+        self._pipe, self.pipe = mp.Pipe(duplex=True)  # a control pipe used to communicate with a background process
+        self._port = mp.Value(ctypes.c_uint32, 0)  # assigned when averager starts, accessible via self.port
+        self._state = mp.Value(ctypes.c_uint16, ProtocolState.NOT_RUNNING.value)
+        self.ready = mp.Event()
+
+        self.averaged_tensors = list(averaged_tensors)
+        for tensor in self.averaged_tensors:
+            assert tensor.grad_fn is None, "averaged_tensors must be either parameters or leaf tensors"
+            tensor.share_memory_()
+
+        self.total_size = sum(tensor.numel() for tensor in self.averaged_tensors)
+        logger.debug(f"Total size of averaged tensors: {self.total_size} elements")
+
+        # internal protocol state variables, only available from inside a running averager process
+        # when forming a group
+        self._my_endpoint: Optional[Endpoint] = None  # my public endpoint, None = not running accepting requests
+        self._my_group_id: Optional[bytes] = None  # a unique identifier of my group, None = not in a group
+        self._my_group: Set[Endpoint] = set()  # a set of peer endpoints in my group
+        self._leader_endpoint: Optional[Endpoint] = None  # group leader's endpoint, None = i'm not a follower
+        self._my_expiration: Optional[DHTExpiration] = None  # i want to average by this time
+
+        # when running all-reduce
+        self._my_part_accumulator: Optional[torch.Tensor] = None  # the sum of vectors
+        self._received_data_from: Optional[Set[Endpoint]] = None  # peers that have sent me their chunk
+        self._my_part_after_averaging: Optional[torch.Tensor] = None  # final average for my part
+        self._finished_accumulating = asyncio.Event()  # triggered if we finished averaging our chunk or failed trying
+
+        if start:
+            self.run_in_background(await_ready=True)
+
+    def run(self):
+        """ Serve DecentralizedAverager forever. This function will not return until the averager is shut down """
+        if asyncio.get_event_loop().is_running():
+            asyncio.get_event_loop().stop()  # if we're in jupyter, get rid of its built-in event loop
+
+        uvloop.install()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        listen, listen_on, receiver_threads, server_kwargs = self.server_opts
+        pipe_awaiter = ThreadPoolExecutor(receiver_threads)
+
+        async def _run():
+            if listen:
+                grpc.aio.init_grpc_aio()
+                server = grpc.aio.server(**server_kwargs)
+                averaging_pb2_grpc.add_DecentralizedAveragingServicer_to_server(self, server)
+                found_port = server.add_insecure_port(listen_on)
+                assert found_port != 0, f"Failed to listen to {listen_on}"
+                self._port.value = found_port
+                await server.start()
+                self.state = ProtocolState.IDLE
+                self.ready.set()
+            else:
+                self.ready.set()
+                raise NotImplementedError("Client-only averaging is not implemented yet.")
+
+            while True:
+                method, args, kwargs = await loop.run_in_executor(pipe_awaiter, self._pipe.recv)
+                asyncio.create_task(getattr(self, method)(*args, **kwargs))
+
+        loop.run_until_complete(_run())
+
+    def run_in_background(self, await_ready=True, timeout=None):
+        """
+        Starts averager in a background process. if await_ready, this method will wait until background dht
+        is ready to process incoming requests or for :timeout: seconds max.
+        """
+        self.start()
+        if await_ready and not self.ready.wait(timeout=timeout):
+            raise TimeoutError("Server didn't notify .ready in {timeout} seconds")
+
+    def shutdown(self) -> None:
+        """ Shut down the averager process """
+        if self.is_alive():
+            self.terminate()
+        else:
+            logger.warning("DHT shutdown has no effect: the process is not alive")
+
+    @property
+    def port(self) -> Optional[Port]:
+        return self._port.value if self._port.value != 0 else None
+
+    @property
+    def state(self) -> ProtocolState:
+        if not self.is_alive():
+            self._state.value = ProtocolState.NOT_RUNNING.value
+        return ProtocolState(self._state.value)
+
+    @state.setter
+    def state(self, new_state: ProtocolState):
+        assert os.getpid() == self.pid, "Averager state can only be changed from inside the averager process"
+        self._state.value = new_state.value
+
+    def _get(self, peer: Endpoint) -> averaging_pb2_grpc.DecentralizedAveragingStub:
+        """ get a GatingFunctionAveragingStub that sends requests to a given peer """
+        channel = grpc.aio.insecure_channel(peer, options=self.channel_options)
+        return averaging_pb2_grpc.DecentralizedAveragingStub(channel)
+
+    def step(self) -> bool:
+        """ Run the averaging protocol: look for group, then run allreduce inside that group """
+        raise NotImplementedError()
+
+    def test_run(self, group_leader: Optional[Endpoint] = None):
+        raise NotImplementedError()
+
+    async def call_join_group(self, recipient: Endpoint):
+        """
+        :param recipient: ask this node to be your group leader. Get acccepted or get directions.
+        :returns: a tuple of (status,
+        """
+        assert os.getpid() == self.pid, "this method is only available from inside a running averager process"
+
+        raise NotImplementedError()
+
+    async def rpc_join_group(self, request: averaging_pb2.MessageToLeader, context: grpc.ServicerContext):
+        """ A peer wants me to be his leader. I will coordinate his actions with the rest of my group. Maybe. """
+        #TODO account for possible concurrent requests to other peers, e.g. use asyncio lock
+        if self._state in (ProtocolState.LOOKING_FOR_GROUP, ProtocolState.LEADER_WAITING_FOR_PEERS):
+            if self._state == ProtocolState.LOOKING_FOR_GROUP:
+                logger.debug(f"Starting a new group as a leader.")
+                self._state = ProtocolState.LEADER_WAITING_FOR_PEERS
+                self._my_group = set()
+
+            peer: Endpoint = context.peer()
+            logger.debug(f"Adding {peer} to my group, new size = {len(self._my_group)}")
+
+    async def rpc_part_averaging(self, request: averaging_pb2.AveragingData, context: grpc.ServicerContext):
+        """ A peer sent me his local tensor part. I'll use it to compute the average and return that average to him """
+        can_recover_from_error = True
+        try:
+            assert self._state == ProtocolState.RUNNING_ALLREDUCE, "currently not running allreduce"
+            assert not self._finished_accumulating.is_set(), "I already finished accumulating"
+            assert request.group_id == self._my_group_id, "group_id doesn't match"
+            peer: Endpoint = context.peer()
+            assert peer in self._my_group, "You're not in my group"
+            assert peer not in self._received_data_from, "I already received a chunk from you"
+
+            can_recover_from_error = False
+            self._received_data_from.add(peer)
+            self._my_part_accumulator += deserialize_torch_tensor(request.tensor)
+
+            if len(self._received_data_from) >= len(self._my_group):
+                assert self._received_data_from == self._my_group, f"Group endpoints ({self._my_group}) do not match " \
+                                                                   f"actual peer endpoints ({self._received_data_from})"
+                self._my_part_after_averaging = self._my_part_accumulator / len(self._my_group)
+                self._finished_accumulating.set()
+
+            await asyncio.wait_for(self._finished_accumulating.wait(), timeout=self._my_expiration - get_dht_time())
+            assert self._my_part_after_averaging is not None, "Internal error: averaged vector not found"
+
+            return serialize_torch_tensor(self._my_part_after_averaging, request.tensor.compression, allow_inplace=False)
+
+        except Exception as e:
+            if not can_recover_from_error:
+                logger.warning(f"DecentralizedAverager failed all-reduce due to {e}")
+                self.TODO()
+            else:
+                logger.warning(f"DecentralizedAverager encountered a correctable error during all-reduce: {e}")
+            return averaging_pb2.AveragingData(error=repr(e))
+
+
+class ProtocolState(Enum):
+    """ State of an averaging protocol """
+    NOT_RUNNING = auto()                  # server not running yet
+    IDLE = auto()                         # server running, not interested in averaging at this time
+    LOOKING_FOR_GROUP = auto()            # placing requests for group in a DHT
+    LEADER_WAITING_FOR_PEERS = auto()     # i am a leader of a group, waiting for more peers (or timeout)
+    FOLLOWER_WAITING_FOR_LEADER = auto()  # i am in a group, but not a leader; waiting for leader to begin allreduce
+    RUNNING_ALLREDUCE = auto()            # i am a leader or member, i currently perform averaging with my group

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -1,0 +1,2 @@
+from hivemind.client.averaging.averager import DecentralizedAverager
+

--- a/hivemind/client/averaging/protocol.py
+++ b/hivemind/client/averaging/protocol.py
@@ -1,0 +1,202 @@
+""" This file contains a state machine that defines DecentralizedAverager protocol """
+from __future__ import annotations
+import asyncio
+import random
+from typing import List, Set, Optional, Sequence, Tuple, Any
+from dataclasses import dataclass, field
+
+import torch
+
+from hivemind.utils import Endpoint
+from hivemind.dht import DHTID, DHTExpiration
+
+
+@dataclass
+class AveragingOutcome:
+    """ A data structure that encodes the outcome of a single attempt at group all-reduce """
+    message: Any = None
+    was_accepted_to_group: bool = False
+    was_leader: bool = False
+    suggested_leader: Optional[Endpoint] = None
+    canceled_looking_for_group: bool = False
+    group_dismissed_by_leader: bool = False
+    started_allreduce: bool = False
+    succeeded_allreduce: bool = False
+    finished: asyncio.Event = field(default_factory=asyncio.Event, init=False)
+
+    async def wait(self):
+        return await self.finished.wait()
+
+
+@dataclass(init=False)
+class ProtocolState:
+    """ The current state of the averaging protocol with auxiliary variables (base class for all states) """
+    def __init__(self):  # note: we could use ABC, but it would be too verbose
+        raise ValueError("Please use one of the subclasses")
+
+    # mandatory fields for all states
+    _is_active_state: bool = field(default=False, init=False)
+    outcome: AveragingOutcome = field(init=False)
+
+    @staticmethod
+    def transition(method):
+        """
+        Decorator: when a transition is called, its output state is marked as active and current state becomes inactive.
+        A single state can only perform one transition before it becomes inactive.
+        """
+        def transition_method(state: ProtocolState, *args, **kwargs):
+            assert state._is_active_state, f"State {state} is not the active state, no longer able to transition"
+            new_state: ProtocolState = method(state, *args, **kwargs)
+            state._is_active_state, new_state._is_active_state = False, True
+            return new_state
+        return transition_method
+
+
+@dataclass
+class Idle(ProtocolState):
+    """ the averager is running, but not interested in averaging at this time """
+    _is_active_state: bool = field(default=True, init=False)  # this is the entry state, it becomes active by default
+    outcome: AveragingOutcome = field(default_factory=AveragingOutcome, init=False)
+    # the outcome field is created here and transferred to all subsequent states until finished or failed
+
+    @ProtocolState.transition
+    def look_for_group(self, my_endpoint: Endpoint, my_expiration: DHTExpiration) -> LookingForGroup:
+        return LookingForGroup(my_endpoint, my_expiration, outcome=self.outcome)
+
+
+@dataclass
+class LookingForGroup(ProtocolState):
+    """ i am currently looking for a group in DHT """
+    my_endpoint: Endpoint
+    my_expiration: DHTExpiration
+    outcome: AveragingOutcome
+    one_request_at_a_time: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+
+    @ProtocolState.transition
+    def become_follower(self, leader_endpoint: Endpoint, group_id: bytes) -> FollowerWaitingForLeader:
+        self.outcome.was_accepted_to_group = True
+        return FollowerWaitingForLeader(my_endpoint=self.my_endpoint, my_expiration=self.my_expiration,
+                                        leader_endpoint=leader_endpoint, group_id=group_id, outcome=self.outcome)
+
+    @ProtocolState.transition
+    def become_leader(self, group_id: Optional[bytes] = None, max_size: Optional[int] = None) -> LeaderWaitingForFollowers:
+        if group_id is None:
+            # note: we generate group_id as DHTID for convenience. Do not assume that it is a DHTID-like sequence
+            group_id = DHTID.generate().to_bytes()
+        self.outcome.was_leader = True
+        return LeaderWaitingForFollowers(
+            leader_endpoint=self.my_endpoint, leader_expiration=self.my_expiration, group_endpoints={self.my_endpoint},
+            group_id=group_id, outcome=self.outcome, max_size=max_size)
+
+    @ProtocolState.transition
+    def cancel_looking_for_group(self, message: Any) -> Idle:
+        self.outcome.canceled_looking_for_group = True
+        self.outcome.message = message
+        self.outcome.finished.set()
+        return Idle()
+
+
+@dataclass
+class FollowerWaitingForLeader(ProtocolState):
+    """ i am in a group, but not a leader; waiting for leader to begin all-reduce """
+    my_endpoint: Endpoint
+    my_expiration: DHTExpiration
+    leader_endpoint: Endpoint
+    group_id: bytes
+    outcome: AveragingOutcome
+
+    @ProtocolState.transition
+    def begin_allreduce(self, group_endpoints: Tuple[Endpoint, ...]) -> RunningAllReduce:
+        assert isinstance(group_endpoints, tuple) and self.my_endpoint in group_endpoints and len(group_endpoints) > 1
+        self.outcome.started_allreduce = True
+        return RunningAllReduce(my_endpoint=self.my_endpoint, group_endpoints=group_endpoints, outcome=self.outcome)
+
+    @ProtocolState.transition
+    def cancel_waiting_for_group(self, message: Any) -> Idle:
+        self.outcome.left_group = True
+        self.outcome.message = message
+        self.outcome.finished.set()
+        return Idle()
+
+
+@dataclass
+class LeaderWaitingForFollowers(ProtocolState):
+    """ i am a leader of a group, waiting for more peers (or timeout) """
+    leader_endpoint: Endpoint
+    leader_expiration: DHTExpiration
+    group_endpoints: Set[Endpoint]
+    group_id: bytes
+    outcome: AveragingOutcome
+    max_size: Optional[int]
+    group_assembled: asyncio.Event = field(default_factory=asyncio.Event, init=False)
+    ordered_group_endpoints: Optional[Tuple[Endpoint, ...]] = field(default=None, init=False)
+
+    def add_follower(self, follower: Endpoint):
+        assert follower not in self.group_endpoints
+        assert self.group_size < (self.max_size or float('inf'))
+        self.group_endpoints.add(follower)
+        if len(self.group_endpoints) >= self.max_size:
+            self.group_assembled.set()
+
+    @property
+    def group_size(self) -> int:
+        return len(self.group_endpoints)
+
+    @ProtocolState.transition
+    def begin_allreduce(self) -> RunningAllReduce:
+        assert len(self.group_endpoints) > 1 and self.leader_expiration in self.group_endpoints, self.group_endpoints
+        self.group_assembled.set()
+        self.outcome.started_allreduce = True
+        if self.ordered_group_endpoints is None:
+            ordered_group_endpoints = list(self.group_endpoints)
+            random.shuffle(ordered_group_endpoints)
+            self.ordered_group_endpoints = tuple(ordered_group_endpoints)
+        return RunningAllReduce(self.leader_endpoint, tuple(self.ordered_group_endpoints), outcome=self.outcome)
+
+
+@dataclass
+class RunningAllReduce(ProtocolState):
+    my_endpoint: Endpoint
+    group_endpoints: Tuple[Endpoint, ...]
+    outcome: AveragingOutcome
+
+    accumulator: Optional[torch.Tensor] = field(default=None, init=False)  # the sum of incoming vector parts
+    average_tensor: Optional[torch.Tensor] = field(default=None, init=False)  # accumulator / group size
+    received_from: Set[Endpoint] = field(default_factory=set, init=False)  # peers that have sent me their chunk
+    finished_accumulating: asyncio.Event = field(default_factory=asyncio.Event, init=False)
+
+    async def accumulate(self, source: Endpoint, part: torch.Tensor) -> torch.Tensor:
+        """ Add your vector to accumulator, wait for all other vectors to be added, return the average """
+        assert not self.finished_accumulating.is_set(), "averaging is already finished"
+        assert source in self.group_endpoints and source not in self.received_from, "unexpected source endpoint"
+        if self.accumulator is None:
+            self.accumulator = part.clone()
+        else:
+            assert part.shape == self.accumulator.shape
+            self.accumulator.add_(part)
+
+        self.received_from.add(source)
+        if len(self.received_from) == len(self.group_endpoints):
+            self.average_tensor = self.accumulator.div_(len(self.received_from))
+            self.finished_accumulating.set()
+        else:
+            await self.finished_accumulating.wait()  # wait for other peers to send their part
+
+        assert self.average_tensor is not None
+        return self.average_tensor
+
+
+def split_into_chunks(tensors: Sequence[torch.Tensor], group_size: int) -> Tuple[torch.Tensor]:
+    """ combines averaged_tensors into one tensor and splits them into equal chunks of size group_size """
+    flat_tensor = torch.cat(tuple(map(torch.Tensor.flatten, tensors)))
+    chunk_slices = torch.linspace(start=0, end=len(flat_tensor), steps=group_size + 1, dtype=torch.int64).numpy()
+    chunk_slices[-1] = len(flat_tensor)
+    return tuple(torch.as_tensor(flat_tensor[chunk_slices[i]: chunk_slices[i + 1]]) for i in range(group_size))
+
+
+def restore_from_chunks(chunks: Sequence[torch.Tensor], shapes: Sequence[torch.Size]) -> Tuple[torch.Tensor, ...]:
+    """ restores the original tensor shapes from chunks obtained by split_into_chunks """
+    flat_tensor = torch.cat(list(chunks))
+    result_sizes = tuple(map(torch.Size.numel, shapes))
+    flat_original_tensors = torch.split_with_sizes(flat_tensor, result_sizes)
+    return tuple(map(torch.Tensor.reshape, flat_original_tensors, shapes))

--- a/hivemind/client/optimizer.py
+++ b/hivemind/client/optimizer.py
@@ -1,0 +1,74 @@
+""" A wrapper for pytorch optimizers that performs decentralized averaging in background """
+from typing import Optional, Iterable
+
+import torch
+
+import hivemind
+from hivemind.client.averaging import DecentralizedAverager
+from hivemind.utils import get_logger, nested_flatten
+
+logger = get_logger(__name__)
+
+# TODO this file is a work in progress, it should be updated after DecentralizedAverager is complete
+
+
+class DecentralizedOptimizer:
+    def __init__(self, optimizer: torch.optim.Optimizer, *, dht: hivemind.dht.DHT,
+                 average_optimizer: bool = False, averaged_tensors: Optional[Iterable[torch.Tensor]] = None, **kwargs):
+        """
+        A wrapper for torch optimizer that will periodically average model parameters with other peers.
+        :param optimizer: an normal pytorch optimizer to be wrapped
+        :param dht: a DHT node that will be used to find groups
+        :param average_optimizer: if True, all-reduce will aggregate both model parameters and optimizer,
+           otherwise average only model parameters (or averaged_tensors, if specified)
+        :param averaged_tensors: manually specify all tensors that should be averaged
+        :param kwargs: see DecentralizedAverager parameters
+        """
+        self.optimizer, self.dht, self._averager, self._called_step = optimizer, dht, None, False
+        assert not average_optimizer or (averaged_tensors is None), "Please use either average_optimizer=True or" \
+                                                                    " averaged_tensors, but not both."
+        self.averager_opts = average_optimizer, averaged_tensors, kwargs
+
+    @property
+    def averager(self) -> DecentralizedAverager:
+        if not self._called_step:
+            raise ValueError("DecentralizedOptimizer.averager will be created when you call .step() for the first time")
+        if self._averager is not None:
+            return self._averager
+
+        average_optimizer, averaged_tensors, kwargs = self.averager_opts
+        if averaged_tensors is None:
+            averaged_tensors = [param for param_group in self.optimizer.param_groups for param in param_group['params']]
+            if average_optimizer:
+                found_optimizer_stats = False
+                for value in nested_flatten(self.optimizer.state_dict()):
+                    if isinstance(value, torch.Tensor) and value not in averaged_tensors:
+                        averaged_tensors.append(value)
+                        found_optimizer_stats = True
+                if not found_optimizer_stats:
+                    logger.warning("Using average_optimizer=True, but found no optimizer statistics. Make sure your "
+                                   "optimizer has tensors in its .state_dict().")
+        else:
+            averaged_tensors = list(averaged_tensors)
+
+        self._averager = DecentralizedAverager(averaged_tensors, dht=self.dht, start=True, **kwargs)
+        return self._averager
+
+    def step(self, *args, **kwargs):
+        step_result = self.optimizer.step(*args, **kwargs)
+        if self.averager.found_group:
+            self.averager.all_reduce(inplace=True)  # TODO background averaging a-la hogwild
+        if not self.averager.looking_for_group:
+            self.averager.look_for_group()
+        return step_result
+
+    def zero_grad(self):
+        return self.optimizer.zero_grad()
+
+    def __repr__(self):
+        return f"DecentralizedOptimizer({repr(self.optimizer)})"
+
+    def __del__(self):
+        logger.info("Deleting DecentralizedOptimizer, shutting down background averaging process")
+        if self._averager is not None:
+            self._averager.shutdown()

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+import "runtime.proto";
+
+
+// Runs alongside each trainer to perform gating function averaging every now and then. Read more: client/averaging.py
+service GatingFunctionAveraging {
+  rpc rpc_join_group(MessageToLeader) returns (stream MessageFromLeader);  // ask leader to coordinate all_reduce
+  rpc rpc_part_averaging(AveragingData) returns (AveragingData);  // my local shard => average shard over all peers
+}
+
+message MessageToLeader {
+  string key = 1;            // I would like to average this kind of data (used as a sanity check)
+  int32 total_size = 2;      // Follower's tensors have this many elements in total (used as a sanity check)
+  string endpoint = 3;       // This is how a (potential) follower perceives the leader
+  float expiration = 4;      // Follower would like to **begin** all_reduce by this point in time
+}
+
+enum GroupStatus {
+  // response to join request
+  ACCEPTED = 0;              // "I accept you in my group / as a freeloader."
+  NOT_A_LEADER = 1;          // "I am not a group a leader. Go ask my leader instead."
+  ALREADY_RUNNING = 2;       // "My group has already began merging. Here's the group leader."
+  NOT_LOOKING_FOR_GROUP = 3; // "I'm not available at the moment. Please, get lost."
+  EXPIRATION_TOO_EARLY = 4;  // "I will not accept you. I cannot guarantee that we begin before you expire."
+  EXPIRATION_TOO_LATE = 5;   // "I will not accept you. You should go to a leader with later expiration time."
+
+  // message from leader when finding peers
+  GROUP_HEARTBEAT = 6;       // "We're still in gathering. Please, stay with us."
+  GROUP_ASSEMBLED = 7;       // "We can begin allreduce now. These are your peers."
+  GROUP_DISMISSED = 8;       // "The group is closed. Go find another group."
+
+  // when averaging
+  ALLREDUCE_FINISHED = 9;   // "We finished allreduce successfully, you can use the results."
+  ALLREDUCE_FAILED = 10;     // "Something went wrong during allreduce. Your results may be wrong."
+}
+
+
+message MessageFromLeader {
+  GroupStatus status = 1;
+  bytes group_id = 2;        // a unique identifier of this group, only valid until allreduce is finished/failed
+  string new_leader = 3;     // if peer is already in a group, it will provide you with an endpoint of his group leader
+  float new_expiration = 4;  // if accepted to a group, this value denotes leader's expiration time (earliest in group)
+  repeated string final_group = 5;  // a sequence of peers, each responsible for one shard during averaging
+  Tensor results = 6;        // full tensor after averaging, only used when sending it to freeloaders
+}
+
+message AveragingData {
+  bytes group_id = 1;        // a unique group identifier, same as in MessageFromLeader
+  Tensor tensor = 2;         // either peer's local tensor part (rpc input) or group average of this part (rpc output)
+  string error = 3;          // in case of protocol violation, this will be the error message
+}

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -9,24 +9,23 @@ service DecentralizedAveraging {
 }
 
 message MessageToLeader {
-  string key = 1;            // I would like to average this kind of data (used as a sanity check)
-  int32 total_size = 2;      // Follower's tensors have this many elements in total (used as a sanity check)
-  string endpoint = 3;       // This is how a (potential) follower perceives the leader
-  float expiration = 4;      // Follower would like to **begin** all_reduce by this point in time
+  bytes scheme_hash = 1;        // I would like to average this kind of data (used for sanity check)
+  string leader_endpoint = 3;  // This is how a (potential) follower perceives the leader (used for sanity check)
+  float expiration = 4;         // Follower would like to **begin** all_reduce by this point in time
 }
 
-enum MessageType {
+enum MessageCode {
   // response to join request
   ACCEPTED = 0;              // "I accept you in my group / as a freeloader."
   NOT_A_LEADER = 1;          // "I am not a group a leader. Go ask my leader instead."
   ALREADY_RUNNING = 2;       // "My group has already began merging. Here's the group leader."
   NOT_LOOKING_FOR_GROUP = 3; // "I'm not available at the moment. Please, get lost."
-  EXPIRATION_TOO_EARLY = 4;  // "I will not accept you. I cannot guarantee that we begin before you expire."
-  EXPIRATION_TOO_LATE = 5;   // "I will not accept you. You should go to a leader with later expiration time."
+  BAD_EXPIRATION_TIME = 4;   // "I will not accept you. I cannot guarantee that we begin before you expire."
+  BAD_SCHEME_HASH = 5;       // "I will not accept you. I am not averaging the samy type of tensors as you."
 
   // message from leader when finding peers
   GROUP_HEARTBEAT = 6;       // "We're still in gathering. Please, stay with us."
-  GROUP_ASSEMBLED = 7;       // "We can begin allreduce now. These are your peers."
+  BEGIN_ALLREDUCE = 7;       // "We can begin allreduce now. These are your peers."
   GROUP_DISMISSED = 8;       // "The group is closed. Go find another group."
 
   // when averaging
@@ -36,16 +35,16 @@ enum MessageType {
 
 
 message MessageFromLeader {
-  MessageType status = 1;
+  MessageCode code = 1;
   bytes group_id = 2;        // a unique identifier of this group, only valid until allreduce is finished/failed
-  string new_leader = 3;     // if peer is already in a group, it will provide you with an endpoint of his group leader
-  float new_expiration = 4;  // if accepted to a group, this value denotes leader's expiration time (earliest in group)
-  repeated string final_group = 5;  // a sequence of peers, each responsible for one shard during averaging
-  Tensor results = 6;        // full tensor after averaging, only used when sending it to freeloaders
+  string suggested_leader = 3;  // if peer is already in a group, it'll provide us with an endpoint of its leader
+  string follower_endpoint = 4;  // This is how a group leader sees its follower (used for sanity check)
+  repeated string group_endpoints = 5;  // a sequence of peers, each responsible for one shard during averaging
 }
 
 message AveragingData {
   bytes group_id = 1;        // a unique group identifier, same as in MessageFromLeader
-  Tensor tensor = 2;         // either peer's local tensor part (rpc input) or group average of this part (rpc output)
-  string error = 3;          // in case of protocol violation, this will be the error message
+  bytes scheme_hash = 2;     // a hash of your key, tensor shape, and part index (used for sanity check)
+  Tensor tensor = 3;         // either peer's local tensor part (rpc input) or group average of this part (rpc output)
+  string error = 4;          // in case of protocol violation, this will be the error message
 }

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -4,8 +4,8 @@ import "runtime.proto";
 
 // Runs alongside each trainer to perform gating function averaging every now and then. Read more: client/averaging.py
 service DecentralizedAveraging {
-  rpc rpc_join_group(MessageToLeader) returns (stream MessageFromLeader);  // ask leader to coordinate all_reduce
-  rpc rpc_part_averaging(AveragingData) returns (AveragingData);  // my local shard => average shard over all peers
+  rpc rpc_group_allreduce(MessageToLeader) returns (stream MessageFromLeader);  // assemble a group and run all-reduce
+  rpc rpc_aggregate_part(AveragingData) returns (AveragingData);  // send my local shard => get aggregated shard
 }
 
 message MessageToLeader {

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -10,7 +10,8 @@ service DecentralizedAveraging {
 
 message MessageToLeader {
   bytes scheme_hash = 1;        // I would like to average this kind of data (used for sanity check)
-  string leader_endpoint = 3;  // This is how a (potential) follower perceives the leader (used for sanity check)
+  string my_endpoint = 2;       // sender's endpoint - to be used for allreduce op
+  string leader_endpoint = 3;   // This is how a (potential) follower perceives the leader (used for sanity check)
   float expiration = 4;         // Follower would like to **begin** all_reduce by this point in time
 }
 
@@ -25,7 +26,7 @@ enum MessageCode {
   DUPLICATE_ENDPOINT = 6;    // "I will not accept you, i already have exactly the same endpoint in my current group"
   GROUP_IS_FULL = 7;         // "I will not accept you, my group already contains too many peers"
   BEGIN_ALLREDUCE = 8;       // "We can begin allreduce now. These are your peers."
-  GROUP_DISMISSED = 9;       // "The group is closed. Go find another group."
+  GROUP_DISBANDED = 9;       // "The group is closed. Go find another group."
 }
 
 
@@ -33,8 +34,7 @@ message MessageFromLeader {
   MessageCode code = 1;
   bytes group_id = 2;        // a unique identifier of this group, only valid until allreduce is finished/failed
   string suggested_leader = 3;  // if peer is already in a group, it'll provide us with an endpoint of its leader
-  repeated string group_endpoints = 5;  // a sequence of peers, each responsible for one shard during averaging
-  string follower_endpoint = 4;  // This is how a group leader sees its follower (used for sanity check)
+  repeated string group_endpoints = 4;  // a sequence of peers, each responsible for one shard during averaging
 }
 
 message AveragingData {

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -3,7 +3,7 @@ import "runtime.proto";
 
 
 // Runs alongside each trainer to perform gating function averaging every now and then. Read more: client/averaging.py
-service GatingFunctionAveraging {
+service DecentralizedAveraging {
   rpc rpc_join_group(MessageToLeader) returns (stream MessageFromLeader);  // ask leader to coordinate all_reduce
   rpc rpc_part_averaging(AveragingData) returns (AveragingData);  // my local shard => average shard over all peers
 }
@@ -15,7 +15,7 @@ message MessageToLeader {
   float expiration = 4;      // Follower would like to **begin** all_reduce by this point in time
 }
 
-enum GroupStatus {
+enum MessageType {
   // response to join request
   ACCEPTED = 0;              // "I accept you in my group / as a freeloader."
   NOT_A_LEADER = 1;          // "I am not a group a leader. Go ask my leader instead."
@@ -36,7 +36,7 @@ enum GroupStatus {
 
 
 message MessageFromLeader {
-  GroupStatus status = 1;
+  MessageType status = 1;
   bytes group_id = 2;        // a unique identifier of this group, only valid until allreduce is finished/failed
   string new_leader = 3;     // if peer is already in a group, it will provide you with an endpoint of his group leader
   float new_expiration = 4;  // if accepted to a group, this value denotes leader's expiration time (earliest in group)

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -22,15 +22,10 @@ enum MessageCode {
   NOT_LOOKING_FOR_GROUP = 3; // "I'm not available at the moment. Please, get lost."
   BAD_EXPIRATION_TIME = 4;   // "I will not accept you. I cannot guarantee that we begin before you expire."
   BAD_SCHEME_HASH = 5;       // "I will not accept you. I am not averaging the samy type of tensors as you."
-
-  // message from leader when finding peers
-  GROUP_HEARTBEAT = 6;       // "We're still in gathering. Please, stay with us."
-  BEGIN_ALLREDUCE = 7;       // "We can begin allreduce now. These are your peers."
-  GROUP_DISMISSED = 8;       // "The group is closed. Go find another group."
-
-  // when averaging
-  ALLREDUCE_FINISHED = 9;   // "We finished allreduce successfully, you can use the results."
-  ALLREDUCE_FAILED = 10;     // "Something went wrong during allreduce. Your results may be wrong."
+  DUPLICATE_ENDPOINT = 6;    // "I will not accept you, i already have exactly the same endpoint in my current group"
+  GROUP_IS_FULL = 7;         // "I will not accept you, my group already contains too many peers"
+  BEGIN_ALLREDUCE = 8;       // "We can begin allreduce now. These are your peers."
+  GROUP_DISMISSED = 9;       // "The group is closed. Go find another group."
 }
 
 
@@ -38,8 +33,8 @@ message MessageFromLeader {
   MessageCode code = 1;
   bytes group_id = 2;        // a unique identifier of this group, only valid until allreduce is finished/failed
   string suggested_leader = 3;  // if peer is already in a group, it'll provide us with an endpoint of its leader
-  string follower_endpoint = 4;  // This is how a group leader sees its follower (used for sanity check)
   repeated string group_endpoints = 5;  // a sequence of peers, each responsible for one shard during averaging
+  string follower_endpoint = 4;  // This is how a group leader sees its follower (used for sanity check)
 }
 
 message AveragingData {

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -33,7 +33,7 @@ def test_chunks():
 @pytest.mark.asyncio
 async def test_allreduce_state():
     allreduce_state = RunningAllReduce(my_endpoint='alice', group_endpoints=('alice', 'bob', 'carol'),
-                                       outcome=AveragingOutcome())
+                                       outcome=AveragingOutcome(), group_id=b'123')
 
     x, y, z = torch.randn(3, 128)
 
@@ -53,14 +53,16 @@ async def test_allreduce_state():
     for tensor in results:
         assert torch.allclose(tensor, ref)
 
-    allreduce_state = RunningAllReduce(my_endpoint='alice', group_endpoints=('alice',), outcome=AveragingOutcome())
+    allreduce_state = RunningAllReduce(my_endpoint='alice', group_endpoints=('alice',),
+                                       outcome=AveragingOutcome(), group_id=b'123')
     assert torch.allclose(x, await allreduce_state.accumulate('alice', x))
 
     with pytest.raises(AssertionError):
         allreduce_state = RunningAllReduce(my_endpoint='alice', group_endpoints=('bob', 'carol'),
-                                           outcome=AveragingOutcome())
+                                           outcome=AveragingOutcome(), group_id=b'123')
         assert torch.allclose(x, await allreduce_state.accumulate('alice', x))
 
     with pytest.raises(AssertionError):
-        allreduce_state = RunningAllReduce(my_endpoint='alice', group_endpoints=tuple(), outcome=AveragingOutcome())
+        allreduce_state = RunningAllReduce(my_endpoint='alice', group_endpoints=tuple(),
+                                           outcome=AveragingOutcome(), group_id=b'123')
         assert torch.allclose(x, await allreduce_state.accumulate('alice', x))

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -8,7 +8,7 @@ import torch
 
 
 def test_chunks():
-    for i in range(100_000):
+    for i in range(100):
         tensors = []
         for i in range(random.randint(1, 5)):
             ndim = random.randint(0, 4)

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -1,0 +1,63 @@
+import asyncio
+import random
+
+import pytest
+import hivemind
+from hivemind.client.averaging import RunningAllReduce, split_into_chunks, restore_from_chunks
+import torch
+
+
+def test_chunks():
+    for i in range(100_000):
+        tensors = []
+        for i in range(random.randint(1, 5)):
+            ndim = random.randint(0, 4)
+            shape = torch.Size([random.randint(0, 16) for _ in range(ndim)])
+            make_tensor = random.choice([torch.rand, torch.randn, torch.zeros, torch.ones])
+            tensors.append(make_tensor(shape))
+
+        total_size = sum(map(torch.Tensor.numel, tensors))
+        if total_size == 0:
+            continue
+        num_chunks = random.randint(1, min(1000, sum(x.numel() for x in tensors)))
+        chunks = split_into_chunks(tensors, group_size=num_chunks)
+        assert len(chunks) == num_chunks
+        shapes = [tensor.shape for tensor in tensors]
+        restored = restore_from_chunks(chunks, shapes)
+        assert len(restored) == len(tensors)
+        assert all(new.shape == old.shape for new, old in zip(restored, tensors))
+        assert all(torch.allclose(new, old) for new, old in zip(restored, tensors))
+
+
+@pytest.mark.asyncio
+async def test_allreduce_state():
+    allreduce_state = RunningAllReduce(my_endpoint='alice', group_endpoints={'alice', 'bob', 'carol'}, part_index=3)
+
+    x, y, z = torch.randn(3, 128)
+
+    results = await asyncio.gather(
+        allreduce_state.accumulate('alice', x),
+        allreduce_state.accumulate('bob', y),
+        allreduce_state.accumulate('carol', z),
+    )
+
+    with pytest.raises(AssertionError):
+        await allreduce_state.accumulate('carol', z),
+
+    with pytest.raises(AssertionError):
+        await allreduce_state.accumulate('mallory', z),
+
+    ref = (x + y + z) / 3
+    for tensor in results:
+        assert torch.allclose(tensor, ref)
+
+    allreduce_state = RunningAllReduce(my_endpoint='alice', group_endpoints={'alice'}, part_index=1337)
+    assert torch.allclose(x, await allreduce_state.accumulate('alice', x))
+
+    with pytest.raises(AssertionError):
+        allreduce_state = RunningAllReduce(my_endpoint='alice', group_endpoints={'bob', 'carol'}, part_index=1337)
+        assert torch.allclose(x, await allreduce_state.accumulate('alice', x))
+
+    with pytest.raises(AssertionError):
+        allreduce_state = RunningAllReduce(my_endpoint='alice', group_endpoints=set(), part_index=1337)
+        assert torch.allclose(x, await allreduce_state.accumulate('alice', x))


### PR DESCRIPTION
Based on #95 , discussion with @mryab 

__TL;DR__ This PR introduces two new objects, DecentralizedAverager and DecentralizedOptimizer, that allow participants to average their gating function (and whatnot) with other peers using a DHT.

__DecentralizedOptimizer__ works exactly like normal pytorch optimizer, but on .step() it will average your model with other peers according to the algorithm below. It runs DecentralizedAverager in background.

__DecentralizedAverager__ is a more low-level interface to averaging that does all the heavy lifting. It periodically finds forms groups with other nodes using DHT and performs allreduce. The algorithm for forming groups is designed so that the group size is small, but each participant converges to global average parameters after a small number of steps (see below, its tricky).



__Algorithm 1:__ DecentralizedAverager pseudocode
```python
def run_in_background(my_node: DHTNode, my_endpoint: Endpoint, num_buckets: int, group_size: int):
  my_bucket_index = randint(0, num_buckets)

  while True:
    store_ok = my_node.store(
        key='averaging.{my_bucket_index}', subkey=my_node.node_id, value=my_endpoint)
    if not store_ok:
      continue  # bad bucket configuration or DHT failure, throw a warning

    while True:
      bucket_nodes = dht_node.get("averaging.{my_bucket_index}")
      if my_node.id not in bucket_nodes:
        break  # expired too fast or DHT failure, throw a warning
      else if len(bucket_nodes) < group_size:
        continue  # wait for more nodes to join. 
      else:  # found at least group_size peers
        my_group = get_my_group(bucket_nodes)
        my_shard_index, active_peers = connect_to_peers(my_group)
        averaged_vector = allreduce(my_shard_index, active_peers)
        update_model(averaged_vector)

        # here's the tricky part. We know that my_shard_index is unique within group
        # AND we don't want to average with the same group again, SO we can just set
        my_bucket_index = my_shard_index   # ... to make sure we won't meet again
        break  # start over
```

__Subroutines:__
* __get_my_group(bucket_nodes: Sequence[Tuple[DHTID, Endpoint]]):__ repeatedly try to add peers in the same bucket starting from one's own node ID. If contacted by another node ID with earlier expiration time, yield priority to that node.
* __connect_to_peers(group: Sequence[Tuple[DHTID, Endpoint]]):__ establish connection with every peer, drop unresponsive peers, agree on (unique) shard ids within group.
* __allreduce(my_shard_index: int, active_peers: Sequence[Endpoint]):__ - butterfly-style allreduce, each node accumulates one part of the full vector according to its shard index, then distributes the result to all nodes.


__Notes:__
* we should adjust group size on the fly:
    * if there are less then group_size peers after K consecutive retries, halve the number of buckets (or give up and average regardless?)
    * If bucket size is larger than group_size * C, double the number of buckets
* shard indices must be shuffled within group to prevent potential harmful side-effects for repeated averaging (e.g. we shoult NOT order shards by ascending node id)
* make sure this won't result in huge-ass dictionaries with thousands of peers.
   * for instance, set up expiration time such that one node is simultaneously present in at most O(1) DHT entries
* if allreduce fails, we should form a new group and try again
* `my_bucket_index = my_shard_index` is a trick that is optimal if sqrt(total_trainers) <= group_size < total_trainers, but it may be suboptimal outside this range
    * if group_size equals total node size, we can average with the same group right away
    * if group size < sqrt(total_trainers), we need to avoid peers from previous T iterations. I'm unsure if we can generalize to that case (upd - it seems we can, see comments below).

* on the first round of averaging, buckets can be uneven due to random initial picks. However, after each allreduce run, the group will be uniformly distributed to other buckets. Hence, the distribution will eventually become uniform.