### PR TITLE
Implement combining validators

### DIFF
--- a/hivemind/__init__.py
+++ b/hivemind/__init__.py
@@ -4,4 +4,4 @@ from hivemind.server import *
 from hivemind.utils import *
 from hivemind.optim import *
 
-__version__ = '0.9.7'
+__version__ = '0.9.8'

--- a/hivemind/dht/__init__.py
+++ b/hivemind/dht/__init__.py
@@ -17,6 +17,7 @@ import asyncio
 import ctypes
 import multiprocessing as mp
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from typing import List, Optional, Sequence, Union, Callable, Awaitable, TypeVar
 
 import hivemind
@@ -195,7 +196,7 @@ class DHT(mp.Process):
                 future.set_exception(e)
 
     def set_validators_if_not_present(self, validators: Dict[str, RecordValidatorBase]) -> None:
-        self.run_coroutine(partial(self._set_validators_if_not_present, validators=validators))
+        self.run_coroutine(partial(DHT._set_validators_if_not_present, validators=validators))
 
     async def _set_validators_if_not_present(
             self, node: DHTNode, validators: Dict[str, RecordValidatorBase]) -> None:

--- a/hivemind/dht/__init__.py
+++ b/hivemind/dht/__init__.py
@@ -194,11 +194,12 @@ class DHT(mp.Process):
             if not future.done():
                 future.set_exception(e)
 
-    def extend_validator(self, **kwargs) -> None:
-        self.run_coroutine(partial(self._extend_validator, **kwargs))
+    def set_validators_if_not_present(self, validators: Dict[str, RecordValidatorBase]) -> None:
+        self.run_coroutine(partial(self._set_validators_if_not_present, validators=validators))
 
-    async def _extend_validator(self, node: DHTNode, **kwargs) -> None:
-        node.protocol.record_validator.extend(**kwargs)
+    async def _set_validators_if_not_present(
+            self, node: DHTNode, validators: Dict[str, RecordValidatorBase]) -> None:
+        node.protocol.record_validator.set_if_not_present(validators)
 
     def get_visible_address(self, num_peers: Optional[int] = None, peers: Sequence[Endpoint] = ()) -> Hostname:
         """

--- a/hivemind/dht/crypto.py
+++ b/hivemind/dht/crypto.py
@@ -87,6 +87,20 @@ class RSASignatureValidator(RecordValidatorBase):
     def _serialize_record(self, record: DHTRecord) -> bytes:
         return MSGPackSerializer.dumps(dataclasses.astuple(record))
 
+    @property
+    def priority(self) -> int:
+        # On validation, this validator must be executed before validators
+        # that deserialize the record
+        return 10
+
+    def merge_with(self, other: RecordValidatorBase) -> bool:
+        if not isinstance(other, RSASignatureValidator):
+            return False
+
+        # Ignore another RSASignatureValidator instance (it doesn't make sense to have several
+        # instances of this class) and report successful merge
+        return True
+
     def __getstate__(self):
         state = self.__dict__.copy()
         # Serializes the private key to make the class instances picklable

--- a/hivemind/dht/crypto.py
+++ b/hivemind/dht/crypto.py
@@ -86,3 +86,16 @@ class RSASignatureValidator(RecordValidatorBase):
 
     def _serialize_record(self, record: DHTRecord) -> bytes:
         return MSGPackSerializer.dumps(dataclasses.astuple(record))
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Serializes the private key to make the class instances picklable
+        state['_private_key'] = self._private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.OpenSSH,
+            encryption_algorithm=serialization.NoEncryption())
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._private_key = serialization.load_ssh_private_key(self._private_key, password=None)

--- a/hivemind/dht/schema.py
+++ b/hivemind/dht/schema.py
@@ -96,7 +96,7 @@ class SchemaValidator(RecordValidatorBase):
         readable_record = {self._alias_to_name.get(key_alias, key_alias):
                            deserialized_record[key_alias]}
         logger.warning(
-            f"Record {readable_record} doesn't match with all schemas: {validation_errors}")
+            f"Record {readable_record} doesn't match any of the schemas: {validation_errors}")
         return False
 
     @staticmethod

--- a/hivemind/dht/schema.py
+++ b/hivemind/dht/schema.py
@@ -1,6 +1,6 @@
 import binascii
 import re
-from typing import Type
+from typing import Any, Dict, Type
 
 import pydantic
 
@@ -19,7 +19,7 @@ class SchemaValidator(RecordValidatorBase):
     This allows to enforce types, min/max values, require a subkey to contain a public key, etc.
     """
 
-    def __init__(self, schema: pydantic.BaseModel):
+    def __init__(self, schema: pydantic.BaseModel, *, allow_extra_keys: bool=True):
         """
         :param schema: The Pydantic model (a subclass of pydantic.BaseModel).
 
@@ -27,6 +27,11 @@ class SchemaValidator(RecordValidatorBase):
             (e.g. ``StrictInt`` instead of ``int``,
             ``confloat(strict=True, ge=0.0)`` instead of ``confloat(ge=0.0)``, etc.).
             See the validate() docstring for details.
+
+        :param allow_extra_keys: Whether to allow keys that are not defined in the schema.
+
+            If a SchemaValidator is merged with another SchemaValidator, this option applies to
+            keys that are not defined in each of the schemas.
         """
 
         self._alias_to_name = {}
@@ -40,6 +45,7 @@ class SchemaValidator(RecordValidatorBase):
         schema.Config.extra = pydantic.Extra.forbid
 
         self._schemas = [schema]
+        self._allow_extra_keys = allow_extra_keys
 
     def validate(self, record: DHTRecord) -> bool:
         """
@@ -63,41 +69,58 @@ class SchemaValidator(RecordValidatorBase):
            .. [3] https://pydantic-docs.helpmanual.io/usage/types/#strict-types
         """
 
-        key_alias = self._key_id_to_str(record.key)
-        deserialized_value = DHTProtocol.serializer.loads(record.value)
-        if record.subkey not in DHTProtocol.RESERVED_SUBKEYS:
-            deserialized_subkey = DHTProtocol.serializer.loads(record.subkey)
-            deserialized_record = {key_alias: {deserialized_subkey: deserialized_value}}
-        else:
-            if isinstance(deserialized_value, dict):
-                logger.warning(
-                    f'Record {record} contains an improperly serialized dictionary (you must use '
-                    f'a DictionaryDHTValue of serialized values instead of a `dict` subclass)')
-                return False
-            deserialized_record = {key_alias: deserialized_value}
+        try:
+            record = self._deserialize_record(record)
+        except ValueError as e:
+            logger.warning(e)
+            return False
+        [key_alias] = list(record.keys())
 
-        parsed_record = None
+        n_outside_schema = 0
         validation_errors = []
         for schema in self._schemas:
             try:
-                parsed_record = schema.parse_obj(deserialized_record)
+                parsed_record = schema.parse_obj(record)
             except pydantic.ValidationError as e:
-                validation_errors.append(e)
+                if self._is_failed_due_to_extra_field(e):
+                    n_outside_schema += 1
+                else:
+                    validation_errors.append(e)
                 continue
 
             parsed_value = parsed_record.dict(by_alias=True)[key_alias]
-            if parsed_value != deserialized_record[key_alias]:
+            if parsed_value != record[key_alias]:
                 validation_errors.append(ValueError(
-                    f"Value {deserialized_record[key_alias]} needed type conversions to match "
+                    f"Value {record[key_alias]} needed type conversions to match "
                     f"the schema: {parsed_value}. Type conversions are not allowed"))
             else:
                 return True
 
-        readable_record = {self._alias_to_name.get(key_alias, key_alias):
-                           deserialized_record[key_alias]}
+        readable_record = {self._alias_to_name.get(key_alias, key_alias): record[key_alias]}
+
+        if n_outside_schema == len(self._schemas):
+            if not self._allow_extra_keys:
+                logger.warning(f"Record {readable_record} contains a field that "
+                               f"is not defined in each of the schemas")
+            return self._allow_extra_keys
+
         logger.warning(
             f"Record {readable_record} doesn't match any of the schemas: {validation_errors}")
         return False
+
+    @staticmethod
+    def _deserialize_record(record: DHTRecord) -> Dict[str, Any]:
+        key_alias = SchemaValidator._key_id_to_str(record.key)
+        deserialized_value = DHTProtocol.serializer.loads(record.value)
+        if record.subkey not in DHTProtocol.RESERVED_SUBKEYS:
+            deserialized_subkey = DHTProtocol.serializer.loads(record.subkey)
+            return {key_alias: {deserialized_subkey: deserialized_value}}
+        else:
+            if isinstance(deserialized_value, dict):
+                raise ValueError(
+                    f'Record {record} contains an improperly serialized dictionary (you must use '
+                    f'a DictionaryDHTValue of serialized values instead of a `dict` subclass)')
+            return {key_alias: deserialized_value}
 
     @staticmethod
     def _key_id_to_str(key_id: bytes) -> str:
@@ -108,12 +131,22 @@ class SchemaValidator(RecordValidatorBase):
 
         return binascii.hexlify(key_id).decode()
 
+    @staticmethod
+    def _is_failed_due_to_extra_field(exc: pydantic.ValidationError):
+        inner_errors = exc.errors()
+        return (
+            len(inner_errors) == 1 and
+            inner_errors[0]['type'] == 'value_error.extra' and
+            len(inner_errors[0]['loc']) == 1  # Require the extra field to be on the top level
+        )
+
     def merge_with(self, other: RecordValidatorBase) -> bool:
         if not isinstance(other, SchemaValidator):
             return False
 
         self._alias_to_name.update(other._alias_to_name)
         self._schemas.extend(other._schemas)
+        self._allow_extra_keys = self._allow_extra_keys or other._allow_extra_keys
         return True
 
 

--- a/hivemind/dht/validation.py
+++ b/hivemind/dht/validation.py
@@ -60,23 +60,23 @@ class CompositeValidator(RecordValidatorBase):
         self._validators = validators if validators is not None else {}
 
     def set_if_not_present(self, validators: Dict[str, RecordValidatorBase]) -> None:
-        for key, val in validators.items():
-            self._validators.setdefault(key, val)
+        for key, validator in validators.items():
+            self._validators.setdefault(key, validator)
 
     def validate(self, record: DHTRecord) -> bool:
-        for i, (_, val) in enumerate(sorted(self._validators.items(), reverse=True)):
-            if not val.validate(record):
+        for i, (_, validator) in enumerate(sorted(self._validators.items(), reverse=True)):
+            if not validator.validate(record):
                 return False
             if i < len(self._validators) - 1:
-                record = dataclasses.replace(record, value=val.strip_value(record))
+                record = dataclasses.replace(record, value=validator.strip_value(record))
         return True
 
     def sign_value(self, record: DHTRecord) -> bytes:
-        for _, val in sorted(self._validators.items()):
-            record = dataclasses.replace(record, value=val.sign_value(record))
+        for _, validator in sorted(self._validators.items()):
+            record = dataclasses.replace(record, value=validator.sign_value(record))
         return record.value
 
     def strip_value(self, record: DHTRecord) -> bytes:
-        for _, val in sorted(self._validators.items(), reverse=True):
-            record = dataclasses.replace(record, value=val.strip_value(record))
+        for _, validator in sorted(self._validators.items(), reverse=True):
+            record = dataclasses.replace(record, value=validator.strip_value(record))
         return record.value

--- a/hivemind/dht/validation.py
+++ b/hivemind/dht/validation.py
@@ -1,6 +1,6 @@
 import dataclasses
 from abc import ABC, abstractmethod
-from typing import List
+from typing import Iterable
 
 
 @dataclasses.dataclass(init=True, repr=True, frozen=True)
@@ -90,12 +90,11 @@ class RecordValidatorBase(ABC):
 
 
 class CompositeValidator(RecordValidatorBase):
-    def __init__(self, validators: List[RecordValidatorBase]=None):
+    def __init__(self, validators: Iterable[RecordValidatorBase]=()):
         self._validators = []
-        if validators is not None:
-            self.extend(validators)
+        self.extend(validators)
 
-    def extend(self, validators: List[RecordValidatorBase]) -> None:
+    def extend(self, validators: Iterable[RecordValidatorBase]) -> None:
         for new_validator in validators:
             for existing_validator in self._validators:
                 if existing_validator.merge_with(new_validator):

--- a/hivemind/dht/validation.py
+++ b/hivemind/dht/validation.py
@@ -59,7 +59,7 @@ class CompositeValidator(RecordValidatorBase):
     def __init__(self, validators: Dict[str, RecordValidatorBase]=None):
         self._validators = validators if validators is not None else {}
 
-    def extend(self, validators: Dict[str, RecordValidatorBase]) -> None:
+    def set_if_not_present(self, validators: Dict[str, RecordValidatorBase]) -> None:
         for key, val in validators.items():
             self._validators.setdefault(key, val)
 

--- a/tests/test_dht_schema.py
+++ b/tests/test_dht_schema.py
@@ -27,17 +27,6 @@ async def dht_nodes_with_schema():
 
 @pytest.mark.forked
 @pytest.mark.asyncio
-async def test_keys_outside_schema(dht_nodes_with_schema):
-    alice, bob = dht_nodes_with_schema
-
-    assert not await bob.store(b'unknown_key', b'foo_bar', get_dht_time() + 10)
-
-    for peer in [alice, bob]:
-        assert (await peer.get(b'unknown_key', latest=True)) is None
-
-
-@pytest.mark.forked
-@pytest.mark.asyncio
 async def test_expecting_regular_value(dht_nodes_with_schema):
     alice, bob = dht_nodes_with_schema
 
@@ -107,6 +96,34 @@ async def test_expecting_public_keys(dht_nodes_with_schema):
 
 @pytest.mark.forked
 @pytest.mark.asyncio
+async def test_keys_outside_schema(dht_nodes_with_schema):
+    class Schema(BaseModel):
+        some_field: StrictInt
+
+    class MergedSchema(BaseModel):
+        another_field: StrictInt
+
+    for allow_extra_keys in [False, True]:
+        validator = SchemaValidator(Schema, allow_extra_keys=allow_extra_keys)
+        assert validator.merge_with(SchemaValidator(MergedSchema, allow_extra_keys=False))
+
+        alice = await DHTNode.create(record_validator=validator)
+        bob = await DHTNode.create(
+            record_validator=validator, initial_peers=[f"{LOCALHOST}:{alice.port}"])
+
+        store_ok = await bob.store(b'unknown_key', b'foo_bar', get_dht_time() + 10)
+        assert store_ok == allow_extra_keys
+
+        for peer in [alice, bob]:
+            result = await peer.get(b'unknown_key', latest=True)
+            if allow_extra_keys:
+                assert result.value == b'foo_bar'
+            else:
+                assert result is None
+
+
+@pytest.mark.forked
+@pytest.mark.asyncio
 async def test_merging_schema_validators(dht_nodes_with_schema):
     alice, bob = dht_nodes_with_schema
 
@@ -126,18 +143,22 @@ async def test_merging_schema_validators(dht_nodes_with_schema):
         another_field: StrictInt  # Allow it to be a StrictInt as well
 
     for schema in [SecondSchema, ThirdSchema]:
-        new_validator = SchemaValidator(schema)
+        new_validator = SchemaValidator(schema, allow_extra_keys=False)
         for peer in [alice, bob]:
             assert peer.protocol.record_validator.merge_with(new_validator)
 
     assert await bob.store(b'experiment_name', b'foo_bar', get_dht_time() + 10)
     assert await bob.store(b'some_field', 777, get_dht_time() + 10)
-    assert await bob.store(b'another_field', 'string_value', get_dht_time() + 10)
+    assert not await bob.store(b'some_field', 'string_value', get_dht_time() + 10)
     assert await bob.store(b'another_field', 42, get_dht_time() + 10)
-    assert not await bob.store(b'unknown_key', 777, get_dht_time() + 10)
+    assert await bob.store(b'another_field', 'string_value', get_dht_time() + 10)
+
+    # Unkown keys are allowed since the first schema is created with allow_extra_keys=True
+    assert await bob.store(b'unknown_key', 999, get_dht_time() + 10)
 
     for peer in [alice, bob]:
         assert (await peer.get(b'experiment_name', latest=True)).value == b'foo_bar'
         assert (await peer.get(b'some_field', latest=True)).value == 777
-        assert (await peer.get(b'another_field', latest=True)).value == 42
-        assert (await peer.get(b'unknown_key', latest=True)) is None
+        assert (await peer.get(b'another_field', latest=True)).value == 'string_value'
+
+        assert (await peer.get(b'unknown_key', latest=True)).value == 999

--- a/tests/test_dht_validation.py
+++ b/tests/test_dht_validation.py
@@ -25,8 +25,8 @@ class SchemaB(BaseModel):
 def validators_for_app():
     # Each application may add its own validator set
     return {
-        'A': [RSASignatureValidator(), SchemaValidator(SchemaA)],
-        'B': [SchemaValidator(SchemaB), RSASignatureValidator()],
+        'A': [RSASignatureValidator(), SchemaValidator(SchemaA, allow_extra_keys=False)],
+        'B': [SchemaValidator(SchemaB, allow_extra_keys=False), RSASignatureValidator()],
     }
 
 

--- a/tests/test_dht_validation.py
+++ b/tests/test_dht_validation.py
@@ -65,7 +65,7 @@ def test_composite_validator(validators_for_app):
 
 
 @pytest.mark.forked
-def test_dht_set_validators_if_not_present(validators_for_app):
+def test_dht_add_validators(validators_for_app):
     # One app may create a DHT with its validators
     dht = hivemind.DHT(start=False, record_validators=validators_for_app['A'])
 

--- a/tests/test_dht_validation.py
+++ b/tests/test_dht_validation.py
@@ -71,11 +71,11 @@ def test_dht_set_validators_if_not_present(validators_for_app):
 
     # While the DHT process is not started, you can't send a command to append new validators
     with pytest.raises(RuntimeError):
-        dht.append_validators(validators_for_app['B'])
+        dht.add_validators(validators_for_app['B'])
     dht.run_in_background(await_ready=True)
 
-    # After starting the process, other apps may append new validators to the existing DHT
-    dht.append_validators(validators_for_app['B'])
+    # After starting the process, other apps may add new validators to the existing DHT
+    dht.add_validators(validators_for_app['B'])
 
     assert dht.store(b'field_a', b'bytes_value', hivemind.get_dht_time() + 10)
     assert dht.get(b'field_a', latest=True).value == b'bytes_value'

--- a/tests/test_dht_validation.py
+++ b/tests/test_dht_validation.py
@@ -1,0 +1,120 @@
+import dataclasses
+from functools import partial
+from typing import List, Tuple
+
+import pytest
+from pydantic import BaseModel
+
+import hivemind
+from hivemind.dht.crypto import RSASignatureValidator
+from hivemind.dht.protocol import DHTProtocol
+from hivemind.dht.routing import DHTID
+from hivemind.dht.schema import SchemaValidator
+from hivemind.dht.validation import DHTRecord, CompositeValidator, RecordValidatorBase
+
+
+class LoggingValidatorWrapper(RecordValidatorBase):
+    def __init__(self, wrapped: RecordValidatorBase, name: str, log: List[Tuple[str, str]]):
+        self._wrapped = wrapped
+        self._log = log
+        self._name = name
+
+    def validate(self, record: DHTRecord) -> bool:
+        self._log.append((self._name, 'validate'))
+        print(self._name, 'validate', record.value)
+        return self._wrapped.validate(record)
+
+    def sign_value(self, record: DHTRecord) -> bytes:
+        self._log.append((self._name, 'sign_value'))
+        print(self._name, 'sign_value')
+        return self._wrapped.sign_value(record)
+
+    def strip_value(self, record: DHTRecord) -> bytes:
+        self._log.append((self._name, 'strip_value'))
+        print(self._name, 'strip_value')
+        return self._wrapped.strip_value(record)
+
+
+class SchemaA(BaseModel):
+    field_a: bytes
+
+
+class SchemaB(BaseModel):
+    field_b: bytes
+
+
+@pytest.fixture
+def logging_validators():
+    log = []
+    log_as = partial(LoggingValidatorWrapper, log=log)
+
+    # Each application may add its own validator set
+    validator_sets = [
+        {
+            '10-schema-app-A': log_as(SchemaValidator(SchemaA), 'schema-val-A'),
+            '20-signature': log_as(RSASignatureValidator(), 'signature-val-A'),
+        },
+        {
+            '10-schema-app-B': log_as(SchemaValidator(SchemaB), 'schema-val-B'),
+            '20-signature': log_as(RSASignatureValidator(), 'signature-val-B'),
+        },
+    ]
+
+    return log, validator_sets
+
+
+def test_composite_validator(logging_validators):
+    log, validator_sets = logging_validators
+    validator = CompositeValidator(validator_sets[0])
+    validator.set_if_not_present(validator_sets[1])
+
+    record = DHTRecord(key=DHTID.generate(source=b'field_a').to_bytes(),
+                       subkey=DHTProtocol.IS_REGULAR_VALUE,
+                       value=DHTProtocol.serializer.dumps(b'value'),
+                       expiration_time=hivemind.get_dht_time() + 10)
+
+    log.clear()
+    signed_record = dataclasses.replace(record, value=validator.sign_value(record))
+    assert log == [
+        ('schema-val-A', 'sign_value'),
+        ('schema-val-B', 'sign_value'),
+        ('signature-val-A', 'sign_value'),
+    ]
+
+    log.clear()
+    assert validator.validate(signed_record)
+    assert log == [
+        ('signature-val-A', 'validate'),
+        ('signature-val-A', 'strip_value'),
+        ('schema-val-B', 'validate'),
+        ('schema-val-B', 'strip_value'),
+        ('schema-val-A', 'validate'),
+    ]
+
+    log.clear()
+    assert validator.strip_value(signed_record) == record.value
+    assert log == [
+        ('signature-val-A', 'strip_value'),
+        ('schema-val-B', 'strip_value'),
+        ('schema-val-A', 'strip_value'),
+    ]
+
+
+async def dummy_dht_coro(self, node, validators):
+    node.protocol.record_validator.set_if_not_present(validators)
+
+
+@pytest.mark.forked
+def test_dht_set_validators_if_not_present(logging_validators):
+    log, validator_sets = logging_validators
+    # One app may create a DHT with its validators
+    dht = hivemind.DHT(start=True, record_validator=CompositeValidator(validator_sets[0]))
+    # Other apps may use the existing DHT and add their own validators
+    dht.set_validators_if_not_present(validator_sets[1])
+
+    assert dht.store(b'field_a', b'bytes_value', hivemind.get_dht_time() + 10)
+    assert dht.get(b'field_a', latest=True).value == b'bytes_value'
+
+    # This record does not pass the SchemaValidator
+    assert not dht.store(b'field_a', 666, hivemind.get_dht_time() + 10)
+    assert dht.get(b'field_a', latest=True).value == b'bytes_value'

--- a/tests/test_dht_validation.py
+++ b/tests/test_dht_validation.py
@@ -21,17 +21,14 @@ class LoggingValidatorWrapper(RecordValidatorBase):
 
     def validate(self, record: DHTRecord) -> bool:
         self._log.append((self._name, 'validate'))
-        print(self._name, 'validate', record.value)
         return self._wrapped.validate(record)
 
     def sign_value(self, record: DHTRecord) -> bytes:
         self._log.append((self._name, 'sign_value'))
-        print(self._name, 'sign_value')
         return self._wrapped.sign_value(record)
 
     def strip_value(self, record: DHTRecord) -> bytes:
         self._log.append((self._name, 'strip_value'))
-        print(self._name, 'strip_value')
         return self._wrapped.strip_value(record)
 
 


### PR DESCRIPTION
This PR proposes a way to combine validators. The API should match the following requirements:

1. An application should be able to add new validators to an existing DHT instance, so that several applications (e.g. the averager and the MoE) may use one DHT instance (passed to them in the class constructors).
2. Some validator classes allow using multiple validator instances (e.g. each application may add a `SchemaValidator` with its own schema), others don't (e.g. only one `RSASignatureValidator` makes sense).
3. The validator classes should be executed in a specific order (e.g. `RSASignatureValidator` should remove the signature before `SchemaValidator` will try to deserialize a record and validate the schema).

The proposed solution is described in this [comment](https://github.com/learning-at-home/hivemind/pull/249#issuecomment-827259341).