### PR TITLE
Fix random freezes in averager.step, improve error handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
           name: setup
       - run:
           command: pytest ./tests
-          no_output_timeout: 30m
           name: tests
   build-and-test-py38:
     docker:
@@ -41,7 +40,6 @@ jobs:
           name: setup
       - run:
           command: pytest ./tests
-          no_output_timeout: 30m
           name: tests
   build-and-test-py39:
     docker:
@@ -62,7 +60,6 @@ jobs:
           name: setup
       - run:
           command: pytest ./tests
-          no_output_timeout: 30m
           name: tests
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
           name: setup
       - run:
           command: pytest ./tests
+          no_output_timeout: 30m
           name: tests
   build-and-test-py38:
     docker:
@@ -40,6 +41,7 @@ jobs:
           name: setup
       - run:
           command: pytest ./tests
+          no_output_timeout: 30m
           name: tests
   build-and-test-py39:
     docker:
@@ -60,6 +62,7 @@ jobs:
           name: setup
       - run:
           command: pytest ./tests
+          no_output_timeout: 30m
           name: tests
 
 workflows:

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -158,7 +158,11 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
         return f"{self.__class__.__name__}({self.endpoint})"
 
     def run(self):
-        """ DAED HELL SALAD """
+        """
+        Run averager function in a background thread; this is needed to avoid a heisenbug with broken OMP on fork
+        Turns out, using a non-main thread creates a separate OMP pool that works even if the original pool is corrupted
+        Read more: https://github.com/pytorch/pytorch/issues/17199
+        """
         thread = threading.Thread(target=self._run_internal, daemon=True)
         thread.start()
         thread.join()

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -276,7 +276,7 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
                         future.set_exception(e)
                     else:
                         logger.warning(f"Averager caught {repr(e)}, retrying")
-                        raise e
+
                 finally:
                     _ = self._running_groups.pop(group_id, None)
                     self._pending_group_assembled.set()

--- a/hivemind/client/averaging/matchmaking.py
+++ b/hivemind/client/averaging/matchmaking.py
@@ -10,7 +10,7 @@ import concurrent.futures
 import asyncio
 
 import grpc
-from grpc._cython.cygrpc import InternalError
+import grpc._cython.cygrpc
 
 from hivemind.client.averaging.group_info import GroupInfo
 from hivemind.client.averaging.key_manager import GroupKeyManager, GroupKey
@@ -200,7 +200,7 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
             if call is not None:
                 call.cancel()
             return None
-        except (grpc.RpcError, grpc.aio.AioRpcError, InternalError, StopAsyncIteration) as e:
+        except (grpc.RpcError, grpc.aio.AioRpcError, grpc._cython.cygrpc.InternalError, StopAsyncIteration) as e:
             logger.warning(f"{self} - failed to request potential leader {leader}: {e}")
             return None
 

--- a/hivemind/client/averaging/matchmaking.py
+++ b/hivemind/client/averaging/matchmaking.py
@@ -10,6 +10,7 @@ import concurrent.futures
 import asyncio
 
 import grpc
+from grpc._cython.cygrpc import InternalError
 
 from hivemind.client.averaging.group_info import GroupInfo
 from hivemind.client.averaging.key_manager import GroupKeyManager, GroupKey
@@ -199,6 +200,10 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
             if call is not None:
                 call.cancel()
             return None
+        except (grpc.RpcError, grpc.aio.AioRpcError, InternalError, StopAsyncIteration) as e:
+            logger.warning(f"{self} - failed to request potential leader {leader}: {e}")
+            return None
+
         finally:
             self.was_accepted_to_group.clear()
             self.current_leader = None

--- a/hivemind/client/averaging/matchmaking.py
+++ b/hivemind/client/averaging/matchmaking.py
@@ -201,7 +201,7 @@ class Matchmaking(averaging_pb2_grpc.DecentralizedAveragingServicer):
                 call.cancel()
             return None
         except (grpc.RpcError, grpc.aio.AioRpcError, grpc._cython.cygrpc.InternalError, StopAsyncIteration) as e:
-            logger.warning(f"{self} - failed to request potential leader {leader}: {e}")
+            logger.error(f"{self} - failed to request potential leader {leader}: {e}")
             return None
 
         finally:


### PR DESCRIPTION
This patch introduces three changes:
- [x] fix a heisenbug where `DecentralizedAverager` would randomly hang on pytorch ops: https://github.com/pytorch/pytorch/issues/17199
- [x] tweak "sanity check failed" clause in `DecentralizedAverager._step` so that it is no longer triggered by sanctioned retries
- [x] tweak `Matchmaking.request_join_group` to handle RPC errors instead of cancelling the entire matchmaking