### PR TITLE
Add Averager load balancing and public endpoints

### DIFF
--- a/hivemind/__init__.py
+++ b/hivemind/__init__.py
@@ -3,4 +3,4 @@ from hivemind.dht import *
 from hivemind.server import *
 from hivemind.utils import *
 
-__version__ = '0.8.25'
+__version__ = '0.8.26'

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -177,7 +177,7 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
           (this operation is known as all-gather). The gathered data will be available as the output of this function.
         :param timeout: if averager was unable to *find* a group in this many seconds, consider allreduce failedK
         :param wait: if True (default), return when finished. Otherwise return MPFuture and run in background.
-        :returns: on success, update averaged_tensors  and return gathered messages, on failure, return None
+        :returns: on success, update averaged_tensors and return group info; on failure, return None
         """
         future, _future = MPFuture.make_pair()
         self.pipe.send(('_step', [], dict(future=_future, gather=gather, allow_retries=allow_retries, timeout=timeout)))

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -15,7 +15,7 @@ import torch
 import numpy as np
 
 import hivemind
-from hivemind.client.averaging.allreduce import AllReduceRunner, AllreduceException, GroupID, DataForGather
+from hivemind.client.averaging.allreduce import AllReduceRunner, AllreduceException, GroupID
 from hivemind.client.averaging.matchmaking import Matchmaking
 from hivemind.proto import averaging_pb2, averaging_pb2_grpc, runtime_pb2
 from hivemind.utils import get_logger, Endpoint, Port, MPFuture, GRPC_KEEPALIVE_OPTIONS, get_dht_time

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -242,7 +242,6 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
             assert len(local_tensors) == len(self._averaged_tensors)
             for tensor, update in zip(local_tensors, averaging_deltas):
                 tensor.add_(update, alpha=self._averaging_alpha)
-            return True
 
     @contextlib.contextmanager
     def get_tensors(self) -> Sequence[torch.Tensor]:

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -114,8 +114,9 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
 
     @property
     def endpoint(self) -> Endpoint:
+        assert self.port is not None, "Averager is not running yet"
         if self._averager_endpoint is None:
-            self._averager_endpoint = replace_port(self.listen_on, self.port if self.port is not None else '*')
+            self._averager_endpoint = f"{self.dht.get_visible_address()}:{self.port}"
             logger.debug(f"Assuming averager endpoint to be {self._averager_endpoint}")
         return self._averager_endpoint
 

--- a/hivemind/client/averaging/allreduce.py
+++ b/hivemind/client/averaging/allreduce.py
@@ -215,12 +215,10 @@ class AllReduceRunner(AllReduceProtocol, averaging_pb2_grpc.DecentralizedAveragi
             yield averaging_pb2.AveragingData(code=averaging_pb2.INTERNAL_ERROR)
 
 
-def split_into_parts(tensors: Sequence[torch.Tensor], group_size: int) -> Tuple[torch.Tensor, ...]:
+def split_into_parts(tensors: Sequence[torch.Tensor], part_sizes: Tuple[int]) -> Tuple[torch.Tensor, ...]:
     """ combines averaged_tensors into one tensor and splits them into equal chunks of size group_size """
     flat_tensor = torch.cat(tuple(map(torch.Tensor.flatten, tensors)))
-    chunk_slices = torch.linspace(start=0, end=len(flat_tensor), steps=group_size + 1, dtype=torch.int64)
-    chunk_slices[-1] = len(flat_tensor)
-    return tuple(flat_tensor[chunk_slices[i]: chunk_slices[i + 1]] for i in range(group_size))
+    return torch.split_with_sizes(flat_tensor, part_sizes, dim=0)
 
 
 def restore_from_parts(chunks: Sequence[torch.Tensor], shapes: Sequence[torch.Size]) -> Tuple[torch.Tensor, ...]:

--- a/hivemind/client/averaging/allreduce.py
+++ b/hivemind/client/averaging/allreduce.py
@@ -28,7 +28,8 @@ class AllReduceProtocol:
     def __init__(self, *, group_id: GroupID, tensors: Sequence[torch.Tensor], endpoint: Endpoint,
                  ordered_group_endpoints: Sequence[Endpoint], part_sizes: Sequence[int], return_deltas: bool = False):
         assert endpoint in ordered_group_endpoints, "endpoint is not a part of the group"
-        self.group_id, self.endpoint, self.ordered_group_endpoints = group_id, endpoint, ordered_group_endpoints
+        self.group_id, self.endpoint = group_id, endpoint
+        self.ordered_group_endpoints, self.part_sizes = ordered_group_endpoints, part_sizes
         self.local_tensor_parts = dict(zip(ordered_group_endpoints, split_into_parts(tensors, part_sizes)))
         self.tensor_shapes = tuple(tensor.shape for tensor in tensors)
         self.return_deltas = return_deltas

--- a/hivemind/client/averaging/allreduce.py
+++ b/hivemind/client/averaging/allreduce.py
@@ -1,15 +1,16 @@
 import asyncio
-from typing import Sequence, Set, Dict, Tuple, Iterable, AsyncIterator, Iterator
+from typing import Sequence, Set, Dict, Tuple, Iterable, AsyncIterator, TypeVar
 
 import grpc
 import torch
 
-from hivemind.utils import Endpoint, get_logger, ChannelCache, anext
+from hivemind.utils import Endpoint, get_logger, ChannelCache, anext, MSGPackSerializer
 from hivemind.utils import serialize_torch_tensor, deserialize_torch_tensor, split_for_streaming, combine_from_streaming
 from hivemind.proto import averaging_pb2_grpc, runtime_pb2, averaging_pb2
 
 # flavour types
 GroupID = bytes
+DataForGather = TypeVar("DataForGather")
 logger = get_logger(__name__)
 
 
@@ -118,6 +119,7 @@ class AllReduceRunner(AllReduceProtocol, averaging_pb2_grpc.DecentralizedAveragi
     """
     A class that implements ButterflyAllReduceProtocol on top of a gRPC servicer
     """
+    serializer = MSGPackSerializer  # used to pack/unpack metadata for all-gather
 
     def __init__(self, *, group_id: GroupID, tensors: Sequence[torch.Tensor], endpoint: Endpoint,
                  ordered_group_endpoints: Sequence[Endpoint], compression_type: runtime_pb2.CompressionType,
@@ -126,18 +128,20 @@ class AllReduceRunner(AllReduceProtocol, averaging_pb2_grpc.DecentralizedAveragi
                          ordered_group_endpoints=ordered_group_endpoints, return_deltas=return_deltas)
         self.compression_type, self.chunk_size_bytes = compression_type, chunk_size_bytes
         self.averaged_part_stream: asyncio.Future[Tuple[runtime_pb2.Tensor, ...]] = asyncio.Future()
+        self.gathered: Dict[Endpoint, DataForGather] = {}
 
     def _get_peer_stub(self, peer: Endpoint) -> averaging_pb2_grpc.DecentralizedAveragingStub:
         return ChannelCache.get_stub(peer, averaging_pb2_grpc.DecentralizedAveragingStub, aio=True)
 
-    async def _average_one_part(self, peer_endpoint: Endpoint, local_part: torch.Tensor) -> torch.Tensor:
-        """ Send one part of local tensors to one groupmate and collect the average for this part """
+    async def _butterfly(self, peer_endpoint: Endpoint, local_part: torch.Tensor, gather: bytes) -> torch.Tensor:
+        """ Send a part of local tensors and metadata to a single peer, receive the average for that part of tensors """
         serialized_tensor_part = serialize_torch_tensor(local_part, self.compression_type, allow_inplace=False)
         chunks = split_for_streaming(serialized_tensor_part, self.chunk_size_bytes)
 
         stream = self._get_peer_stub(peer_endpoint).rpc_aggregate_part()
-        await stream.write(averaging_pb2.AveragingData(code=averaging_pb2.PART_FOR_AVERAGING, group_id=self.group_id,
-                                                       endpoint=self.endpoint, tensor_part=next(chunks)))
+        await stream.write(averaging_pb2.AveragingData(
+            code=averaging_pb2.PART_FOR_AVERAGING, group_id=self.group_id, endpoint=self.endpoint,
+            tensor_part=next(chunks), gather=gather))
         for chunk in chunks:
             await stream.write(averaging_pb2.AveragingData(tensor_part=chunk))
         await stream.done_writing()
@@ -158,12 +162,16 @@ class AllReduceRunner(AllReduceProtocol, averaging_pb2_grpc.DecentralizedAveragi
         await stream.write(averaging_pb2.AveragingData(group_id=self.group_id, endpoint=self.endpoint, code=code))
         await stream.done_writing()
 
-    async def run(self) -> Sequence[torch.Tensor]:
+    async def run(self, gather: DataForGather = None) -> Sequence[torch.Tensor]:
         """
         send allreduce requests to all peers and collect results, return the averaged tensor (or deltas)
+
+        :param gather: optionally perform all-gather with this (serializable) message
         """
         try:
-            await asyncio.gather(self, *(self._average_one_part(peer, part)
+            self.gathered[self.endpoint] = gather
+            binary_data_for_gather = self.serializer.dumps(gather)
+            await asyncio.gather(self, *(self._butterfly(peer, part, binary_data_for_gather)
                                          for peer, part in self.local_tensor_parts.items() if peer != self.endpoint))
             return await self
         except BaseException as e:
@@ -200,9 +208,11 @@ class AllReduceRunner(AllReduceProtocol, averaging_pb2_grpc.DecentralizedAveragi
             try:
                 tensor_chunks = (request.tensor_part, *[msg.tensor_part async for msg in stream])
                 averaged_chunks = iter(await self.accumulate_part_streaming(request.endpoint, tensor_chunks))
+                self.gathered[request.endpoint] = self.serializer.loads(request.gather)
                 yield averaging_pb2.AveragingData(code=averaging_pb2.AVERAGED_PART, tensor_part=next(averaged_chunks))
                 for averaged_chunk in averaged_chunks:
                     yield averaging_pb2.AveragingData(tensor_part=averaged_chunk)
+
             except Exception as e:
                 self.set_exception(e)
                 yield averaging_pb2.AveragingData(code=averaging_pb2.INTERNAL_ERROR)

--- a/hivemind/client/averaging/load_balancing.py
+++ b/hivemind/client/averaging/load_balancing.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Optional
+from typing import Sequence, Optional, Tuple
 import numpy as np
 import scipy.optimize
 
@@ -7,7 +7,7 @@ from hivemind.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-def load_balance_peers(vector_size, throughputs: Sequence[Optional[float]], min_size: int = 0) -> Sequence[int]:
+def load_balance_peers(vector_size, throughputs: Sequence[Optional[float]], min_size: int = 0) -> Tuple[int, ...]:
     """
     Find an optimal partitioning of weights for butterfly all-reduce given peer throughputs.
     :param vector_size: total size of the averaged vector (in elements, not bytes)
@@ -24,7 +24,7 @@ def load_balance_peers(vector_size, throughputs: Sequence[Optional[float]], min_
     else:
         fractions = np.asarray([1.0 if throughput is None else 0.0 for throughput in throughputs])
 
-    return hagenbach_bishoff(vector_size, fractions)
+    return tuple(hagenbach_bishoff(vector_size, fractions))
 
 
 def optimize_parts_lp(vector_size: int, throughputs: np.ndarray, min_size: int = 0, eps: float = 1e-15) -> np.ndarray:

--- a/hivemind/client/averaging/load_balancing.py
+++ b/hivemind/client/averaging/load_balancing.py
@@ -22,6 +22,7 @@ def load_balance_peers(vector_size, throughputs: Sequence[Optional[float]], min_
         throughputs = [throughput if throughput is not None else default_throughput for throughput in throughputs]
         fractions = optimize_parts_lp(vector_size, np.asarray(throughputs), min_size)
     else:
+        assert not all(throughput == 0 for throughput in throughputs), "Must have at least one nonzero throughput"
         fractions = np.asarray([1.0 if throughput is None else 0.0 for throughput in throughputs])
 
     return tuple(hagenbach_bishoff(vector_size, fractions))

--- a/hivemind/client/averaging/load_balancing.py
+++ b/hivemind/client/averaging/load_balancing.py
@@ -1,0 +1,65 @@
+def load_balance_peers(vector_size: int, throughputs: np.ndarray, min_size: int = 0) -> np.ndarray:
+    """
+    Find an optimal partitioning of weights for butterfly all-reduce given peer throughputs.
+
+    This method solves an optimization problem to minimize the total allreduce time.
+    In butterfly all-reduce, each peer acts both as a "client" and as an "aggregator":
+    * a "client" splits his local vector into shards and sends each shard to one peer, then downloads the average
+    * an "aggregator" receives a certain part of vector components from all peers, aggregates and returns the average
+
+    Peer i network load as a "client" = vector_size * (1 - fraction_assigned_to_peer_i)
+    Peer i network load as an "aggregator" = vector_size * (group_size - 1) * fraction_assigned_to_peer_i
+    Peer i total communication = vector_size * [1 + (group_size - 2) * fraction_assigned_to_peer_i]
+    Total time = max_i (total_communication_for_peer_i / throughputs[i])
+
+    We find optimal vector fractions by minimizing the total time (using https://tinyurl.com/minimax-to-lp )
+    Then, we use Hagenbach-Bishoff apportionment to split the finite vector based on the optimal fractions.
+
+    :param vector_size: total size of the averaged vector (in elements, not bytes)
+    :param throughputs: 1d array of throughputs for each peer, typically min(upload speed, download speed)
+    :param min_size: peers that can aggregate less than this many elements will be assigned nothing
+    :returns: an integer array where i-th element is the number of weights assigned to i-th peer
+    """
+    assert np.min(throughputs) > 0
+    group_size = len(throughputs)
+    num_variables = group_size + 1  # [w_1, ..., w_N, ksi]
+
+    c = np.zeros(num_variables)
+    c[-1] = 1.0  # optimize w.r.t. ksi
+
+    # the constraints below are tuples (A, b) such that Ax <= b
+    nonnegative_weights = -np.eye(group_size, M=num_variables), np.zeros(group_size)
+    weights_sum_to_one = c[None, :] - 1.0, np.array([-1.0])
+    coeff_per_variable = (group_size - 1.0) / throughputs
+    coeff_matrix_minus_ksi = np.hstack([np.diag(coeff_per_variable), -np.ones((group_size, 1))])
+    ksi_is_maximum = coeff_matrix_minus_ksi, -1.0 / throughputs
+
+    A, b = list(map(np.concatenate, zip(nonnegative_weights, weights_sum_to_one, ksi_is_maximum)))
+
+    solution = scipy.optimize.linprog(c, A_ub=A, b_ub=b)
+    if solution.success:
+        peer_fractions = solution.x[:group_size]
+        peer_fractions[peer_fractions < min_size / float(vector_size)] = 0.0
+        return peer_fractions
+    else:
+        logger.error(f"Failed to solve load-balancing for bandwidths {throughputs}.")
+        peer_fractions = np.ones(group_size) / group_size
+    return hagenbach_bishoff(vector_size, peer_fractions)
+
+def hagenbach_bishoff(vector_size: int, scores: Sequence[float]) -> Sequence[int]:
+    """
+    Split a vector between participants based on continuous fractions.
+    https://en.wikipedia.org/wiki/Hagenbach-Bischoff_system
+
+    :param vector_size: the total number of elements to be split
+    :param scores: real-valued vector fractions for each peer
+    :returns: integer-valued partitions assigned to every peer
+    """
+    total_score = sum(scores)
+    allocated = [int(vector_size * score_i / total_score) for score_i in scores]
+    while sum(allocated) < vector_size:
+        print('.')
+        quotients = [score / (allocated[idx] + 1) for idx, score in enumerate(scores)]
+        idx_max = quotients.index(max(quotients))
+        allocated[idx_max] += 1
+    return allocated

--- a/hivemind/client/averaging/load_balancing.py
+++ b/hivemind/client/averaging/load_balancing.py
@@ -1,5 +1,11 @@
+from typing import Sequence
 import numpy as np
 import scipy.optimize
+
+from hivemind.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
 
 def load_balance_peers(vector_size: int, throughputs: np.ndarray, min_size: int = 0) -> np.ndarray:
     """

--- a/hivemind/client/averaging/load_balancing.py
+++ b/hivemind/client/averaging/load_balancing.py
@@ -1,3 +1,6 @@
+import numpy as np
+import scipy.optimize
+
 def load_balance_peers(vector_size: int, throughputs: np.ndarray, min_size: int = 0) -> np.ndarray:
     """
     Find an optimal partitioning of weights for butterfly all-reduce given peer throughputs.

--- a/hivemind/client/averaging/matchmaking.py
+++ b/hivemind/client/averaging/matchmaking.py
@@ -478,5 +478,3 @@ def compute_schema_hash(tensors: Sequence[torch.Tensor]) -> bytes:
                      for field_name, field_value in asdict(TensorDescriptor.from_tensor(tensor)).items()}
                     for tensor in tensors]
     return DHTID.generate(source=MSGPackSerializer.dumps(schema_dicts)).to_bytes()
-
-

--- a/hivemind/client/averaging/matchmaking.py
+++ b/hivemind/client/averaging/matchmaking.py
@@ -6,21 +6,20 @@ import contextlib
 import random
 from dataclasses import asdict
 from math import isfinite
-from typing import Sequence, Optional, AsyncIterator, Set, Tuple, Dict, TypeVar
+from typing import Sequence, Optional, AsyncIterator, Set, Tuple, Dict
 import asyncio
 
 import grpc
 import torch
 
 import hivemind
-from hivemind.client.averaging.allreduce import AllReduceRunner, GroupID
+from hivemind.client.averaging.allreduce import AllReduceRunner
 from hivemind.client.averaging.load_balancing import load_balance_peers
 from hivemind.dht import DHTID, DHTExpiration, get_dht_time, GroupKey
 from hivemind.utils import get_logger, Endpoint, TensorDescriptor, MSGPackSerializer, TimedStorage
 from hivemind.proto import averaging_pb2, averaging_pb2_grpc
 from hivemind.utils.grpc import ChannelCache
 
-DataForGather = TypeVar('DataForGather')
 logger = get_logger(__name__)
 
 
@@ -35,7 +34,6 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
       This deadlock only happens if averagers have outdated information on expirations (due to network delays). 
       While A->B->A deadlock is easy to fix, it gets much harder with more peers (e.g. A -> B -> C -> D -> A).
       Hence, instead of accounting for such deadlocks, we simply break them with request_timeout.
-    
     """
 
     def __init__(self, endpoint: Endpoint, averaged_tensors: Sequence[torch.Tensor], dht: hivemind.dht.DHT, *,
@@ -64,8 +62,9 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
         self.assembled_group = asyncio.Future()
 
         self.current_leader: Optional[Endpoint] = None  # iff i am a follower, this is a link to my current leader
-        self.current_followers: Dict[Endpoint, float] = {}  # iff i am a leader, this contains followers excluding self
+        self.current_followers: Dict[Endpoint, averaging_pb2.JoinRequest] = {}  # my current followers excluding myself
         self.potential_leaders = PotentialLeaders(endpoint, dht, averaging_expiration, target_group_size)
+        self.data_for_gather: bytes = None
 
     @property
     def is_looking_for_group(self):
@@ -86,8 +85,10 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
         return f"{self.__class__.__name__}(endpoint={self.endpoint}, schema={schema_hash_repr}, {lfg_status}" \
                f" current key = {self.current_group_key})"
 
-    async def look_for_group(self, *, timeout: Optional[float] = None) -> Optional[AllReduceRunner]:
+    async def look_for_group(self, *, data_for_gather: bytes = b'', timeout: Optional[float] = None
+                             ) -> Optional[AllReduceRunner]:
         """
+        :param gather: optionally send this data to all peers in the next group and gather it from every groupmate
         :param timeout: maximum time that may be spent looking for group (does not include allreduce itself)
         :returns: an assembled group if successful, None if failed; does NOT perform the actual averaging
         Iterate over the averagers from a given group_identifier that have higher leadership priority than yourself.
@@ -96,6 +97,7 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
             logger.info("Another look_for_group is already in progress. The current run will be scheduled after"
                         " the existing group is either assembled or disbanded.")
         async with self.lock_looking_for_group:
+            self.data_for_gather = data_for_gather
             request_leaders_task = asyncio.create_task(self._request_join_potential_leaders(timeout))
             try:
                 return await asyncio.wait_for(self.assembled_group, timeout=timeout)
@@ -121,6 +123,7 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
                 # note: the code above ensures that we send all followers away before creating new future
                 self.assembled_group = asyncio.Future()
                 self.was_accepted_to_group.clear()
+                self.data_for_gather = None
 
     async def _request_join_potential_leaders(self, timeout: Optional[float]) -> AllReduceRunner:
         """ Request leaders from queue until we find the first runner. This coroutine is meant to run in background. """
@@ -167,7 +170,8 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
                 leader_stub = ChannelCache.get_stub(leader, averaging_pb2_grpc.DecentralizedAveragingStub, aio=True)
                 call = leader_stub.rpc_join_group(averaging_pb2.JoinRequest(
                     endpoint=self.endpoint, schema_hash=self.schema_hash, expiration=expiration_time,
-                    throughput=self.throughput if self.throughput is not None else -1.0))
+                    throughput=self.throughput if self.throughput is not None else -1.0,
+                    gather=self.data_for_gather))
                 message = await asyncio.wait_for(call.read(), timeout=self.request_timeout)
 
                 if message.code == averaging_pb2.ACCEPTED:
@@ -223,7 +227,7 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
                     yield reason_to_reject
                     return
 
-                self.current_followers[request.endpoint] = request.throughput if request.throughput >= 0 else None
+                self.current_followers[request.endpoint] = request
                 yield averaging_pb2.MessageFromLeader(code=averaging_pb2.ACCEPTED)
 
                 if len(self.current_followers) + 1 >= self.target_group_size and not self.assembled_group.done():
@@ -256,9 +260,10 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
                     return
 
             allreduce_group = self.assembled_group.result()
-            yield averaging_pb2.MessageFromLeader(code=averaging_pb2.BEGIN_ALLREDUCE, group_id=allreduce_group.group_id,
-                                                  ordered_group_endpoints=allreduce_group.ordered_group_endpoints,
-                                                  part_sizes=allreduce_group.part_sizes)
+            yield averaging_pb2.MessageFromLeader(
+                code=averaging_pb2.BEGIN_ALLREDUCE, group_id=allreduce_group.group_id,
+                ordered_group_endpoints=allreduce_group.ordered_group_endpoints,
+                part_sizes=allreduce_group.part_sizes, gathered=allreduce_group.gathered)
 
         except Exception as e:
             logger.exception(e)
@@ -303,13 +308,22 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
         ordered_group_endpoints.append(self.endpoint)
         random.shuffle(ordered_group_endpoints)
 
-        throughputs = [self.current_followers.get(endpoint, self.throughput) for endpoint in ordered_group_endpoints]
+        throughputs, gathered = [], []
+        for endpoint in ordered_group_endpoints:
+            if endpoint == self.endpoint:
+                throughputs.append(self.throughput)
+                gathered.append(self.data_for_gather)
+            else:
+                follower_info = self.current_followers[endpoint]
+                throughputs.append(follower_info.throughput if follower_info.throughput >= 0 else None)
+                gathered.append(follower_info.gather if follower_info.gather else None)
+
         part_sizes = load_balance_peers(self.total_size, throughputs, self.min_vector_size)
 
         logger.debug(f"{self.endpoint} - leader started allreduce for {len(ordered_group_endpoints)} peers.")
         allreduce_group = AllReduceRunner(group_id=group_id, tensors=self.averaged_tensors, endpoint=self.endpoint,
-                                          ordered_group_endpoints=ordered_group_endpoints,
-                                          part_sizes=part_sizes, **self.allreduce_kwargs)
+                                          ordered_group_endpoints=ordered_group_endpoints, part_sizes=part_sizes,
+                                          gathered=gathered, **self.allreduce_kwargs)
         self.assembled_group.set_result(allreduce_group)
         return allreduce_group
 
@@ -321,12 +335,12 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
 
         group_id, ordered_group_endpoints, part_sizes = msg.group_id, msg.ordered_group_endpoints, msg.part_sizes
         assert self.endpoint in ordered_group_endpoints, "Leader sent us group_endpoints that does not contain us!"
-        assert len(ordered_group_endpoints) == len(part_sizes)
+        assert len(ordered_group_endpoints) == len(part_sizes) == len(msg.gathered)
 
         logger.debug(f"{self.endpoint} - follower started allreduce after being prompted by leader {leader}.")
         allreduce_group = AllReduceRunner(group_id=group_id, tensors=self.averaged_tensors, endpoint=self.endpoint,
                                           ordered_group_endpoints=tuple(ordered_group_endpoints),
-                                          part_sizes=tuple(part_sizes), **self.allreduce_kwargs)
+                                          part_sizes=tuple(part_sizes), gathered=msg.gathered, **self.allreduce_kwargs)
         self.assembled_group.set_result(allreduce_group)
         return allreduce_group
 

--- a/hivemind/client/averaging/matchmaking.py
+++ b/hivemind/client/averaging/matchmaking.py
@@ -84,6 +84,7 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
 
     async def look_for_group(self, *, timeout: Optional[float] = None) -> Optional[AllReduceRunner]:
         """
+        :param timeout: maximum time that may be spent looking for group (does not include allreduce itself)
         :returns: an assembled group if successful, None if failed; does NOT perform the actual averaging
         Iterate over the averagers from a given group_identifier that have higher leadership priority than yourself.
         """

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -33,6 +33,7 @@ message JoinRequest {
   string endpoint = 1;          // A follower accepts incoming allreduce requests at this address
   bytes schema_hash = 2;        // A hash that describes follower's tensors (shapes, num tensors, etc)
   double expiration = 3;        // Follower would like to **begin** all_reduce by this point in time
+  uint32 throughput = 4;        // Follower has this bandwidth for averaging (0 = no incoming requests, -1 = default)
 }
 
 message MessageFromLeader {

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -42,6 +42,7 @@ message MessageFromLeader {
   bytes group_id = 2;        // a unique identifier of this group, only valid until allreduce is finished/failed
   string suggested_leader = 3;  // if peer is already in a group, it'll provide us with an endpoint of its leader
   repeated string ordered_group_endpoints = 4;  // a sequence of peers, each responsible for one shard during averaging
+  repeated int32 part_sizes = 5;  // a sequence of tensor parts assigned to each peer, same order as endpoints
 }
 
 message AveragingData {

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -44,7 +44,8 @@ message MessageFromLeader {
 
 message AveragingData {
   MessageCode code = 1;     // in case of a protocol violation, this will be the error message
-  bytes group_id = 2;        // a unique group identifier, same as in MessageFromLeader
+  bytes group_id = 2;       // a unique group identifier, same as in MessageFromLeader
   string endpoint = 3;      // sender's rpc endpoint, used for coordination
-  Tensor tensor_part = 4;    // either peer's local tensor part (rpc input) or group average of this part (rpc output)
+  Tensor tensor_part = 4;   // either peer's local tensor part (rpc input) or group average of this part (rpc output)
+  bytes gather = 5;         // optional metadata that is gathered from all peers (e.g. batch size or current loss)
 }

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -33,7 +33,8 @@ message JoinRequest {
   string endpoint = 1;          // A follower accepts incoming allreduce requests at this address
   bytes schema_hash = 2;        // A hash that describes follower's tensors (shapes, num tensors, etc)
   double expiration = 3;        // Follower would like to **begin** all_reduce by this point in time
-  uint32 throughput = 4;        // Follower has this bandwidth for averaging (0 = no incoming requests, -1 = default)
+  bytes gather = 4;             // optional metadata that is gathered from all peers (e.g. batch size or current loss)
+  float throughput = 5;         // Follower has this bandwidth for averaging (0 = default, negative = client only)
 }
 
 message MessageFromLeader {
@@ -48,5 +49,4 @@ message AveragingData {
   bytes group_id = 2;       // a unique group identifier, same as in MessageFromLeader
   string endpoint = 3;      // sender's rpc endpoint, used for coordination
   Tensor tensor_part = 4;   // either peer's local tensor part (rpc input) or group average of this part (rpc output)
-  bytes gather = 5;         // optional metadata that is gathered from all peers (e.g. batch size or current loss)
 }

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -43,6 +43,7 @@ message MessageFromLeader {
   string suggested_leader = 3;  // if peer is already in a group, it'll provide us with an endpoint of its leader
   repeated string ordered_group_endpoints = 4;  // a sequence of peers, each responsible for one shard during averaging
   repeated int32 part_sizes = 5;  // a sequence of tensor parts assigned to each peer, same order as endpoints
+  repeated bytes gathered = 6;  // metadata (gather) from all groupmates in the same order as their endoints
 }
 
 message AveragingData {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 PyYAML
 torch>=1.6.0
 numpy>=1.17
+scipy>=1.2.1
 prefetch_generator>=1.0.1
 msgpack>=0.5.6
 sortedcontainers

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -136,7 +136,7 @@ def test_load_balancing():
     for i in range(10):
         vector_size = np.random.randint(1, 1024 ** 3)
         num_peers = np.random.randint(1, 256)
-        scale = 1e-9 + np.random.rand() * 1000
+        scale = 1e-9 + np.random.rand() * 1e5
         throughputs = np.random.rand(num_peers) * scale + 1e-6
         min_size = np.random.choice([0, np.random.randint(0, vector_size // 10)])
         assignment = load_balance_peers(vector_size, throughputs, min_size)

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -2,10 +2,12 @@ import asyncio
 import random
 import time
 
+import numpy as np
 import torch
 import pytest
 import hivemind
 from hivemind.client.averaging.allreduce import AllReduceProtocol, split_into_parts, restore_from_parts
+from hivemind.client.averaging.load_balancing import load_balance_peers
 from hivemind.utils import Endpoint
 
 

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -156,7 +156,7 @@ def test_load_balancing():
                    for i in range(len(partitions)))
 
     def check_optimality(vector_size, throughputs, ref_partitions):
-        partitions = load_balance_peers(vector_size, throughputs).tolist()
+        partitions = load_balance_peers(vector_size, throughputs)
         assert get_cost(vector_size, partitions, throughputs) <= get_cost(vector_size, ref_partitions, throughputs)
 
     check_optimality(60, np.array([0.25, 0.25, 0.25, 0.25]), [15, 15, 15, 15])
@@ -165,10 +165,10 @@ def test_load_balancing():
     check_optimality(60, np.array([0.55, 0.44, 0.40]), [35, 16, 9])
     check_optimality(1024 * 1024, np.array([0.3, 0.5, 0.9, 0.6]), [0, 169327, 602629, 276620])
     check_optimality(1024 * 1024, np.array([0.0, 0.5, 0.0, 0.6]), [0, 428963, 0, 619613])
-    assert load_balance_peers(60, np.array([0.55, 0.44, 0.40]), min_size=10).tolist() == [41, 19, 0]
-    assert load_balance_peers(60, np.array([0.32, 0.55, 0.44]), min_size=10).tolist() == [0, 40, 20]
-    assert load_balance_peers(2, np.array([0.55, 0.20, 0.44]), min_size=10).tolist() == [1, 0, 1]
-    assert load_balance_peers(1, np.array([0.55, 0.20, 0.44]), min_size=10).tolist() == [1, 0, 0]
+    assert load_balance_peers(60, np.array([0.55, 0.44, 0.40]), min_size=10) == [41, 19, 0]
+    assert load_balance_peers(60, np.array([0.32, 0.55, 0.44]), min_size=10) == [0, 40, 20]
+    assert load_balance_peers(2, np.array([0.55, 0.20, 0.44]), min_size=10) == [1, 0, 1]
+    assert load_balance_peers(1, np.array([0.55, 0.20, 0.44]), min_size=10) == [1, 0, 0]
 
     for i in range(10):
         vector_size = np.random.randint(1, 1024 ** 3)

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -37,7 +37,7 @@ def test_getset_averagers():
 
 @pytest.mark.forked
 def test_allreduce_once():
-    dht = hivemind.DHT(start=True)
+    dht = hivemind.DHT(start=True, endpoint=f'{hivemind.LOCALHOST}:*')
 
     tensors1 = [torch.randn(123), torch.zeros(3)]
     tensors2 = [torch.rand(123), torch.ones(3)]
@@ -121,6 +121,7 @@ def test_partitioning():
         assert len(restored) == len(tensors)
         assert all(new.shape == old.shape for new, old in zip(restored, tensors))
         assert all(torch.allclose(new, old) for new, old in zip(restored, tensors))
+
 
 @pytest.mark.forked
 def test_load_balancing():

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -100,7 +100,8 @@ async def test_allreduce_protocol():
 
     group_id = random.getrandbits(160).to_bytes(length=20, byteorder='big')
     allreduce_protocols = [AllReduceProtocol(
-        group_id=group_id, endpoint=peer, tensors=tensors_by_peer[peer], ordered_group_endpoints=peers)
+        group_id=group_id, endpoint=peer, tensors=tensors_by_peer[peer],
+        ordered_group_endpoints=peers, part_sizes=(150, 200, 67))
         for peer in peers]
 
     async def _accumulate(sender: Endpoint, recipient: Endpoint):

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -176,6 +176,9 @@ def test_load_balancing():
     assert load_balance_peers(100, (None, None, None, None, None)) == (20, 20, 20, 20, 20)
     assert load_balance_peers(100, (0, 0, 0, None, None)) == (0, 0, 0, 50, 50)
 
+    with pytest.raises(AssertionError):
+        load_balance_peers(100, (0, 0, 0))
+
     for i in range(10):
         vector_size = np.random.randint(1, 1024 ** 3)
         num_peers = np.random.randint(1, 256)

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -172,6 +172,10 @@ def test_load_balancing():
     assert load_balance_peers(2, np.array([0.55, 0.20, 0.44]), min_size=10) == (1, 0, 1)
     assert load_balance_peers(1, np.array([0.55, 0.20, 0.44]), min_size=10) == (1, 0, 0)
 
+    assert load_balance_peers(100, (None, None)) == (50, 50)
+    assert load_balance_peers(100, (None, None, None, None, None)) == (20, 20, 20, 20, 20)
+    assert load_balance_peers(100, (0, 0, 0, None, None)) == (0, 0, 0, 50, 50)
+
     for i in range(10):
         vector_size = np.random.randint(1, 1024 ** 3)
         num_peers = np.random.randint(1, 256)


### PR DESCRIPTION
* averager can now specify available network throughput at init
  * this parameter is used to dynamically split the vector
* averagers can now gather a small metadata message from their groupmates (passed through the leader)