### PR TITLE
Add anomaly detection to RemoteMixtureOfExperts

### DIFF
--- a/hivemind/__init__.py
+++ b/hivemind/__init__.py
@@ -3,4 +3,4 @@ from hivemind.dht import *
 from hivemind.server import *
 from hivemind.utils import *
 
-__version__ = '0.8.18'
+__version__ = '0.8.19'

--- a/hivemind/client/moe.py
+++ b/hivemind/client/moe.py
@@ -168,7 +168,7 @@ class _RemoteCallMany(torch.autograd.Function):
 
         flat_inputs_cpu = []
         for tensor in flat_inputs:
-            if not tensor.isfinite().all():
+            if detect_anomalies and not tensor.isfinite().all():
                 raise ValueError("One of inputs has nan/inf values")
             flat_inputs_cpu.append(tensor.cpu())
 
@@ -224,7 +224,7 @@ class _RemoteCallMany(torch.autograd.Function):
 
         flat_grad_outputs_cpu = []
         for tensor in flat_grad_outputs:
-            if not tensor.isfinite().all():
+            if detect_anomalies and not tensor.isfinite().all():
                 raise ValueError("One of gradients has nan/inf values")
             flat_grad_outputs_cpu.append(tensor.cpu())
 

--- a/hivemind/client/moe.py
+++ b/hivemind/client/moe.py
@@ -69,9 +69,6 @@ class RemoteMixtureOfExperts(nn.Module):
         :param kwargs: extra keyword parameters that will be passed to each expert, batch-first
         :returns: averaged predictions of all experts that delivered result on time, nested structure of batch-first
         """
-        if self.detect_anomalies and not input.isfinite().all():
-            raise ValueError("Input tensor has nan/inf values")
-
         if input.ndim != 2:
             input_for_gating = input.mean(dim=tuple(range(1, input.ndim - 1)))
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
-torch>=1.3.0
+torch>=1.6.0
 numpy>=1.17
 prefetch_generator>=1.0.1
 msgpack>=0.5.6

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -193,10 +193,7 @@ def test_client_anomaly_detection():
     server = hivemind.Server(dht, experts, num_connection_handlers=1)
     server.start()
     try:
-        # dht_listen_on = hivemind.replace_port(server.dht.listen_on, server.dht.port)
         server.ready.wait()
-
-        # dht = hivemind.DHT(start=True, expiration=999, initial_peers=[dht_listen_on])
 
         dmoe = hivemind.RemoteMixtureOfExperts(in_features=16, grid_size=(3,), dht=dht, k_best=3, uid_prefix='expert.')
 

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -195,7 +195,8 @@ def test_client_anomaly_detection():
     try:
         server.ready.wait()
 
-        dmoe = hivemind.RemoteMixtureOfExperts(in_features=16, grid_size=(3,), dht=dht, k_best=3, uid_prefix='expert.')
+        dmoe = hivemind.RemoteMixtureOfExperts(in_features=16, grid_size=(3,), dht=dht, k_best=3, uid_prefix='expert.',
+                                               detect_anomalies=True)
 
         input = torch.randn(1, 16)
         input[0, 0] = float('nan')
@@ -210,7 +211,8 @@ def test_client_anomaly_detection():
         with pytest.raises(ValueError):
             inf_loss.backward()
 
-        dmoe = hivemind.RemoteMixtureOfExperts(in_features=16, grid_size=(4,), dht=dht, k_best=4, uid_prefix='expert.')
+        dmoe = hivemind.RemoteMixtureOfExperts(in_features=16, grid_size=(4,), dht=dht, k_best=4, uid_prefix='expert.',
+                                               detect_anomalies=True)
         output = dmoe(input)
         assert output.isfinite().all()
 

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -32,6 +32,7 @@ def test_call_many():
     backward_k_min = 1
     forward_timeout = None
     backward_timeout = None
+    detect_anomalies = False
     atol = 1e-5
 
     with background_server(num_experts=5, device='cpu', expert_cls='ffn', num_handlers=8, hidden_dim=64,
@@ -42,8 +43,8 @@ def test_call_many():
         e5 = hivemind.RemoteExpert(f'thisshouldnotexist', '127.0.0.1:80')
 
         mask, expert_outputs = hivemind.client.moe._RemoteCallMany.apply(
-            DUMMY, [[e0, e1, e2], [e2, e4], [e1, e5, e3], []],
-            k_min, backward_k_min, timeout_after_k_min, forward_timeout, backward_timeout, e1.info, inputs
+            DUMMY, [[e0, e1, e2], [e2, e4], [e1, e5, e3], []], k_min, backward_k_min, timeout_after_k_min,
+            forward_timeout, backward_timeout, detect_anomalies, e1.info, inputs
         )
         assert mask.shape == (4, 3)
         assert expert_outputs.shape == (4, 3, 64)


### PR DESCRIPTION
This PR implements client-side anomaly detection in RemoteMixtureOfExperts: to prevent network contamination, any forward/backward pass will raise an error if passed a tensor with NaN/inf values. To prevent spreading errors from "broken" experts, we also ignore their outputs when collecting the forward/backward results of a mixture