### PR TITLE
Serialize DHTID source with msgpack

### DIFF
--- a/hivemind/client/averaging/matchmaking.py
+++ b/hivemind/client/averaging/matchmaking.py
@@ -487,7 +487,7 @@ def compute_schema_hash(tensors: Sequence[torch.Tensor]) -> bytes:
     schema_dicts = [{field_name: str(field_value)
                      for field_name, field_value in asdict(TensorDescriptor.from_tensor(tensor)).items()}
                     for tensor in tensors]
-    return DHTID.generate(source=MSGPackSerializer.dumps(schema_dicts)).to_bytes()
+    return DHTID.generate(source=schema_dicts).to_bytes()
 
 
 class MatchmakingException(Exception):

--- a/hivemind/dht/routing.py
+++ b/hivemind/dht/routing.py
@@ -8,7 +8,7 @@ import random
 from collections.abc import Iterable
 from itertools import chain
 from typing import Tuple, Optional, List, Dict, Set, Union, Any, Sequence
-from hivemind.utils import Endpoint, PickleSerializer, get_dht_time, DHTExpiration
+from hivemind.utils import Endpoint, MSGPackSerializer, get_dht_time, DHTExpiration
 
 DHTKey, Subkey, DHTValue, BinaryDHTID, BinaryDHTValue, = Any, Any, Any, bytes, bytes
 
@@ -255,7 +255,7 @@ class DHTID(int):
             by default, generates a random dhtid from :nbits: random bits
         """
         source = random.getrandbits(nbits).to_bytes(nbits, byteorder='big') if source is None else source
-        source = PickleSerializer.dumps(source) if not isinstance(source, bytes) else source
+        source = MSGPackSerializer.dumps(source) if not isinstance(source, bytes) else source
         raw_uid = cls.HASH_FUNC(source).digest()
         return cls(int(raw_uid.hex(), 16))
 

--- a/hivemind/utils/serializer.py
+++ b/hivemind/utils/serializer.py
@@ -1,5 +1,4 @@
 """ A unified interface for several common serialization methods """
-import pickle
 from io import BytesIO
 from typing import Dict, Any
 
@@ -18,28 +17,6 @@ class SerializerBase:
     @staticmethod
     def loads(buf: bytes) -> object:
         raise NotImplementedError()
-
-
-class PickleSerializer(SerializerBase):
-    @staticmethod
-    def dumps(obj: object) -> bytes:
-        return pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
-
-    @staticmethod
-    def loads(buf: bytes) -> object:
-        return pickle.loads(buf)
-
-
-class PytorchSerializer(SerializerBase):
-    @staticmethod
-    def dumps(obj: object) -> bytes:
-        s = BytesIO()
-        torch.save(obj, s, pickle_protocol=pickle.HIGHEST_PROTOCOL)
-        return s.getvalue()
-
-    @staticmethod
-    def loads(buf: bytes) -> object:
-        return torch.load(BytesIO(buf))
 
 
 class MSGPackSerializer(SerializerBase):

--- a/hivemind/utils/serializer.py
+++ b/hivemind/utils/serializer.py
@@ -43,6 +43,8 @@ class MSGPackSerializer(SerializerBase):
         if type_code is not None:
             return msgpack.ExtType(type_code, obj.packb())
         elif isinstance(obj, tuple):
+            # Tuples need to be handled separately to ensure that
+            # 1. tuple serialization works and 2. tuples serialized not as lists
             data = msgpack.packb(list(obj), strict_types=True, use_bin_type=True, default=cls._encode_ext_types)
             return msgpack.ExtType(cls._MsgpackExtTypeCodeTuple, data)
         return obj

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -5,7 +5,6 @@ from itertools import chain, zip_longest
 
 from hivemind import LOCALHOST
 from hivemind.dht.routing import RoutingTable, DHTID
-from hivemind.utils.serializer import MSGPackSerializer
 
 
 def test_ids_basic():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -5,7 +5,7 @@ from itertools import chain, zip_longest
 
 from hivemind import LOCALHOST
 from hivemind.dht.routing import RoutingTable, DHTID
-from hivemind.utils.serializer import PickleSerializer
+from hivemind.utils.serializer import MSGPackSerializer
 
 
 def test_ids_basic():
@@ -15,7 +15,6 @@ def test_ids_basic():
         assert DHTID.MIN <= id1 < DHTID.MAX and DHTID.MIN <= id2 <= DHTID.MAX
         assert DHTID.xor_distance(id1, id1) == DHTID.xor_distance(id2, id2) == 0
         assert DHTID.xor_distance(id1, id2) > 0 or (id1 == id2)
-        assert len(PickleSerializer.dumps(id1)) - len(PickleSerializer.dumps(int(id1))) < 40
         assert DHTID.from_bytes(bytes(id1)) == id1 and DHTID.from_bytes(id2.to_bytes()) == id2
 
 


### PR DESCRIPTION
Using msgpack to create bytes from DHT keys to avoid pickle compatibility issue.