### PR TITLE
attempt to combat faulty CircleCI builds with medium+ resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
   build-and-test-py37:
     docker:
       - image: circleci/python:3.7.10
+    resource_class: medium+
     steps:
       - checkout
       - restore_cache:
@@ -24,6 +25,7 @@ jobs:
   build-and-test-py38:
     docker:
       - image: circleci/python:3.8.1
+    resource_class: medium+
     steps:
       - checkout
       - restore_cache:
@@ -44,6 +46,7 @@ jobs:
   build-and-test-py39:
     docker:
       - image: circleci/python:3.9.1
+    resource_class: medium+
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Currently, 1 in ~5-10 circleci jobs fails when installing dependencies, presumably due to insufficient memory:
![image](https://user-images.githubusercontent.com/3491902/115215528-438e2280-a10c-11eb-8d33-82b71169e766.png)

Restarting these jobs fixes the issue, but wastes developer time.

This PR attempts to get rid of this problem by increasing worker RAM from 4GB to 6GB.

If subsequent PRs continue to experience the issue, we should roll back to `medium` workers.
