### PR TITLE
Fix the remaining tests for py37

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,5 +65,6 @@ jobs:
 workflows:
   main:
     jobs:
+      - build-and-test-py37
       - build-and-test-py38
       - build-and-test-py39

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           command: pip install -e .
           name: setup
       - run:
-          command: pytest ./tests
+          command: pytest ./tests/test_training.py
           name: tests
   build-and-test-py38:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           command: pip install -e .
           name: setup
       - run:
-          command: pytest ./tests/test_training.py
+          command: pytest ./tests
           name: tests
   build-and-test-py38:
     docker:

--- a/hivemind/__init__.py
+++ b/hivemind/__init__.py
@@ -3,4 +3,4 @@ from hivemind.dht import *
 from hivemind.server import *
 from hivemind.utils import *
 
-__version__ = '0.9.3'
+__version__ = '0.9.4'

--- a/hivemind/__init__.py
+++ b/hivemind/__init__.py
@@ -3,4 +3,4 @@ from hivemind.dht import *
 from hivemind.server import *
 from hivemind.utils import *
 
-__version__ = '0.9.1'
+__version__ = '0.9.2'

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -432,8 +432,12 @@ def is_power_of_two(n):
     return (n != 0) and (n & (n - 1) == 0)
 
 
-def _background_thread_fetch_current_state(pipe: mp.connection.Connection, get_current_state_weakref):
-    """ Executed in the host process as a background thread. Fetches the averager state when asked by peers. """
+def _background_thread_fetch_current_state(pipe: mp.connection.Connection, get_current_state_ref: weakref.WeakMethod):
+    """
+    Executed in the host process as a background thread. Fetches the averager state when asked by peers.
+    :param pipe: DecentralizedAverager's control pipe (from host process side)
+    :param get_current_state_ref: a WeakMethod wrapped around DecentraliedAverager.get_current_state (instance-bound)
+    """
     while True:
         trigger, future = pipe.recv()
         if trigger == '_SHUTDOWN':
@@ -441,7 +445,7 @@ def _background_thread_fetch_current_state(pipe: mp.connection.Connection, get_c
 
         assert trigger == '_TRIGGER_GET_CURRENT_STATE'
         try:
-            get_current_state = get_current_state_weakref()
+            get_current_state = get_current_state_ref()
             if get_current_state is None:
                 break
             state_metadata, state_tensors = get_current_state()

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -125,9 +125,10 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
         self._port = mp.Value(ctypes.c_uint32, 0)  # assigned when averager starts, accessible via self.port
         self._averager_endpoint: Optional[Endpoint] = None
         self.ready = mp.Event()  # whether the averager process has started (and ready for incoming requests)
+        # note: we create a background thread weakref and with daemon=True to ensure garbage collection
         background_fetcher = threading.Thread(daemon=True, target=_background_thread_fetch_current_state,
                                               args=[self.pipe, weakref.WeakMethod(self.get_current_state)])
-        background_fetcher.start()  # note: this thread is daemon to avoid cyclic references
+        background_fetcher.start()
         if start:
             self.run_in_background(await_ready=True)
 

--- a/hivemind/client/averaging/matchmaking.py
+++ b/hivemind/client/averaging/matchmaking.py
@@ -7,6 +7,7 @@ import random
 from dataclasses import asdict
 from math import isfinite
 from typing import Sequence, Optional, AsyncIterator, Set, Tuple, Dict
+import concurrent.futures
 import asyncio
 
 import grpc
@@ -142,6 +143,8 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
                         elif len(self.current_followers) > 0:
                             await self.leader_disband_group()
                         continue
+                except (concurrent.futures.CancelledError, asyncio.CancelledError):
+                    break  # note: this is a compatibility layer for python3.7
                 except Exception as e:
                     if not self.assembled_group.done():
                         self.assembled_group.set_exception(e)
@@ -256,7 +259,8 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
                 code=averaging_pb2.BEGIN_ALLREDUCE, group_id=allreduce_group.group_id,
                 ordered_group_endpoints=allreduce_group.ordered_group_endpoints, part_sizes=allreduce_group.part_sizes,
                 gathered=allreduce_group.gathered, group_key_seed=allreduce_group.group_key_seed)
-
+        except (concurrent.futures.CancelledError, asyncio.CancelledError):
+            return  # note: this is a compatibility layer for python3.7
         except Exception as e:
             logger.exception(e)
             yield averaging_pb2.MessageFromLeader(code=averaging_pb2.INTERNAL_ERROR)
@@ -445,6 +449,8 @@ class PotentialLeaders:
                     {self.running.wait(), self.update_triggered.wait()}, return_when=asyncio.ALL_COMPLETED,
                     timeout=self.search_end_time - get_dht_time() if isfinite(self.search_end_time) else None)
                 self.update_triggered.clear()
+        except (concurrent.futures.CancelledError, asyncio.CancelledError):
+            return  # note: this is a compatibility layer for python3.7
         except Exception as e:
             logger.error(f"{self.endpoint} - caught {type(e)}: {e}")
             raise
@@ -463,7 +469,8 @@ class PotentialLeaders:
                     await asyncio.sleep(self.declared_expiration_time - get_dht_time())
                     if self.running.is_set() and len(self.leader_queue) == 0:
                         await key_manager.update_key_on_not_enough_peers()
-
+            except (concurrent.futures.CancelledError, asyncio.CancelledError):
+                pass  # note: this is a compatibility layer for python3.7
             except Exception as e:  # note: we catch exceptions here because otherwise they are never printed
                 logger.error(f"{self.endpoint} - caught {type(e)}: {e}")
             finally:

--- a/hivemind/utils/threading.py
+++ b/hivemind/utils/threading.py
@@ -12,7 +12,7 @@ def run_in_background(func: callable, *args, **kwargs) -> Future:
     """ run func(*args, **kwargs) in background and return Future for its outputs """
     global EXECUTOR_PID, GLOBAL_EXECUTOR
     if os.getpid() != EXECUTOR_PID:
-        GLOBAL_EXECUTOR = ThreadPoolExecutor(max_workers=os.environ.get("HIVEMIND_THREADS", float('inf')))
+        GLOBAL_EXECUTOR = ThreadPoolExecutor(max_workers=float(os.environ.get("HIVEMIND_THREADS", float('inf'))))
         EXECUTOR_PID = os.getpid()
     return GLOBAL_EXECUTOR.submit(func, *args, **kwargs)
 

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -70,6 +70,10 @@ def test_allreduce_once():
             for ref, our in zip(reference, averaged_tensors):
                 assert torch.allclose(ref, our, atol=1e-6)
 
+    for averager in averagers:
+        averager.shutdown()
+    dht.shutdown()
+
 
 def compute_mean_std(averagers, unbiased=True):
     results = []
@@ -108,6 +112,10 @@ def test_allreduce_grid():
         else:
             assert torch.allclose(stds, torch.zeros_like(stds), atol=1e-6, rtol=0)
 
+    for averager in averagers:
+        averager.shutdown()
+    dht.shutdown()
+
 
 @pytest.mark.forked
 def test_allgather():
@@ -132,6 +140,10 @@ def test_allgather():
 
         for endpoint in gathered:
             assert gathered[endpoint] == reference_metadata[endpoint]
+
+    for averager in averagers:
+        averager.shutdown()
+    dht.shutdown()
 
 
 @pytest.mark.forked
@@ -249,6 +261,10 @@ def test_too_few_peers():
     for future in step_futures:
         assert len(future.result()) == 2
 
+    for averager in averagers:
+        averager.shutdown()
+    dht.shutdown()
+
 
 @pytest.mark.forked
 def test_overcrowded():
@@ -257,10 +273,14 @@ def test_overcrowded():
         averaged_tensors=[torch.randn(3)], dht=dht, target_group_size=2,
         averaging_expiration=1, request_timeout=0.5,
         prefix='mygroup', initial_group_bits='', start=True)
-        for _ in range(16)]
+        for _ in range(32)]
     for t in range(5):
         step_futures = [averager.step(wait=False, timeout=5) for averager in averagers]
         assert sum(len(future.result() or []) == 2 for future in step_futures) >= len(averagers) - 1
+
+    for averager in averagers:
+        averager.shutdown()
+    dht.shutdown()
 
 
 @pytest.mark.forked

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -257,7 +257,7 @@ def test_overcrowded():
         averaged_tensors=[torch.randn(3)], dht=dht, target_group_size=2,
         averaging_expiration=1, request_timeout=0.5,
         prefix='mygroup', initial_group_bits='', start=True)
-        for _ in range(32)]
+        for _ in range(16)]
     for t in range(5):
         step_futures = [averager.step(wait=False, timeout=5) for averager in averagers]
         assert sum(len(future.result() or []) == 2 for future in step_futures) >= len(averagers) - 1

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -277,7 +277,7 @@ def test_load_state_from_peers():
             """
             nonlocal num_calls, super_metadata, super_tensors
             num_calls += 1
-            return super_metadata, super_tensors
+            return self.serializer.dumps(super_metadata), super_tensors
 
     dht_root = hivemind.DHT(start=True)
     initial_peers = [f'{hivemind.LOCALHOST}:{dht_root.port}']
@@ -307,11 +307,6 @@ def test_load_state_from_peers():
     assert num_calls == 2
     assert got_metadata == super_metadata
     assert all(map(torch.allclose, got_tensors, super_tensors))
-
-    # check that normal averaging still works
-    # futures = [averager.step(wait=False) for averager in [averager1, averager2]]
-    # for future in futures:
-    #     future.result()
 
 
 @pytest.mark.forked


### PR DESCRIPTION
* [x] DecentralizedAverager is now compatible with python37's acyncio exception
    * the problem was: grpc.aio with python37 raised concurrent.futures.CancelledError in some cases;
    * we relied on isinstance(asyncio.CancelledError, Exception) == False
    * but isinstance(concurrent.futures.CancelledError, Exception) == True
* [x] DecentralizedAverager now shuts down if dereferenced in the main process
    * [x] though it won't shutdown if dereferenced in forks for obvious reasons
* [x] HIVEMIND_THREADS now actually works
* [x] test_averaging now shuts down dht and averager instances to avoid leaking processes