### PR TITLE
Load state from peers in DecentralizedAverager

### DIFF
--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -16,8 +16,6 @@ pip install .
 
 You can also install it in the editable mode with `pip install -e .`.
 
-__Note:__ we currently recommend installing hivemind from github (i.e. not pip) as it can run RemoteMixtureOfExperts faster by an order of magnitude. These changes will only reach PyPI in v0.9.0 release.
-
 * __Dependencies:__ Hivemind requires python 3.7+ (3.8 is recommended), it will install [requirements](https://github.com/learning-at-home/hivemind/blob/master/requirements.txt) automatically; 
 * __OS support:__ Linux and macOS should [just work](https://github.com/learning-at-home/hivemind/issues).
 We do not officially support Windows, but you are welcome to contribute your windows build :)

--- a/hivemind/__init__.py
+++ b/hivemind/__init__.py
@@ -3,4 +3,4 @@ from hivemind.dht import *
 from hivemind.server import *
 from hivemind.utils import *
 
-__version__ = '0.8.28'
+__version__ = '0.8.29'

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -290,7 +290,7 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
         chunk_size_bytes = self.matchmaking_kwargs.get('chunk_size_bytes', 2 ** 16)
 
         for tensor in self._averaged_tensors:
-            for part in split_for_streaming(serialize_torch_tensor(tensor), chunk_size_bytes)
+            for part in split_for_streaming(serialize_torch_tensor(tensor), chunk_size_bytes):
                 yield averaging_pb2.DownloadData(tensor_part=part)
 
     def try_load_parameters(self):

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -302,6 +302,7 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
         """
         Get the up-to-date trainer state from a peer.
         The state consists of two parts: (metadata, tensors)
+
          - metadata is a small pickle-serialized entry meant to store scalars and hyperparameters
          - tensors is a sequence of pytorch tensors that represent model parameters or optimizer statistics
         """

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -299,7 +299,12 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
 
     async def rpc_download_state(self, request: averaging_pb2.DownloadRequest, context: grpc.ServicerContext
                                  ) -> AsyncIterator[averaging_pb2.DownloadData]:
-        """ a newcomer requests us to send over our current trainer state for his initialization """
+        """
+        Get the up-to-date trainer state from a peer.
+        The state consists of two parts: (metadata, tensors)
+         - metadata is a small pickle-serialized entry meant to store scalars and hyperparameters
+         - tensors is a sequence of pytorch tensors that represent model parameters or optimizer statistics
+        """
         chunk_size_bytes = self.matchmaking_kwargs.get('chunk_size_bytes', DEFAULT_CHUNK_SIZE_BYTES)
         metadata, tensors = await self._get_current_state_from_host_process()
 

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -320,7 +320,7 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
         :returns: a tuple of (serializable_small_metadata, sequence of torch tensors)
         """
         with self.get_tensors() as tensors:
-            return dict(group_key=self.get_current_group_key()), tensors
+            return dict(group_key=self.get_group_bits()), tensors
 
     async def _get_current_state_from_host_process(self):
         """ Executed in the averager process inside rpc_download_state """

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -270,6 +270,7 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
         """
         with self.lock_averaged_tensors:
             yield self._averaged_tensors
+        self.last_updated = get_dht_time()
 
     async def rpc_join_group(self, request: averaging_pb2.JoinRequest, context: grpc.ServicerContext
                              ) -> AsyncIterator[averaging_pb2.MessageFromLeader]:
@@ -383,6 +384,7 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
                     if current_tensor_parts:
                         tensors.append(deserialize_torch_tensor(combine_from_streaming(current_tensor_parts)))
                     future.set_result((metadata, tensors))
+                    self.last_updated = get_dht_time()
                     break
                 except grpc.aio.AioRpcError as e:
                     logger.info(f"Failed to download state from {peer} - {e}")

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -130,7 +130,6 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
             self.run_in_background(await_ready=True)
             hivemind.run_in_background(self._background_thread_fetch_current_state_if_asked)
 
-
     @property
     def port(self) -> Optional[Port]:
         return self._port.value if self._port.value != 0 else None

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -34,7 +34,6 @@ logger = get_logger(__name__)
 
 class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragingServicer):
     """
-    **Warning!** Decentralized averager is in active development, some critical functionality is still underway
 
     Parameter averaging service. A trainer can run this service in background to periodically average his parameters
     with other trainers. The averaging pattern is chosen so that (1) you only need to average with a small

--- a/hivemind/client/averaging/key_manager.py
+++ b/hivemind/client/averaging/key_manager.py
@@ -37,7 +37,7 @@ class GroupKeyManager:
         self.target_group_size = target_group_size
         self.insufficient_size = insufficient_size or max(1, target_group_size // 2)
         self.excessive_size = excessive_size or target_group_size * 3
-        self.nbits_expiration, self.nbits_rewrite_grace_period = nbits_expiration, nbits_rewrite_grace_period
+        self.nbits_expiration, self.nbits_grace_period = nbits_expiration, nbits_rewrite_grace_period
         self.suggested_nbits: Optional[int] = None
 
     @property
@@ -140,6 +140,6 @@ class GroupKeyManager:
 
         root_data, _ = await self.dht.get(f"{self.prefix}.0b", latest=False, return_future=True) or ({}, None)
         if isinstance(root_data, dict) and root_data.get(
-                self.RESERVED_KEY_FOR_NBITS, (None, -float('inf'))) > get_dht_time() + self.nbits_rewrite_grace_period:
+                self.RESERVED_KEY_FOR_NBITS, (None, -float('inf')))[1] > get_dht_time() + self.nbits_grace_period:
             return
         await self.declare_nbits(f"{self.prefix}.0b", len(self.group_bits), get_dht_time() + self.nbits_expiration)

--- a/hivemind/client/averaging/key_manager.py
+++ b/hivemind/client/averaging/key_manager.py
@@ -109,7 +109,7 @@ class GroupKeyManager:
         generalized_index = rng.sample(range(self.target_group_size), allreduce_group.group_size)[index]
         nbits = int(np.ceil(np.log2(self.target_group_size)))
         new_bits = bin(generalized_index)[2:].rjust(nbits, '0')
-        self.group_bits = (self.group_bits + new_bits)[-len(self.group_bits):]
+        self.group_bits = (self.group_bits + new_bits)[-len(self.group_bits):] if self.group_bits else ''
         logger.debug(f"{self.endpoint} - updated group key to {self.group_bits}")
 
         if is_leader and self.insufficient_size < allreduce_group.group_size < self.excessive_size:
@@ -123,7 +123,7 @@ class GroupKeyManager:
     async def update_key_on_not_enough_peers(self):
         """ this function is triggered whenever averager fails to assemble group within timeout """
         new_nbits = self.suggested_nbits if self.suggested_nbits is not None else len(self.group_bits) - 1
-        prev_nbits, self.group_bits = self.group_bits, self.group_bits[-new_nbits:]
+        prev_nbits, self.group_bits = self.group_bits, self.group_bits[-new_nbits:] if new_nbits else ''
         if self.group_bits != prev_nbits:
             logger.warning(f'{self.endpoint} - switching to {len(self.group_bits)}-bit keys')
         self.suggested_nbits = None

--- a/hivemind/client/averaging/key_manager.py
+++ b/hivemind/client/averaging/key_manager.py
@@ -27,16 +27,17 @@ class GroupKeyManager:
 
     def __init__(self, dht: DHT, endpoint: Endpoint, prefix: str, initial_group_bits: Optional[str],
                  target_group_size: int, insufficient_size: Optional[int] = None, excessive_size: Optional[int] = None,
-                 nbits_expiration: float = 60):
+                 nbits_expiration: float = 60, nbits_rewrite_grace_period: float = 15):
         assert initial_group_bits is None or all(bit in '01' for bit in initial_group_bits)
         if initial_group_bits is None:
             search_result = dht.get(f"{prefix}.0b", latest=True)
-            initial_group_bits = self.get_suggested_nbits(search_result) or ''
+            initial_group_nbits = self.get_suggested_nbits(search_result) or 0
+            initial_group_bits = ''.join(random.choice('01') for _ in range(initial_group_nbits))
         self.dht, self.endpoint, self.prefix, self.group_bits = dht, endpoint, prefix, initial_group_bits
         self.target_group_size = target_group_size
         self.insufficient_size = insufficient_size or max(1, target_group_size // 2)
         self.excessive_size = excessive_size or target_group_size * 3
-        self.nbits_expiration = nbits_expiration
+        self.nbits_expiration, self.nbits_rewrite_grace_period = nbits_expiration, nbits_rewrite_grace_period
         self.suggested_nbits: Optional[int] = None
 
     @property
@@ -112,7 +113,7 @@ class GroupKeyManager:
         logger.debug(f"{self.endpoint} - updated group key to {self.group_bits}")
 
         if is_leader and self.insufficient_size < allreduce_group.group_size < self.excessive_size:
-            asyncio.create_task(self.notify_stragglers_on_success())
+            asyncio.create_task(self.notify_stragglers())
         if self.suggested_nbits is not None and self.suggested_nbits != len(self.group_bits):
             num_extra_bits = max(0, self.suggested_nbits - len(self.group_bits))
             self.group_bits = ''.join((random.choice('01') for _ in range(num_extra_bits))) + self.group_bits
@@ -127,7 +128,7 @@ class GroupKeyManager:
             logger.warning(f'{self.endpoint} - switching to {len(self.group_bits)}-bit keys')
         self.suggested_nbits = None
 
-    async def notify_stragglers_on_success(self):
+    async def notify_stragglers(self):
         """ Find averagers that have fewer nbits and redirect them to your current nbits """
         for nbits in reversed(range(1, len(self.group_bits) - 1)):
             preceding_key = f"{self.prefix}.0b{self.group_bits[-nbits:] if nbits else ''}"
@@ -137,6 +138,8 @@ class GroupKeyManager:
                 await self.declare_nbits(preceding_key, len(self.group_bits), get_dht_time() + self.nbits_expiration)
                 break
 
-        root_data = await self.dht.get(f"{self.prefix}.0b", latest=False, return_future=True)
-        if root_data is None or self.RESERVED_KEY_FOR_NBITS not in root_data.value:
-            await self.declare_nbits(f"{self.prefix}.0b", len(self.group_bits), get_dht_time() + self.nbits_expiration)
+        root_data, _ = await self.dht.get(f"{self.prefix}.0b", latest=False, return_future=True) or ({}, None)
+        if isinstance(root_data, dict) and root_data.get(
+                self.RESERVED_KEY_FOR_NBITS, (None, -float('inf'))) > get_dht_time() + self.nbits_rewrite_grace_period:
+            return
+        await self.declare_nbits(f"{self.prefix}.0b", len(self.group_bits), get_dht_time() + self.nbits_expiration)

--- a/hivemind/client/averaging/key_manager.py
+++ b/hivemind/client/averaging/key_manager.py
@@ -81,7 +81,8 @@ class GroupKeyManager:
         num_active_averagers = len([key for key, entry in result.value.items() if entry.value is True])
 
         suggested_nbits = self.get_suggested_nbits(result)
-        if suggested_nbits is not None and suggested_nbits != self.suggested_nbits:
+        if suggested_nbits is not None and suggested_nbits != len(self.group_bits) and \
+                suggested_nbits != self.suggested_nbits:
             self.suggested_nbits = suggested_nbits
             logger.warning(f"{self.endpoint} - another averager suggested {self.suggested_nbits}-bit keys")
         elif num_active_averagers >= self.excessive_size:

--- a/hivemind/dht/__init__.py
+++ b/hivemind/dht/__init__.py
@@ -48,6 +48,7 @@ def is_valid_prefix(maybe_prefix: str) -> bool:
     """ An uid prefix must contain a string expert type, followed by optional numeric indices and a trailing period """
     return bool(PREFIX_PATTERN.fullmatch(maybe_prefix))
 
+
 def split_uid(uid_or_prefix: Union[ExpertUID, ExpertPrefix]) -> Tuple[ExpertPrefix, Coordinate]:
     """ Separate an expert UID or prefix into a new ExpertPrefix and integer for the last coordinate """
     uid_or_prefix = uid_or_prefix.rstrip(UID_DELIMITER)

--- a/hivemind/dht/node.py
+++ b/hivemind/dht/node.py
@@ -75,7 +75,7 @@ class DHTNode:
     async def create(
             cls, node_id: Optional[DHTID] = None, initial_peers: List[Endpoint] = (),
             bucket_size: int = 20, num_replicas: int = 5, depth_modulo: int = 5, parallel_rpc: int = None,
-            wait_timeout: float = 5, refresh_timeout: Optional[float] = None, bootstrap_timeout: Optional[float] = None,
+            wait_timeout: float = 3, refresh_timeout: Optional[float] = None, bootstrap_timeout: Optional[float] = None,
             cache_locally: bool = True, cache_nearest: int = 1, cache_size=None, cache_refresh_before_expiry: float = 5,
             cache_on_store: bool = True, reuse_get_requests: bool = True, num_workers: int = 1, chunk_size: int = 16,
             blacklist_time: float = 5.0, backoff_rate: float = 2.0,

--- a/hivemind/dht/node.py
+++ b/hivemind/dht/node.py
@@ -155,7 +155,7 @@ class DHTNode:
                     straggler.cancel()
                 finished_pings |= finished_in_time
 
-            if not finished_pings:
+            if not finished_pings or all(ping.result() is None for ping in finished_pings):
                 logger.warning("DHTNode bootstrap failed: none of the initial_peers responded to a ping.")
 
             if strict:

--- a/hivemind/dht/protocol.py
+++ b/hivemind/dht/protocol.py
@@ -110,7 +110,8 @@ class DHTProtocol(dht_grpc.DHTServicer):
         if responded and validate:
             try:
                 if self.server is not None and not response.available:
-                    raise ValidationError(f"peer {peer} couldn't access this node at {response.sender_endpoint} .")
+                    raise ValidationError(f"Peer {peer} couldn't access this node at {response.sender_endpoint} . "
+                                          f"Make sure that this port is open for incoming requests.")
 
                 if response.dht_time != dht_pb2.PingResponse.dht_time.DESCRIPTOR.default_value:
                     if response.dht_time < time_requested - MAX_DHT_TIME_DISCREPANCY_SECONDS or \

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -59,5 +59,5 @@ message DownloadRequest {}
 
 message DownloadData {
   bytes metadata = 1;
-  Tensor tensor_part = 3;
+  Tensor tensor_part = 2;
 }

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -6,6 +6,7 @@ import "runtime.proto";
 service DecentralizedAveraging {
   rpc rpc_join_group(JoinRequest) returns (stream MessageFromLeader);  // assemble a group for allreduce
   rpc rpc_aggregate_part(stream AveragingData) returns (stream AveragingData);  // send local part => get average part
+  rpc rpc_download_state(DownloadRequest) returns (DownloadData);
 }
 
 enum MessageCode {
@@ -52,4 +53,12 @@ message AveragingData {
   bytes group_id = 2;       // a unique group identifier, same as in MessageFromLeader
   string endpoint = 3;      // sender's rpc endpoint, used for coordination
   Tensor tensor_part = 4;   // either peer's local tensor part (rpc input) or group average of this part (rpc output)
+}
+
+message DownloadRequest {}
+
+message DownloadData {
+  bytes metadata = 1;
+  bytes tensor_proto = 2;
+  Tensor tensor_part = 3;
 }

--- a/hivemind/proto/averaging.proto
+++ b/hivemind/proto/averaging.proto
@@ -6,7 +6,7 @@ import "runtime.proto";
 service DecentralizedAveraging {
   rpc rpc_join_group(JoinRequest) returns (stream MessageFromLeader);  // assemble a group for allreduce
   rpc rpc_aggregate_part(stream AveragingData) returns (stream AveragingData);  // send local part => get average part
-  rpc rpc_download_state(DownloadRequest) returns (DownloadData);
+  rpc rpc_download_state(DownloadRequest) returns (stream DownloadData);
 }
 
 enum MessageCode {
@@ -59,6 +59,5 @@ message DownloadRequest {}
 
 message DownloadData {
   bytes metadata = 1;
-  bytes tensor_proto = 2;
   Tensor tensor_part = 3;
 }

--- a/hivemind/utils/mpfuture.py
+++ b/hivemind/utils/mpfuture.py
@@ -161,4 +161,5 @@ class MPFuture(base.Future):
 
     def __del__(self):
         self._shutdown_trigger.set_result(True)
-        self.connection.close()
+        if hasattr(self, 'connection'):
+            self.connection.close()

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -279,7 +279,6 @@ def test_get_state():
             num_calls += 1
             return super_metadata, super_tensors
 
-
     dht_root = hivemind.DHT(start=True)
     initial_peers = [f'{hivemind.LOCALHOST}:{dht_root.port}']
     dht1 = hivemind.DHT(initial_peers=initial_peers, start=True)

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -264,7 +264,7 @@ def test_overcrowded():
 
 
 @pytest.mark.forked
-def test_get_state():
+def test_load_state_from_peers():
     num_calls = 0
     super_metadata = dict(x=123)
     super_tensors = (torch.randn(3), torch.randint(0, 5, (3,)))
@@ -312,3 +312,12 @@ def test_get_state():
     futures = [averager.step(wait=False) for averager in [averager1, averager2]]
     for future in futures:
         future.result()
+
+
+@pytest.mark.forked
+def test_getset_bits():
+    dht = hivemind.DHT(start=True, endpoint='127.0.0.1:*')
+    averager = hivemind.DecentralizedAverager([torch.randn(3)], dht=dht, start=True,
+                                              prefix='test_prefix', target_group_size=2)
+    averager.set_group_bits('00101011101010')
+    assert averager.get_group_bits() == '00101011101010'

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -285,13 +285,13 @@ def test_get_state():
     dht1 = hivemind.DHT(initial_peers=initial_peers, start=True)
     averager1 = TestAverager([torch.randn(3), torch.rand(5)],
                              dht=dht1, start=True,
-                             prefix='demo-run', target_group_size=8)
+                             prefix='demo-run', target_group_size=2)
 
     dht2 = hivemind.DHT(initial_peers=initial_peers, start=True)
     dht2.get('demo-run.all_averagers')
     averager2 = TestAverager([torch.randn(3), torch.rand(5)],
                              dht=dht2, start=True,
-                             prefix='demo-run', target_group_size=8)
+                             prefix='demo-run', target_group_size=2)
 
     assert num_calls == 0
     got_metadata, got_tensors = averager2.load_state_from_peers()
@@ -308,3 +308,8 @@ def test_get_state():
     assert num_calls == 2
     assert got_metadata == super_metadata
     assert all(map(torch.allclose, got_tensors, super_tensors))
+
+    # check that normal averaging still works
+    futures = [averager.step(wait=False) for averager in [averager1, averager2]]
+    for future in futures:
+        future.result()


### PR DESCRIPTION
* [x] implemented DecentralizedAverager.load_state_from_peers that attempts to load the training state from another averager
   * The donor averager is chosen in the order from latest successfully updated to earliest
   * The definition of state can be extended by the user (by inheriting from DecentralizedAverager)
* [x] calling `__del__` on a partially created MPFuture will no longer cause error (edge case from albert)
![image](https://user-images.githubusercontent.com/3491902/109388032-bb627c80-7915-11eb-8c31-27177db02538.png)

* [x] DecentralizedAverager now supports manually getting/setting current group bits (used as dht key)