### PR TITLE
copytree implementation for py37 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,26 @@
 version: 2.1
 
 jobs:
+  build-and-test-py37:
+    docker:
+      - image: circleci/python:3.7.10
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+      - run: pip install -r requirements.txt
+      - run: pip install -r requirements-dev.txt
+      - save_cache:
+          key: v1-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          paths:
+            - '~/.cache/pip'
+      - run:
+          command: pip install -e .
+          name: setup
+      - run:
+          command: pytest ./tests
+          name: tests
   build-and-test-py38:
     docker:
       - image: circleci/python:3.8.1

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ the [NeurIPS 2020 paper](https://arxiv.org/abs/2002.04013).
 
 ## Installation
 
-Before installing hivemind, make sure that your environment has Python 3.8+
+Before installing hivemind, make sure that your environment has Python 3.7+
 and [PyTorch](https://pytorch.org/get-started/locally/#start-locally) with a version at least as new as 1.6.0.
 
 To start using this library, you can either use the pip package manager or build it from source. Since currently the

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -16,7 +16,7 @@ pip install .
 
 You can also install it in the editable mode with `pip install -e .`.
 
-* __Dependencies:__ Hivemind requires Python 3.8+.
+* __Dependencies:__ Hivemind requires Python 3.7+.
   The [requirements](https://github.com/learning-at-home/hivemind/blob/master/requirements.txt) are installed
   automatically.
 * __OS support:__ Linux and macOS should just work. We do not officially support Windows, but you are welcome to

--- a/hivemind/__init__.py
+++ b/hivemind/__init__.py
@@ -3,4 +3,4 @@ from hivemind.dht import *
 from hivemind.server import *
 from hivemind.utils import *
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering',


### PR DESCRIPTION
Google Colab has python3.7 version.
In python3.7 shutil.copytree has no dirs_exist_ok flag (https://docs.python.org/3/library/shutil.html#shutil.copytree). Here is a python3.7 compatible implementation. Tests for this version are also added to CI.