### PR TITLE
Protect training progress and metrics with signatures and DHT schema validation

### DIFF
--- a/examples/albert/metrics_utils.py
+++ b/examples/albert/metrics_utils.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Tuple
 
 from hivemind.dht.crypto import RSASignatureValidator
-from hivemind.dht.schema import SchemaValidator
+from hivemind.dht.schema import BytesWithPublicKey, SchemaValidator
 from hivemind.dht.validation import RecordValidatorBase
 from pydantic import BaseModel, StrictFloat, confloat, conint
 

--- a/examples/albert/metrics_utils.py
+++ b/examples/albert/metrics_utils.py
@@ -1,0 +1,18 @@
+from hivemind.dht.schema import SchemaValidator
+from pydantic import BaseModel, StrictFloat, UUID4, confloat, conint
+
+
+class LocalMetrics(BaseModel):
+    step: conint(ge=0, strict=True)
+    samples_per_second: confloat(ge=0.0, strict=True)
+    samples_accumulated: conint(ge=0, strict=True)
+    loss: StrictFloat
+    mini_steps: conint(ge=0, strict=True)
+
+
+class MetricSchema(BaseModel):
+    metrics: Dict[UUID4, LocalMetrics]
+
+
+def make_schema_validator(experiment_prefix: str) -> SchemaValidator:
+    return SchemaValidator(MetricSchema, prefix=experiment_prefix)

--- a/examples/albert/metrics_utils.py
+++ b/examples/albert/metrics_utils.py
@@ -1,5 +1,9 @@
+from typing import Dict, List, Tuple
+
+from hivemind.dht.crypto import RSASignatureValidator
 from hivemind.dht.schema import SchemaValidator
-from pydantic import BaseModel, StrictFloat, UUID4, confloat, conint
+from hivemind.dht.validation import RecordValidatorBase
+from pydantic import BaseModel, StrictFloat, confloat, conint
 
 
 class LocalMetrics(BaseModel):
@@ -11,8 +15,11 @@ class LocalMetrics(BaseModel):
 
 
 class MetricSchema(BaseModel):
-    metrics: Dict[UUID4, LocalMetrics]
+    metrics: Dict[BytesWithPublicKey, LocalMetrics]
 
 
-def make_schema_validator(experiment_prefix: str) -> SchemaValidator:
-    return SchemaValidator(MetricSchema, prefix=experiment_prefix)
+def make_validators(experiment_prefix: str) -> Tuple[List[RecordValidatorBase], bytes]:
+    signature_validator = RSASignatureValidator()
+    validators = [SchemaValidator(MetricSchema, prefix=experiment_prefix),
+                  signature_validator]
+    return validators, signature_validator.local_public_key

--- a/examples/albert/run_first_peer.py
+++ b/examples/albert/run_first_peer.py
@@ -34,9 +34,9 @@ if __name__ == '__main__':
         logger.warning("No address specified. Attempting to infer address from DNS.")
         args.address = get_ip(GoogleDnsProvider)
 
-    dht = hivemind.DHT(
-        start=True, listen_on=args.listen_on, endpoint=f"{args.address}:*",
-        record_validators=[metrics_utils.make_schema_validator(args.experiment_prefix)])
+    validators, local_public_key = metrics_utils.make_validators(args.experiment_prefix)
+    dht = hivemind.DHT(start=True, listen_on=args.listen_on, endpoint=f"{args.address}:*",
+                       record_validators=validators)
     logger.info(f"Running DHT root at {args.address}:{dht.port}")
 
     wandb.init(project=args.wandb_project)

--- a/examples/albert/run_trainer.py
+++ b/examples/albert/run_trainer.py
@@ -274,7 +274,8 @@ def main():
 
     opt, scheduler = get_optimizer_and_scheduler(training_args, model)
 
-    validators, local_public_key = metrics_utils.make_validators(args.experiment_prefix)
+    validators, local_public_key = metrics_utils.make_validators(
+        collaboration_args_dict['experiment_prefix'])
     dht = hivemind.DHT(
         start=True, initial_peers=collaboration_args_dict.pop('initial_peers'),
         listen=not collaboration_args_dict['client_mode'],

--- a/hivemind/dht/crypto.py
+++ b/hivemind/dht/crypto.py
@@ -16,7 +16,7 @@ logger = get_logger(__name__)
 class RSASignatureValidator(RecordValidatorBase):
     """
     Introduces a notion of *protected records* whose key/subkey contains substring
-    "[owner:ssh-rsa ...]" (the format can be changed) with an RSA public key of the owner.
+    "[owner:ssh-rsa ...]" with an RSA public key of the owner.
 
     If this validator is used, changes to such records always must be signed with
     the corresponding private key (so only the owner can change them).

--- a/hivemind/dht/crypto.py
+++ b/hivemind/dht/crypto.py
@@ -64,13 +64,13 @@ class RSASignatureValidator(RecordValidatorBase):
             return True  # The record is not protected with a public key
 
         if len(set(public_keys)) > 1:
-            logger.debug(f"Key and subkey can't contain different public keys in {record}")
+            logger.warning(f"Key and subkey can't contain different public keys in {record}")
             return False
         public_key = serialization.load_ssh_public_key(public_keys[0])
 
         signatures = self._signature_re.findall(record.value)
         if len(signatures) != 1:
-            logger.debug(f"Record should have exactly one signature in {record}")
+            logger.warning(f"Record should have exactly one signature in {record}")
             return False
         signature = base64.b64decode(signatures[0])
 
@@ -81,7 +81,7 @@ class RSASignatureValidator(RecordValidatorBase):
                               self._padding, self._hash_algorithm)
             return True
         except InvalidSignature:
-            logger.debug(f'Signature is invalid in {record}')
+            logger.warning(f'Signature is invalid in {record}')
             return False
 
     def sign_value(self, record: DHTRecord) -> bytes:

--- a/hivemind/dht/crypto.py
+++ b/hivemind/dht/crypto.py
@@ -64,13 +64,13 @@ class RSASignatureValidator(RecordValidatorBase):
             return True  # The record is not protected with a public key
 
         if len(set(public_keys)) > 1:
-            logger.warning(f"Key and subkey can't contain different public keys in {record}")
+            logger.debug(f"Key and subkey can't contain different public keys in {record}")
             return False
         public_key = serialization.load_ssh_public_key(public_keys[0])
 
         signatures = self._SIGNATURE_RE.findall(record.value)
         if len(signatures) != 1:
-            logger.warning(f"Record should have exactly one signature in {record}")
+            logger.debug(f"Record should have exactly one signature in {record}")
             return False
         signature = base64.b64decode(signatures[0])
 
@@ -81,7 +81,7 @@ class RSASignatureValidator(RecordValidatorBase):
                               self._padding, self._hash_algorithm)
             return True
         except InvalidSignature:
-            logger.warning(f'Signature is invalid in {record}')
+            logger.debug(f'Signature is invalid in {record}')
             return False
 
     def sign_value(self, record: DHTRecord) -> bytes:

--- a/hivemind/dht/crypto.py
+++ b/hivemind/dht/crypto.py
@@ -45,6 +45,9 @@ class RSASignatureValidator(RecordValidatorBase):
             encoding=serialization.Encoding.OpenSSH, format=serialization.PublicFormat.OpenSSH)
         self._local_public_key = self.PUBLIC_KEY_FORMAT.replace(b'_key_', serialized_public_key)
 
+        self._init_signature_params()
+
+    def _init_signature_params(self) -> None:
         self._padding = padding.PSS(mgf=padding.MGF1(hashes.SHA256()),
                                     salt_length=padding.PSS.MAX_LENGTH)
         self._hash_algorithm = hashes.SHA256()
@@ -122,3 +125,4 @@ class RSASignatureValidator(RecordValidatorBase):
     def __setstate__(self, state):
         self.__dict__.update(state)
         self._private_key = serialization.load_ssh_private_key(self._private_key, password=None)
+        self._init_signature_params()

--- a/hivemind/dht/schema.py
+++ b/hivemind/dht/schema.py
@@ -1,6 +1,6 @@
 import binascii
 import re
-from typing import Any, Dict, Type
+from typing import Any, Dict, Optional, Type
 
 import pydantic
 
@@ -19,7 +19,8 @@ class SchemaValidator(RecordValidatorBase):
     This allows to enforce types, min/max values, require a subkey to contain a public key, etc.
     """
 
-    def __init__(self, schema: pydantic.BaseModel, *, allow_extra_keys: bool=True):
+    def __init__(self, schema: pydantic.BaseModel, *,
+                 allow_extra_keys: bool=True, prefix: Optional[str]=None):
         """
         :param schema: The Pydantic model (a subclass of pydantic.BaseModel).
 
@@ -32,11 +33,15 @@ class SchemaValidator(RecordValidatorBase):
 
             If a SchemaValidator is merged with another SchemaValidator, this option applies to
             keys that are not defined in each of the schemas.
+
+        :param prefix: (optional) Add ``prefix + '_'`` to the names of all schema fields.
         """
 
         self._alias_to_name = {}
 
         for field in schema.__fields__.values():
+            if prefix is not None:
+                field.name = prefix + '_' + field.name
             field.alias = self._key_id_to_str(DHTID.generate(source=field.name.encode()).to_bytes())
             self._alias_to_name[field.alias] = field.name
 

--- a/hivemind/dht/schema.py
+++ b/hivemind/dht/schema.py
@@ -43,7 +43,7 @@ class SchemaValidator(RecordValidatorBase):
         for field in schema.__fields__.values():
             if prefix is not None:
                 field.name = f'{prefix}_{field.name}'
-            field.alias = self._key_id_to_str(DHTID.generate(source=field.name.encode()).to_bytes())
+            field.alias = self._key_id_to_str(DHTID.generate(source=field.name).to_bytes())
             self._alias_to_name[field.alias] = field.name
 
             # Because validate() interface provides one key at a time

--- a/hivemind/dht/schema.py
+++ b/hivemind/dht/schema.py
@@ -42,7 +42,7 @@ class SchemaValidator(RecordValidatorBase):
 
         for field in schema.__fields__.values():
             if prefix is not None:
-                field.name = prefix + '_' + field.name
+                field.name = f'{prefix}_{field.name}'
             field.alias = self._key_id_to_str(DHTID.generate(source=field.name.encode()).to_bytes())
             self._alias_to_name[field.alias] = field.name
 

--- a/hivemind/dht/schema.py
+++ b/hivemind/dht/schema.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Type
 
 import pydantic
 
+from hivemind.dht.crypto import RSASignatureValidator
 from hivemind.dht.protocol import DHTProtocol
 from hivemind.dht.routing import DHTID, DHTKey
 from hivemind.dht.validation import DHTRecord, RecordValidatorBase
@@ -175,3 +176,6 @@ def conbytes(*, regex: bytes=None, **kwargs) -> Type[pydantic.BaseModel]:
             return value
 
     return ConstrainedBytesWithRegex
+
+
+BytesWithPublicKey = conbytes(regex=b'.*' + RSASignatureValidator.PUBLIC_KEY_REGEX + b'.*')

--- a/hivemind/dht/schema.py
+++ b/hivemind/dht/schema.py
@@ -82,14 +82,14 @@ class SchemaValidator(RecordValidatorBase):
 
         if record.key not in self._key_id_to_field_name:
             if not self._allow_extra_keys:
-                logger.warning(f"Record {record} has a key ID that is not defined in any of the "
-                               f"schemas (therefore, the raw key is unknown)")
+                logger.debug(f"Record {record} has a key ID that is not defined in any of the "
+                             f"schemas (therefore, the raw key is unknown)")
             return self._allow_extra_keys
 
         try:
             record = self._deserialize_record(record)
         except ValueError as e:
-            logger.warning(e)
+            logger.debug(e)
             return False
         [field_name] = list(record.keys())
 
@@ -111,7 +111,7 @@ class SchemaValidator(RecordValidatorBase):
             else:
                 return True
 
-        logger.warning(f"Record {record} doesn't match any of the schemas: {validation_errors}")
+        logger.debug(f"Record {record} doesn't match any of the schemas: {validation_errors}")
         return False
 
     def _deserialize_record(self, record: DHTRecord) -> Dict[str, Any]:

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -11,6 +11,8 @@ from pydantic import BaseModel, StrictBool, confloat, conint
 
 from hivemind.client.averaging.training import TrainingAverager
 from hivemind.dht import DHT
+from hivemind.dht.crypto import RSASignatureValidator
+from hivemind.dht.schema import SchemaValidator
 from hivemind.optim.base import DecentralizedOptimizerBase
 from hivemind.optim.performance_ema import PerformanceEMA
 from hivemind.utils import Endpoint, ValueWithExpiration, get_dht_time, get_logger

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
+
+import logging
 from dataclasses import dataclass
 from threading import Thread, Lock, Event
 from typing import Optional, Iterator
-import logging
 
-import torch
 import numpy as np
+import torch
+from pydantic import BaseModel, StrictBool, confloat, conint
 
+from hivemind.client.averaging.training import TrainingAverager
 from hivemind.dht import DHT
 from hivemind.optim.base import DecentralizedOptimizerBase
-from hivemind.client.averaging.training import TrainingAverager
-from hivemind.utils import get_logger, get_dht_time, ValueWithExpiration
 from hivemind.optim.performance_ema import PerformanceEMA
+from hivemind.utils import Endpoint, ValueWithExpiration, get_dht_time, get_logger
+
 
 logger = get_logger(__name__)
 LRSchedulerBase = getattr(torch.optim.lr_scheduler, '_LRScheduler', None)
@@ -35,6 +38,18 @@ class CollaborationState:
         self.optimizer_step = max(local_step, self.optimizer_step)
         self.samples_accumulated = 0
         self.eta_next_step = float('inf')
+
+
+class LocalTrainingProgress(BaseModel):
+    step: conint(ge=0, strict=True)
+    samples_accumulated: conint(ge=0, strict=True)
+    samples_per_second: confloat(ge=0.0, strict=True)
+    time: StrictFloat
+    client_mode: StrictBool
+
+
+class TrainingProgressSchema(BaseModel):
+    progress: Dict[Endpoint, Optional[LocalTrainingProgress]]
 
 
 class CollaborativeOptimizer(DecentralizedOptimizerBase):
@@ -87,6 +102,8 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
                  reuse_grad_buffers: bool = False, accumulate_grads_on: Optional[torch.device] = None,
                  client_mode: bool = False, verbose: bool = False, **kwargs):
         super().__init__(opt, dht)
+        dht.add_validators([SchemaValidator(TrainingProgressSchema, prefix=prefix)])
+
         if reuse_grad_buffers and accumulate_grads_on is not None:
             logger.warning("Setting 'accumulate_grads_on' has no effect if reuse_grad_buffers=True")
         self.prefix, self.scheduler = prefix, scheduler
@@ -262,13 +279,17 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
             self.should_report_progress.wait()
             self.should_report_progress.clear()
             with self.lock_local_progress:
-                current_time = get_dht_time()
-                local_state_info = [self.local_step, self.local_samples_accumulated,
-                                    self.performance_ema.samples_per_second, current_time, not self.averager.listen]
+                local_state_info = LocalTrainingProgress(
+                    step=self.local_step,
+                    samples_accumulated=self.local_samples_accumulated,
+                    samples_per_second=self.performance_ema.samples_per_second,
+                    time=get_dht_time(),
+                    client_mode=not self.averager.listen)
 
-            assert self.is_valid_peer_state(local_state_info), local_state_info
-            self.dht.store(self.training_progress_key, subkey=self.averager.endpoint, value=local_state_info,
-                           expiration_time=current_time + self.metadata_expiration, return_future=True)
+            self.dht.store(key=self.training_progress_key, subkey=self.averager.endpoint,
+                           value=local_state_info.dict(),
+                           expiration_time=current_time + self.metadata_expiration,
+                           return_future=True)
 
     def check_collaboration_state_periodically(self):
         """
@@ -296,24 +317,26 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
                                       num_peers=0, num_clients=0, eta_next_step=current_time + local_eta_next_step,
                                       next_fetch_time=current_time + self.default_refresh_period)
 
-        valid_peer_states = [peer_state.value for peer_state in response.values()
-                             if isinstance(peer_state, ValueWithExpiration)
-                             and self.is_valid_peer_state(peer_state.value)]
+        valid_peer_states = [LocalTrainingProgress.parse_obj(peer_state.value)
+                             for peer_state in response.values()
+                             if peer_state.value is not None]
 
         num_peers = len(valid_peer_states)
-        num_clients = sum(is_client for *_, is_client in valid_peer_states)
+        num_clients = sum(state.client_mode for state in valid_peer_states)
         global_optimizer_step = self.local_step
-        for opt_step, samples_accumulated, samples_per_second, timestep, is_client in valid_peer_states:
-            if not is_client:
-                global_optimizer_step = max(global_optimizer_step, opt_step)
+        for state in valid_peer_states:
+            if not state.client_mode:
+                global_optimizer_step = max(global_optimizer_step, state.step)
 
         total_samples_accumulated = estimated_current_samples = total_samples_per_second = 0
 
-        for opt_step, samples_accumulated, samples_per_second, timestep, is_client in valid_peer_states:
-            total_samples_per_second += samples_per_second
-            if opt_step == global_optimizer_step:
-                total_samples_accumulated += samples_accumulated
-                estimated_current_samples += samples_accumulated + max(0, current_time - timestep) * samples_per_second
+        for state in valid_peer_states:
+            total_samples_per_second += state.samples_per_second
+            if state.step == global_optimizer_step:
+                total_samples_accumulated += state.samples_accumulated
+                estimated_current_samples += (
+                    state.samples_accumulated +
+                    max(0, current_time - state.time) * state.samples_per_second)
             # note: we deliberately count only valid peers for samples_accumulated, but all peers for performance;
             # the rationale behind this is that outdated peers will synchronize and begin contributing shortly.
 
@@ -336,11 +359,6 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
             raise ValueError(f"When running {self.__class__.__name__} with reuse_grad_buffers=True, user should never "
                              f"call zero_grad manually. Gradients will be refreshed internally.")
         return self.opt.zero_grad(*args, **kwargs)
-
-    @staticmethod
-    def is_valid_peer_state(state):
-        return isinstance(state, (list, tuple)) and len(state) == 5 \
-               and all(map(isinstance, state, (int, int, float, float, bool)))
 
     def update_scheduler(self):
         if self.scheduler:

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from threading import Thread, Lock, Event
-from typing import Optional, Iterator
+from typing import Dict, Optional, Iterator
 
 import numpy as np
 import torch
-from pydantic import BaseModel, StrictBool, confloat, conint
+from pydantic import BaseModel, StrictBool, StrictFloat, confloat, conint
 
 from hivemind.client.averaging.training import TrainingAverager
 from hivemind.dht import DHT
 from hivemind.dht.crypto import RSASignatureValidator
-from hivemind.dht.schema import SchemaValidator
+from hivemind.dht.schema import BytesWithPublicKey, SchemaValidator
 from hivemind.optim.base import DecentralizedOptimizerBase
 from hivemind.optim.performance_ema import PerformanceEMA
 from hivemind.utils import Endpoint, ValueWithExpiration, get_dht_time, get_logger
@@ -286,6 +286,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
             self.should_report_progress.wait()
             self.should_report_progress.clear()
             with self.lock_local_progress:
+                current_time = get_dht_time()
                 local_state_info = LocalTrainingProgress(
                     endpoint=self.averager.endpoint,
                     step=self.local_step,

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -47,7 +47,7 @@ class TrainingState(BaseModel):
     step: conint(ge=0, strict=True)
     samples_accumulated: conint(ge=0, strict=True)
     samples_per_second: confloat(ge=0.0, strict=True)
-    current_time: StrictFloat
+    time: StrictFloat
     client_mode: StrictBool
 
 
@@ -292,7 +292,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
                     step=self.local_step,
                     samples_accumulated=self.local_samples_accumulated,
                     samples_per_second=self.performance_ema.samples_per_second,
-                    current_time=get_dht_time(),
+                    time=current_time,
                     client_mode=not self.averager.listen)
 
             self.dht.store(key=self.training_progress_key, subkey=self._local_public_key,
@@ -344,7 +344,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
             if state.step == global_optimizer_step:
                 total_samples_accumulated += state.samples_accumulated
                 estimated_current_samples += (state.samples_accumulated +
-                                              max(0, current_time - state.current_time) * state.samples_per_second)
+                                              max(0, current_time - state.time) * state.samples_per_second)
             # note: we deliberately count only valid peers for samples_accumulated, but all peers for performance;
             # the rationale behind this is that outdated peers will synchronize and begin contributing shortly.
 

--- a/tests/test_dht_crypto.py
+++ b/tests/test_dht_crypto.py
@@ -2,15 +2,17 @@ import dataclasses
 
 import pytest
 
+import hivemind
 from hivemind.dht import get_dht_time
 from hivemind.dht.crypto import RSASignatureValidator
+from hivemind.dht.node import LOCALHOST
 from hivemind.dht.validation import DHTRecord
 
 
 def test_rsa_signature_validator():
     receiver_validator = RSASignatureValidator()
-    sender_validator = RSASignatureValidator()
-    mallory_validator = RSASignatureValidator()
+    sender_validator = RSASignatureValidator(ignore_cached_key=True)
+    mallory_validator = RSASignatureValidator(ignore_cached_key=True)
 
     plain_record = DHTRecord(key=b'key', subkey=b'subkey', value=b'value',
                              expiration_time=get_dht_time() + 10)
@@ -41,3 +43,44 @@ def test_rsa_signature_validator():
                        for record in protected_records]  # With someone else's signature
     for record in signed_records:
         assert not receiver_validator.validate(record)
+
+
+def test_cached_key():
+    first_validator = RSASignatureValidator()
+    second_validator = RSASignatureValidator()
+    assert first_validator.local_public_key == second_validator.local_public_key
+
+    third_validator = RSASignatureValidator(ignore_cached_key=True)
+    assert first_validator.local_public_key != third_validator.local_public_key
+
+
+@pytest.mark.forked
+@pytest.mark.asyncio
+async def test_dhtnode_signatures():
+    alice = await hivemind.DHTNode.create(record_validator=RSASignatureValidator())
+    bob = await hivemind.DHTNode.create(
+        record_validator=RSASignatureValidator(ignore_cached_key=True),
+        initial_peers=[f"{LOCALHOST}:{alice.port}"])
+    mallory = await hivemind.DHTNode.create(
+        record_validator=RSASignatureValidator(ignore_cached_key=True),
+        initial_peers=[f"{LOCALHOST}:{alice.port}"])
+
+    key = b'key'
+    subkey = b'protected_subkey' + bob.protocol.record_validator.local_public_key
+
+    assert await bob.store(key, b'true_value', hivemind.get_dht_time() + 10, subkey=subkey)
+    assert (await alice.get(key, latest=True)).value[subkey].value == b'true_value'
+
+    store_ok = await mallory.store(key, b'fake_value', hivemind.get_dht_time() + 10, subkey=subkey)
+    assert not store_ok
+    assert (await alice.get(key, latest=True)).value[subkey].value == b'true_value'
+
+    assert await bob.store(key, b'updated_true_value', hivemind.get_dht_time() + 10, subkey=subkey)
+    assert (await alice.get(key, latest=True)).value[subkey].value == b'updated_true_value'
+
+    await bob.shutdown()  # Bob has shut down, now Mallory is the single peer of Alice
+
+    store_ok = await mallory.store(key, b'updated_fake_value',
+                                   hivemind.get_dht_time() + 10, subkey=subkey)
+    assert not store_ok
+    assert (await alice.get(key, latest=True)).value[subkey].value == b'updated_true_value'

--- a/tests/test_dht_crypto.py
+++ b/tests/test_dht_crypto.py
@@ -56,8 +56,8 @@ def test_cached_key():
     assert first_validator.local_public_key != third_validator.local_public_key
 
 
-def test_validator_instance_is_pickable():
-    # Needs to be pickable because the validator instance may be sent between processes
+def test_validator_instance_is_picklable():
+    # Needs to be picklable because the validator instance may be sent between processes
 
     original_validator = RSASignatureValidator()
     unpickled_validator = pickle.loads(pickle.dumps(original_validator))

--- a/tests/test_dht_crypto.py
+++ b/tests/test_dht_crypto.py
@@ -16,9 +16,9 @@ def test_rsa_signature_validator():
                              expiration_time=get_dht_time() + 10)
     protected_records = [
         dataclasses.replace(plain_record,
-                            key=plain_record.key + sender_validator.ownership_marker),
+                            key=plain_record.key + sender_validator.local_public_key),
         dataclasses.replace(plain_record,
-                            subkey=plain_record.subkey + sender_validator.ownership_marker),
+                            subkey=plain_record.subkey + sender_validator.local_public_key),
     ]
 
     # test 1: Non-protected record (no signature added)

--- a/tests/test_dht_node.py
+++ b/tests/test_dht_node.py
@@ -10,7 +10,6 @@ import pytest
 
 import hivemind
 from hivemind import get_dht_time, replace_port
-from hivemind.dht.crypto import RSASignatureValidator
 from hivemind.dht.node import DHTID, Endpoint, DHTNode, LOCALHOST
 from hivemind.dht.protocol import DHTProtocol, ValidationError
 from hivemind.dht.storage import DictionaryDHTValue
@@ -454,33 +453,3 @@ async def test_dhtnode_edge_cases():
         assert stored is not None
         assert subkey in stored.value
         assert stored.value[subkey].value == value
-
-
-@pytest.mark.forked
-@pytest.mark.asyncio
-async def test_dhtnode_signatures():
-    alice = await hivemind.DHTNode.create(record_validator=RSASignatureValidator())
-    bob = await hivemind.DHTNode.create(
-        record_validator=RSASignatureValidator(), initial_peers=[f"{LOCALHOST}:{alice.port}"])
-    mallory = await hivemind.DHTNode.create(
-        record_validator=RSASignatureValidator(), initial_peers=[f"{LOCALHOST}:{alice.port}"])
-
-    key = b'key'
-    subkey = b'protected_subkey' + bob.protocol.record_validator.local_public_key
-
-    assert await bob.store(key, b'true_value', hivemind.get_dht_time() + 10, subkey=subkey)
-    assert (await alice.get(key, latest=True)).value[subkey].value == b'true_value'
-
-    store_ok = await mallory.store(key, b'fake_value', hivemind.get_dht_time() + 10, subkey=subkey)
-    assert not store_ok
-    assert (await alice.get(key, latest=True)).value[subkey].value == b'true_value'
-
-    assert await bob.store(key, b'updated_true_value', hivemind.get_dht_time() + 10, subkey=subkey)
-    assert (await alice.get(key, latest=True)).value[subkey].value == b'updated_true_value'
-
-    await bob.shutdown()  # Bob has shut down, now Mallory is the single peer of Alice
-
-    store_ok = await mallory.store(key, b'updated_fake_value',
-                                   hivemind.get_dht_time() + 10, subkey=subkey)
-    assert not store_ok
-    assert (await alice.get(key, latest=True)).value[subkey].value == b'updated_true_value'

--- a/tests/test_dht_node.py
+++ b/tests/test_dht_node.py
@@ -466,7 +466,7 @@ async def test_dhtnode_signatures():
         record_validator=RSASignatureValidator(), initial_peers=[f"{LOCALHOST}:{alice.port}"])
 
     key = b'key'
-    subkey = b'protected_subkey' + bob.protocol.record_validator.ownership_marker
+    subkey = b'protected_subkey' + bob.protocol.record_validator.local_public_key
 
     assert await bob.store(key, b'true_value', hivemind.get_dht_time() + 10, subkey=subkey)
     assert (await alice.get(key, latest=True)).value[subkey].value == b'true_value'

--- a/tests/test_dht_schema.py
+++ b/tests/test_dht_schema.py
@@ -31,17 +31,17 @@ async def test_expecting_regular_value(dht_nodes_with_schema):
     alice, bob = dht_nodes_with_schema
 
     # Regular value (bytes) expected
-    assert await bob.store(b'experiment_name', b'foo_bar', get_dht_time() + 10)
-    assert not await bob.store(b'experiment_name', 666, get_dht_time() + 10)
-    assert not await bob.store(b'experiment_name', b'foo_bar', get_dht_time() + 10,
+    assert await bob.store('experiment_name', b'foo_bar', get_dht_time() + 10)
+    assert not await bob.store('experiment_name', 666, get_dht_time() + 10)
+    assert not await bob.store('experiment_name', b'foo_bar', get_dht_time() + 10,
                                subkey=b'subkey')
 
     # Refuse records despite https://pydantic-docs.helpmanual.io/usage/models/#data-conversion
-    assert not await bob.store(b'experiment_name', [], get_dht_time() + 10)
-    assert not await bob.store(b'experiment_name', [1, 2, 3], get_dht_time() + 10)
+    assert not await bob.store('experiment_name', [], get_dht_time() + 10)
+    assert not await bob.store('experiment_name', [1, 2, 3], get_dht_time() + 10)
 
     for peer in [alice, bob]:
-        assert (await peer.get(b'experiment_name', latest=True)).value == b'foo_bar'
+        assert (await peer.get('experiment_name', latest=True)).value == b'foo_bar'
 
 
 @pytest.mark.forked
@@ -50,27 +50,27 @@ async def test_expecting_dictionary(dht_nodes_with_schema):
     alice, bob = dht_nodes_with_schema
 
     # Dictionary (bytes -> non-negative int) expected
-    assert await bob.store(b'n_batches', 777, get_dht_time() + 10, subkey=b'uid1')
-    assert await bob.store(b'n_batches', 778, get_dht_time() + 10, subkey=b'uid2')
-    assert not await bob.store(b'n_batches', -666, get_dht_time() + 10, subkey=b'uid3')
-    assert not await bob.store(b'n_batches', 666, get_dht_time() + 10)
-    assert not await bob.store(b'n_batches', b'not_integer', get_dht_time() + 10, subkey=b'uid1')
-    assert not await bob.store(b'n_batches', 666, get_dht_time() + 10, subkey=666)
+    assert await bob.store('n_batches', 777, get_dht_time() + 10, subkey=b'uid1')
+    assert await bob.store('n_batches', 778, get_dht_time() + 10, subkey=b'uid2')
+    assert not await bob.store('n_batches', -666, get_dht_time() + 10, subkey=b'uid3')
+    assert not await bob.store('n_batches', 666, get_dht_time() + 10)
+    assert not await bob.store('n_batches', b'not_integer', get_dht_time() + 10, subkey=b'uid1')
+    assert not await bob.store('n_batches', 666, get_dht_time() + 10, subkey=666)
 
     # Refuse storing a plain dictionary bypassing the DictionaryDHTValue convention
-    assert not await bob.store(b'n_batches', {b'uid3': 779}, get_dht_time() + 10)
+    assert not await bob.store('n_batches', {b'uid3': 779}, get_dht_time() + 10)
 
     # Refuse records despite https://pydantic-docs.helpmanual.io/usage/models/#data-conversion
-    assert not await bob.store(b'n_batches', 779.5, get_dht_time() + 10, subkey=b'uid3')
-    assert not await bob.store(b'n_batches', 779.0, get_dht_time() + 10, subkey=b'uid3')
-    assert not await bob.store(b'n_batches', [], get_dht_time() + 10)
-    assert not await bob.store(b'n_batches', [(b'uid3', 779)], get_dht_time() + 10)
+    assert not await bob.store('n_batches', 779.5, get_dht_time() + 10, subkey=b'uid3')
+    assert not await bob.store('n_batches', 779.0, get_dht_time() + 10, subkey=b'uid3')
+    assert not await bob.store('n_batches', [], get_dht_time() + 10)
+    assert not await bob.store('n_batches', [(b'uid3', 779)], get_dht_time() + 10)
 
     # Refuse records despite https://github.com/samuelcolvin/pydantic/issues/1268
-    assert not await bob.store(b'n_batches', '', get_dht_time() + 10)
+    assert not await bob.store('n_batches', '', get_dht_time() + 10)
 
     for peer in [alice, bob]:
-        dictionary = (await peer.get(b'n_batches', latest=True)).value
+        dictionary = (await peer.get('n_batches', latest=True)).value
         assert (len(dictionary) == 2 and
                 dictionary[b'uid1'].value == 777 and
                 dictionary[b'uid2'].value == 778)
@@ -83,13 +83,13 @@ async def test_expecting_public_keys(dht_nodes_with_schema):
 
     # Subkeys expected to contain a public key
     # (so hivemind.dht.crypto.RSASignatureValidator would require a signature)
-    assert await bob.store(b'signed_data', b'foo_bar', get_dht_time() + 10,
+    assert await bob.store('signed_data', b'foo_bar', get_dht_time() + 10,
                            subkey=b'uid[owner:public-key]')
-    assert not await bob.store(b'signed_data', b'foo_bar', get_dht_time() + 10,
+    assert not await bob.store('signed_data', b'foo_bar', get_dht_time() + 10,
                                subkey=b'uid-without-public-key')
 
     for peer in [alice, bob]:
-        dictionary = (await peer.get(b'signed_data', latest=True)).value
+        dictionary = (await peer.get('signed_data', latest=True)).value
         assert (len(dictionary) == 1 and
                 dictionary[b'uid[owner:public-key]'].value == b'foo_bar')
 
@@ -111,11 +111,11 @@ async def test_keys_outside_schema(dht_nodes_with_schema):
         bob = await DHTNode.create(
             record_validator=validator, initial_peers=[f"{LOCALHOST}:{alice.port}"])
 
-        store_ok = await bob.store(b'unknown_key', b'foo_bar', get_dht_time() + 10)
+        store_ok = await bob.store('unknown_key', b'foo_bar', get_dht_time() + 10)
         assert store_ok == allow_extra_keys
 
         for peer in [alice, bob]:
-            result = await peer.get(b'unknown_key', latest=True)
+            result = await peer.get('unknown_key', latest=True)
             if allow_extra_keys:
                 assert result.value == b'foo_bar'
             else:
@@ -134,13 +134,13 @@ async def test_prefix():
     bob = await DHTNode.create(
         record_validator=validator, initial_peers=[f"{LOCALHOST}:{alice.port}"])
 
-    assert await bob.store(b'prefix_field', 777, get_dht_time() + 10)
-    assert not await bob.store(b'prefix_field', 'string_value', get_dht_time() + 10)
-    assert not await bob.store(b'field', 777, get_dht_time() + 10)
+    assert await bob.store('prefix_field', 777, get_dht_time() + 10)
+    assert not await bob.store('prefix_field', 'string_value', get_dht_time() + 10)
+    assert not await bob.store('field', 777, get_dht_time() + 10)
 
     for peer in [alice, bob]:
-        assert (await peer.get(b'prefix_field', latest=True)).value == 777
-        assert (await peer.get(b'field', latest=True)) is None
+        assert (await peer.get('prefix_field', latest=True)).value == 777
+        assert (await peer.get('field', latest=True)) is None
 
 
 @pytest.mark.forked
@@ -168,18 +168,18 @@ async def test_merging_schema_validators(dht_nodes_with_schema):
         for peer in [alice, bob]:
             assert peer.protocol.record_validator.merge_with(new_validator)
 
-    assert await bob.store(b'experiment_name', b'foo_bar', get_dht_time() + 10)
-    assert await bob.store(b'some_field', 777, get_dht_time() + 10)
-    assert not await bob.store(b'some_field', 'string_value', get_dht_time() + 10)
-    assert await bob.store(b'another_field', 42, get_dht_time() + 10)
-    assert await bob.store(b'another_field', 'string_value', get_dht_time() + 10)
+    assert await bob.store('experiment_name', b'foo_bar', get_dht_time() + 10)
+    assert await bob.store('some_field', 777, get_dht_time() + 10)
+    assert not await bob.store('some_field', 'string_value', get_dht_time() + 10)
+    assert await bob.store('another_field', 42, get_dht_time() + 10)
+    assert await bob.store('another_field', 'string_value', get_dht_time() + 10)
 
     # Unknown keys are allowed since the first schema is created with allow_extra_keys=True
-    assert await bob.store(b'unknown_key', 999, get_dht_time() + 10)
+    assert await bob.store('unknown_key', 999, get_dht_time() + 10)
 
     for peer in [alice, bob]:
-        assert (await peer.get(b'experiment_name', latest=True)).value == b'foo_bar'
-        assert (await peer.get(b'some_field', latest=True)).value == 777
-        assert (await peer.get(b'another_field', latest=True)).value == 'string_value'
+        assert (await peer.get('experiment_name', latest=True)).value == b'foo_bar'
+        assert (await peer.get('some_field', latest=True)).value == 777
+        assert (await peer.get('another_field', latest=True)).value == 'string_value'
 
-        assert (await peer.get(b'unknown_key', latest=True)).value == 999
+        assert (await peer.get('unknown_key', latest=True)).value == 999

--- a/tests/test_dht_schema.py
+++ b/tests/test_dht_schema.py
@@ -174,7 +174,7 @@ async def test_merging_schema_validators(dht_nodes_with_schema):
     assert await bob.store(b'another_field', 42, get_dht_time() + 10)
     assert await bob.store(b'another_field', 'string_value', get_dht_time() + 10)
 
-    # Unkown keys are allowed since the first schema is created with allow_extra_keys=True
+    # Unknown keys are allowed since the first schema is created with allow_extra_keys=True
     assert await bob.store(b'unknown_key', 999, get_dht_time() + 10)
 
     for peer in [alice, bob]:

--- a/tests/test_dht_schema.py
+++ b/tests/test_dht_schema.py
@@ -6,7 +6,7 @@ from typing import Dict
 
 from hivemind.dht import get_dht_time
 from hivemind.dht.node import DHTNode, LOCALHOST
-from hivemind.dht.schema import SchemaValidator, conbytes
+from hivemind.dht.schema import BytesWithPublicKey, SchemaValidator, conbytes
 from hivemind.dht.validation import DHTRecord, RecordValidatorBase
 
 
@@ -15,7 +15,7 @@ async def dht_nodes_with_schema():
     class Schema(BaseModel):
         experiment_name: bytes
         n_batches: Dict[bytes, conint(ge=0, strict=True)]
-        signed_data: Dict[conbytes(regex=rb'.*\[owner:.+\]'), bytes]
+        signed_data: Dict[BytesWithPublicKey, bytes]
 
     validator = SchemaValidator(Schema)
 

--- a/tests/test_dht_validation.py
+++ b/tests/test_dht_validation.py
@@ -9,7 +9,7 @@ import hivemind
 from hivemind.dht.crypto import RSASignatureValidator
 from hivemind.dht.protocol import DHTProtocol
 from hivemind.dht.routing import DHTID
-from hivemind.dht.schema import SchemaValidator
+from hivemind.dht.schema import BytesWithPublicKey, SchemaValidator
 from hivemind.dht.validation import DHTRecord, CompositeValidator, RecordValidatorBase
 
 
@@ -18,7 +18,7 @@ class SchemaA(BaseModel):
 
 
 class SchemaB(BaseModel):
-    field_b: Dict[bytes, StrictInt]
+    field_b: Dict[BytesWithPublicKey, StrictInt]
 
 
 @pytest.fixture

--- a/tests/test_dht_validation.py
+++ b/tests/test_dht_validation.py
@@ -41,7 +41,7 @@ def test_composite_validator(validators_for_app):
     assert len(validator._validators[0]._schemas) == 2
 
     local_public_key = validators_for_app['A'][0].local_public_key
-    record = DHTRecord(key=DHTID.generate(source=b'field_b').to_bytes(),
+    record = DHTRecord(key=DHTID.generate(source='field_b').to_bytes(),
                        subkey=DHTProtocol.serializer.dumps(local_public_key),
                        value=DHTProtocol.serializer.dumps(777),
                        expiration_time=hivemind.get_dht_time() + 10)
@@ -53,7 +53,7 @@ def test_composite_validator(validators_for_app):
     assert validator.validate(signed_record)
     assert validator.strip_value(signed_record) == record.value
 
-    record = DHTRecord(key=DHTID.generate(source=b'unknown_key').to_bytes(),
+    record = DHTRecord(key=DHTID.generate(source='unknown_key').to_bytes(),
                        subkey=DHTProtocol.IS_REGULAR_VALUE,
                        value=DHTProtocol.serializer.dumps(777),
                        expiration_time=hivemind.get_dht_time() + 10)
@@ -77,17 +77,17 @@ def test_dht_add_validators(validators_for_app):
     # After starting the process, other apps may add new validators to the existing DHT
     dht.add_validators(validators_for_app['B'])
 
-    assert dht.store(b'field_a', b'bytes_value', hivemind.get_dht_time() + 10)
-    assert dht.get(b'field_a', latest=True).value == b'bytes_value'
+    assert dht.store('field_a', b'bytes_value', hivemind.get_dht_time() + 10)
+    assert dht.get('field_a', latest=True).value == b'bytes_value'
 
-    assert not dht.store(b'field_a', 666, hivemind.get_dht_time() + 10)
-    assert dht.get(b'field_a', latest=True).value == b'bytes_value'
+    assert not dht.store('field_a', 666, hivemind.get_dht_time() + 10)
+    assert dht.get('field_a', latest=True).value == b'bytes_value'
 
     local_public_key = validators_for_app['A'][0].local_public_key
-    assert dht.store(b'field_b', 777, hivemind.get_dht_time() + 10, subkey=local_public_key)
-    dictionary = dht.get(b'field_b', latest=True).value
+    assert dht.store('field_b', 777, hivemind.get_dht_time() + 10, subkey=local_public_key)
+    dictionary = dht.get('field_b', latest=True).value
     assert (len(dictionary) == 1 and
             dictionary[local_public_key].value == 777)
 
-    assert not dht.store(b'unknown_key', 666, hivemind.get_dht_time() + 10)
-    assert dht.get(b'unknown_key', latest=True) is None
+    assert not dht.store('unknown_key', 666, hivemind.get_dht_time() + 10)
+    assert dht.get('unknown_key', latest=True) is None

--- a/tests/test_dht_validation.py
+++ b/tests/test_dht_validation.py
@@ -40,9 +40,9 @@ def test_composite_validator(validators_for_app):
         [SchemaValidator, RSASignatureValidator])
     assert len(validator._validators[0]._schemas) == 2
 
-    public_key = validators_for_app['A'][0].ownership_marker
+    local_public_key = validators_for_app['A'][0].local_public_key
     record = DHTRecord(key=DHTID.generate(source=b'field_b').to_bytes(),
-                       subkey=DHTProtocol.serializer.dumps(public_key),
+                       subkey=DHTProtocol.serializer.dumps(local_public_key),
                        value=DHTProtocol.serializer.dumps(777),
                        expiration_time=hivemind.get_dht_time() + 10)
 
@@ -83,11 +83,11 @@ def test_dht_add_validators(validators_for_app):
     assert not dht.store(b'field_a', 666, hivemind.get_dht_time() + 10)
     assert dht.get(b'field_a', latest=True).value == b'bytes_value'
 
-    public_key = validators_for_app['A'][0].ownership_marker
-    assert dht.store(b'field_b', 777, hivemind.get_dht_time() + 10, subkey=public_key)
+    local_public_key = validators_for_app['A'][0].local_public_key
+    assert dht.store(b'field_b', 777, hivemind.get_dht_time() + 10, subkey=local_public_key)
     dictionary = dht.get(b'field_b', latest=True).value
     assert (len(dictionary) == 1 and
-            dictionary[public_key].value == 777)
+            dictionary[local_public_key].value == 777)
 
     assert not dht.store(b'unknown_key', 666, hivemind.get_dht_time() + 10)
     assert dht.get(b'unknown_key', latest=True) is None


### PR DESCRIPTION
This PR follows #219 and implements:

1. Validating DHT schema for training progress and metrics
2. Signing the training progress and the metrics (so a peer can't change the stats of someone else)
3. Using the local public key as a replacement for the peer's UUID
4. Using type-validated data structures for the stats in the code instead of plain lists

I have tested the following:

1. Training (`run_first_peer.py` and `run_trainer.py`) works without errors.
2. When connecting to the DHT from the Python interactive console, the DHT does not accept progress/metrics records that:
    - Doesn't match the schema.
    - Doesn't have a signature or have an invalid one.

Along the way, it improves the validator system:

1. Makes `RSASignatureValidator` and `SchemaValidator` picklable because their instances may be sent to the DHT in another process (this happens when we add validators to the existing DHT process after its creation).
1. Implements caching of the private key while creating `RSASignatureValidator`, so it is not generated again for each DHT-using entity inside one process (saves time because the generation takes ~100 ms).
1. Implements the `BytesWithPublicKey` type for DHT schemas.
1. Adds `prefix` parameter to `SchemaValidator` (if present, adds `prefix + '_'` to all field names) and moves them from the `bytes` to `str` keys (since the rest of code uses `str` keys).
1. Refactors `RSASignatureValidator` (e.g. better naming like `signature_validator.ownership_marker` -> `signature_validator.local_public_key`).