### PR TITLE
Improve error handling, remove deprecated functionality

### DIFF
--- a/benchmarks/benchmark_dht.py
+++ b/benchmarks/benchmark_dht.py
@@ -25,7 +25,7 @@ def benchmark_dht(num_peers: int, initial_peers: int, num_experts: int, expert_b
     for _ in trange(num_peers):
         neighbors = [f'0.0.0.0:{node.port}' for node in random.sample(peers, min(initial_peers, len(peers)))]
         peer = hivemind.DHT(initial_peers=neighbors, start=True, wait_timeout=wait_timeout,
-                            expiration=expiration, listen_on=f'0.0.0.0:*')
+                            listen_on=f'0.0.0.0:*')
         peers.append(peer)
 
     store_peer, get_peer = peers[-2:]
@@ -43,7 +43,8 @@ def benchmark_dht(num_peers: int, initial_peers: int, num_experts: int, expert_b
     for start in trange(0, num_experts, expert_batch_size):
         store_start = time.perf_counter()
         endpoints.append(random_endpoint())
-        store_ok = hivemind.declare_experts(store_peer, expert_uids[start: start + expert_batch_size], endpoints[-1])
+        store_ok = hivemind.declare_experts(store_peer, expert_uids[start: start + expert_batch_size], endpoints[-1],
+                                            expiration=expiration)
         successes = store_ok.values()
         total_store_time += time.perf_counter() - store_start
 

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -154,7 +154,7 @@ dht = hivemind.DHT(initial_peers=["localhost:1338"], listen=False, start=True)
 # note: listen=False means that your peer will operate in "client only" mode: 
 # this means that it can request other peers, but will not accept requests in return 
 
-expert1, expert4 = dht.get_experts(["expert.1", "expert.4"])
+expert1, expert4 = hivemind.get_experts(dht, ["expert.1", "expert.4"])
 assert expert1 is not None and expert4 is not None, "server hasn't declared experts (yet?)"
 ```
 

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -464,7 +464,7 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
 
         finally:
             if not future.done():
-                logger.warning("Averager could not load state from peers: all peers failed.")
+                logger.warning("Averager could not load state from peers: all requests have failed.")
                 future.set_result(None)
 
     def get_group_bits(self, wait: bool = True):

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -457,7 +457,7 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
                         self.last_updated = get_dht_time()
                         return
                     except BaseException as e:
-                        logger.warning(f"Failed to download state from {peer} - {repr(e)}")
+                        logger.exception(f"Failed to download state from {peer} - {repr(e)}")
                     finally:
                         if stream is not None:
                             await stream.code()

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -452,6 +452,7 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
                             current_tensor_parts.append(message.tensor_part)
                         if current_tensor_parts:
                             tensors.append(deserialize_torch_tensor(combine_from_streaming(current_tensor_parts)))
+                        logger.info(f"Finished downloading state from {peer}")
                         future.set_result((metadata, tensors))
                         self.last_updated = get_dht_time()
                         return
@@ -463,7 +464,7 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
 
         finally:
             if not future.done():
-                logger.warning("Averager could not load state from peers: all attempts failed.")
+                logger.warning("Averager could not load state from peers: all peers failed.")
                 future.set_result(None)
 
     def get_group_bits(self, wait: bool = True):

--- a/hivemind/client/averaging/__init__.py
+++ b/hivemind/client/averaging/__init__.py
@@ -183,7 +183,7 @@ class DecentralizedAverager(mp.Process, averaging_pb2_grpc.DecentralizedAveragin
                     self._port.value = found_port
                     await server.start()
                 else:
-                    logger.info(f"The averager running in an experimental client mode, please report any bugs.")
+                    logger.debug(f"The averager is running in client mode.")
 
                 self._matchmaking = Matchmaking(self.endpoint, self.schema_hash, self.dht, **self.matchmaking_kwargs,
                                                 client_mode=not self.listen)

--- a/hivemind/client/beam_search.py
+++ b/hivemind/client/beam_search.py
@@ -22,7 +22,7 @@ class MoEBeamSearcher:
         * optional prefix that determines expert role, experiment name, etc.
         * one or more integers that determine that expert's position in an N-dimensional grid
 
-    A hivemind.Server can ``DHT.declare_experts(expert_uids: List[str])`` to make its experts visible to everyone.
+    A hivemind.Server can ``declare_experts(dht, expert_uids: List[str])`` to make its experts visible to everyone.
     When declaring experts, DHT will store each expert's uid and all its prefixes until :expiration: (specified at init)
     For instance, declaring "ffn_expert.98.76.54.32.10" will store the following keys in a DHT:
     ``"ffn_expert.98", "ffn_expert.98.76", "ffn_expert.98.76.54", ..., "ffn_expert.98.76.54.32.10"``

--- a/hivemind/dht/__init__.py
+++ b/hivemind/dht/__init__.py
@@ -257,12 +257,3 @@ class DHT(mp.Process):
         else:
             future.set_exception(ValueError(f"Can't get address: DHT node has no peers and no public endpoint."
                                             f" Please ensure the node is connected or specify peers=... manually."))
-
-    def declare_experts(self, uids, endpoint, wait: bool = True):
-        logger.warning("dht.declare_experts is scheduled for removal in 0.9.8, please use hivemind.declare_experts.")
-        return hivemind.declare_experts(self, uids, endpoint, wait=wait)
-
-    def get_experts(self, uids, expiration_time: Optional[DHTExpiration] = None,
-                    return_future: bool = False) -> List[Optional[RemoteExpert]]:
-        logger.warning("dht.get_experts is scheduled for removal in 0.9.8, please use hivemind.get_experts.")
-        return hivemind.get_experts(self, uids, expiration_time, return_future)

--- a/hivemind/dht/__init__.py
+++ b/hivemind/dht/__init__.py
@@ -51,13 +51,11 @@ class DHT(mp.Process):
 
     def __init__(self, listen_on: Endpoint = "0.0.0.0:*", initial_peers: Sequence[Endpoint] = (), *, start: bool,
                  daemon: bool = True, max_workers: Optional[int] = None, parallel_rpc: Optional[int] = None,
-                 expiration: float = 300, record_validators: Iterable[RecordValidatorBase] = (),
-                 **kwargs):
+                 record_validators: Iterable[RecordValidatorBase] = (), **kwargs):
         super().__init__()
         assert not isinstance(initial_peers, str), "please specify a list/tuple of initial peers (even if there's one)"
         self.listen_on, self.initial_peers, self.kwargs = listen_on, initial_peers, kwargs
         self.max_workers, self.parallel_rpc = max_workers, parallel_rpc
-        self.default_expiration = expiration
         self._record_validator = CompositeValidator(record_validators)
         self._port = mp.Value(ctypes.c_int32, 0)  # initialized after dht starts
         self._pipe, self.pipe = mp.Pipe(duplex=True)

--- a/hivemind/server/__init__.py
+++ b/hivemind/server/__init__.py
@@ -261,7 +261,7 @@ class Server(threading.Thread):
             self.dht.join()
 
         logger.debug(f"Shutting down runtime")
-        self.runtime.stop.set()
+        self.runtime.shutdown()
         logger.info("Server shutdown succesfully")
 
 

--- a/hivemind/server/__init__.py
+++ b/hivemind/server/__init__.py
@@ -67,7 +67,7 @@ class Server(threading.Thread):
 
         if self.dht and self.experts:
             self.dht_handler_thread = DHTHandlerThread(experts=self.experts, dht=self.dht, endpoint=self.listen_on,
-                                                       update_period=self.update_period)
+                                                       update_period=self.update_period, daemon=True)
 
         if start:
             self.run_in_background(await_ready=True)

--- a/hivemind/server/__init__.py
+++ b/hivemind/server/__init__.py
@@ -261,6 +261,7 @@ class Server(threading.Thread):
             self.dht.join()
 
         logger.debug(f"Shutting down runtime")
+
         self.runtime.shutdown()
         logger.info("Server shutdown succesfully")
 

--- a/hivemind/server/dht_handler.py
+++ b/hivemind/server/dht_handler.py
@@ -10,8 +10,8 @@ from hivemind.utils import Endpoint, get_dht_time, get_port
 
 
 class DHTHandlerThread(threading.Thread):
-    def __init__(self, experts, dht: DHT, endpoint: Endpoint, update_period: int = 5):
-        super().__init__()
+    def __init__(self, experts, dht: DHT, endpoint: Endpoint, update_period: int = 5, **kwargs):
+        super().__init__(**kwargs)
         assert get_port(endpoint) is not None
         self.endpoint = endpoint
         self.experts = experts

--- a/hivemind/server/expert_uid.py
+++ b/hivemind/server/expert_uid.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import random
 import re
 from typing import NamedTuple, Union, Tuple, Optional, List

--- a/hivemind/server/expert_uid.py
+++ b/hivemind/server/expert_uid.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
 import random
 import re
 from typing import NamedTuple, Union, Tuple, Optional, List
 
+import hivemind
 from hivemind.dht import DHT
 from hivemind.utils import Endpoint, get_logger
 
@@ -81,7 +83,7 @@ def generate_uids_from_pattern(num_experts: int, expert_pattern: Optional[str], 
 
         # 2. look into DHT (if given) and remove duplicates
         if dht:
-            existing_expert_uids = {found_expert.uid for found_expert in dht.get_experts(new_uids)
+            existing_expert_uids = {found_expert.uid for found_expert in hivemind.get_experts(dht, new_uids)
                                     if found_expert is not None}
             new_uids = [new_uid for new_uid in new_uids if new_uid not in existing_expert_uids]
 

--- a/hivemind/server/runtime.py
+++ b/hivemind/server/runtime.py
@@ -92,12 +92,13 @@ class Runtime(threading.Thread):
     def shutdown(self):
         """ Gracefully terminate a running runtime. """
         logger.info("Shutting down")
+        self.ready.clear()
 
         if self.stats_report_interval is not None:
             self.stats_reporter.stop.set()
             self.stats_reporter.join()
 
-        # self.shutdown_send.send(self.SHUTDOWN_TRIGGER)  # trigger background thread to shutdown
+        self.shutdown_send.send(self.SHUTDOWN_TRIGGER)  # trigger background thread to shutdown
 
         logger.debug("Terminating pools")
         for pool in self.pools:

--- a/hivemind/server/task_pool.py
+++ b/hivemind/server/task_pool.py
@@ -173,6 +173,7 @@ class TaskPool(TaskPoolBase):
             batch_inputs = [inp.detach().requires_grad_(inp.requires_grad).share_memory_() for inp in batch_inputs]
 
             logger.debug(f"{self.name}, batch {batch_index}: sending to runtime")
+            print(f"{self.name}, batch {batch_index}: sending to runtime")
             self.batch_sender.send((batch_index, batch_inputs))
             logger.debug(f"{self.name}, batch {batch_index}: sent to runtime")
             prev_num_tasks = len(batch_tasks)

--- a/hivemind/server/task_pool.py
+++ b/hivemind/server/task_pool.py
@@ -173,7 +173,6 @@ class TaskPool(TaskPoolBase):
             batch_inputs = [inp.detach().requires_grad_(inp.requires_grad).share_memory_() for inp in batch_inputs]
 
             logger.debug(f"{self.name}, batch {batch_index}: sending to runtime")
-            print(f"{self.name}, batch {batch_index}: sending to runtime")
             self.batch_sender.send((batch_index, batch_inputs))
             logger.debug(f"{self.name}, batch {batch_index}: sent to runtime")
             prev_num_tasks = len(batch_tasks)

--- a/hivemind/server/task_pool.py
+++ b/hivemind/server/task_pool.py
@@ -136,7 +136,7 @@ class TaskPool(TaskPoolBase):
         pending_batches = {}  # Dict[batch uuid, List[MPFuture]] for each batch currently in runtime
 
         output_thread = threading.Thread(target=self._pool_output_loop, args=[pending_batches],
-                                         name=f'{self.name}_output')
+                                         name=f'{self.name}_output', daemon=True)
 
         try:
             output_thread.start()

--- a/hivemind/utils/timed_storage.py
+++ b/hivemind/utils/timed_storage.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 KeyType = TypeVar('KeyType')
 ValueType = TypeVar('ValueType')
 get_dht_time = time.time  # a global (weakly synchronized) time
-MAX_DHT_TIME_DISCREPANCY_SECONDS = 3  # max allowed difference between get_dht_time for two DHT nodes.
+MAX_DHT_TIME_DISCREPANCY_SECONDS = 3  # max allowed difference between get_dht_time for two DHT nodes
 DHTExpiration = float
 ROOT = 0
 

--- a/hivemind/utils/timed_storage.py
+++ b/hivemind/utils/timed_storage.py
@@ -13,6 +13,7 @@ MAX_DHT_TIME_DISCREPANCY_SECONDS = 3  # max allowed difference between get_dht_t
 DHTExpiration = float
 ROOT = 0
 
+
 @dataclass(init=True, repr=True, frozen=True)
 class ValueWithExpiration(Generic[ValueType]):
     value: ValueType
@@ -37,10 +38,12 @@ class ValueWithExpiration(Generic[ValueType]):
         else:
             return False
 
+
 @dataclass(init=True, repr=True, order=True, frozen=True)
 class HeapEntry(Generic[KeyType]):
     expiration_time: DHTExpiration
     key: KeyType
+
 
 class TimedStorage(Generic[KeyType, ValueType]):
     """ A dictionary that maintains up to :maxsize: key-value-expiration tuples until their expiration_time """

--- a/hivemind/utils/timed_storage.py
+++ b/hivemind/utils/timed_storage.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 KeyType = TypeVar('KeyType')
 ValueType = TypeVar('ValueType')
 get_dht_time = time.time  # a global (weakly synchronized) time
-MAX_DHT_TIME_DISCREPANCY_SECONDS = 3  # max allowed difference between get_dht_time for two DHT nodes. Enforced when joining DHT.(TODO)
+MAX_DHT_TIME_DISCREPANCY_SECONDS = 3  # max allowed difference between get_dht_time for two DHT nodes.
 DHTExpiration = float
 ROOT = 0
 

--- a/tests/test_dht_experts.py
+++ b/tests/test_dht_experts.py
@@ -46,7 +46,7 @@ def test_beam_search(dht_size=20, total_experts=128, batch_size=32, initial_peer
     dht = []
     for i in range(dht_size):
         neighbors_i = [f'{LOCALHOST}:{node.port}' for node in random.sample(dht, min(initial_peers, len(dht)))]
-        dht.append(hivemind.DHT(start=True, expiration=999999, initial_peers=neighbors_i, parallel_rpc=parallel_rpc))
+        dht.append(hivemind.DHT(start=True, initial_peers=neighbors_i, parallel_rpc=parallel_rpc))
 
     real_experts = sorted({
         'expert.' + '.'.join([str(random.randint(0, dim - 1)) for dim in grid_dims])
@@ -57,7 +57,7 @@ def test_beam_search(dht_size=20, total_experts=128, batch_size=32, initial_peer
                         endpoint=f"host{batch_start // batch_size}:{random.randint(0, 65536)}")
 
     neighbors_i = [f'{LOCALHOST}:{node.port}' for node in random.sample(dht, min(initial_peers, len(dht)))]
-    you = hivemind.DHT(start=True, expiration=999999, initial_peers=neighbors_i, parallel_rpc=parallel_rpc)
+    you = hivemind.DHT(start=True, initial_peers=neighbors_i, parallel_rpc=parallel_rpc)
     beam_search = MoEBeamSearcher(you, 'expert.', grid_dims)
 
     for i in range(10):
@@ -75,7 +75,7 @@ def test_beam_search(dht_size=20, total_experts=128, batch_size=32, initial_peer
 
 @pytest.mark.forked
 def test_dht_single_node():
-    node = hivemind.DHT(start=True, expiration=999)
+    node = hivemind.DHT(start=True)
     beam_search = MoEBeamSearcher(node, 'expert.', grid_size=(10,))
 
     assert all(declare_experts(node, ['expert.1', 'expert.2', 'expert.3'], f"{hivemind.LOCALHOST}:1337").values())

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -120,7 +120,7 @@ def test_remote_module_call(hidden_dim=16):
 def test_beam_search_correctness():
     all_expert_uids = [f'ffn.{5 + i}.{10 + j}.{15 + k}' for i in range(10) for j in range(10) for k in range(10)]
     dht = hivemind.DHT(start=True, expiration=999)
-    assert all(dht.declare_experts(all_expert_uids, endpoint='fake-endpoint'))
+    assert all(hivemind.declare_experts(dht, all_expert_uids, endpoint='fake-endpoint'))
 
     dmoe = hivemind.RemoteMixtureOfExperts(
         in_features=32, grid_size=(32, 32, 32), dht=dht, k_best=4, uid_prefix='ffn.')

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -15,7 +15,7 @@ def test_moe():
                        for _ in range(10)]
     with background_server(expert_uids=all_expert_uids, device='cpu', expert_cls='ffn', num_handlers=1,
                            hidden_dim=16) as (server_endpoint, dht_endpoint):
-        dht = hivemind.DHT(start=True, expiration=999, initial_peers=[dht_endpoint])
+        dht = hivemind.DHT(start=True, initial_peers=[dht_endpoint])
 
         dmoe = hivemind.RemoteMixtureOfExperts(
             in_features=16, grid_size=(4, 4, 4), dht=dht, k_best=3, uid_prefix='ffn.')
@@ -31,7 +31,7 @@ def test_no_experts():
                        for _ in range(10)]
     with background_server(expert_uids=all_expert_uids, device='cpu', expert_cls='nop_delay', num_handlers=1,
                            hidden_dim=16) as (server_endpoint, dht_endpoint):
-        dht = hivemind.DHT(start=True, expiration=999, initial_peers=[dht_endpoint])
+        dht = hivemind.DHT(start=True, initial_peers=[dht_endpoint])
 
         dmoe = hivemind.RemoteSwitchMixtureOfExperts(
             in_features=16, grid_size=(4, 4, 4), dht=dht, uid_prefix='expert.', forward_timeout=0.1,
@@ -119,7 +119,7 @@ def test_remote_module_call(hidden_dim=16):
 @pytest.mark.forked
 def test_beam_search_correctness():
     all_expert_uids = [f'ffn.{5 + i}.{10 + j}.{15 + k}' for i in range(10) for j in range(10) for k in range(10)]
-    dht = hivemind.DHT(start=True, expiration=999)
+    dht = hivemind.DHT(start=True)
     assert all(hivemind.declare_experts(dht, all_expert_uids, endpoint='fake-endpoint'))
 
     dmoe = hivemind.RemoteMixtureOfExperts(
@@ -208,7 +208,7 @@ def test_client_anomaly_detection():
 
     experts['expert.3'].expert.ffn.weight.data[0, 0] = float('nan')
 
-    dht = hivemind.DHT(start=True, expiration=999)
+    dht = hivemind.DHT(start=True)
     server = hivemind.Server(dht, experts, num_connection_handlers=1)
     server.start()
     try:

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -48,7 +48,7 @@ def test_moe_training(max_steps: int = 100, threshold: float = 0.9, num_experts=
     all_expert_uids = [f'expert.{i}' for i in range(num_experts)]
     with background_server(expert_uids=all_expert_uids, device='cpu', optim_cls=SGD, hidden_dim=64, num_handlers=1) \
             as (server_endpoint, dht_endpoint):
-        dht = DHT(start=True, expiration=999, initial_peers=[dht_endpoint])
+        dht = DHT(start=True, initial_peers=[dht_endpoint])
 
         moe = RemoteMixtureOfExperts(in_features=64, grid_size=(num_experts,), dht=dht, uid_prefix='expert.', k_best=2)
         model = nn.Sequential(moe, nn.Linear(64, 2))
@@ -91,7 +91,7 @@ def test_switch_training(max_steps: int = 10, threshold: float = 0.9, num_expert
     all_expert_uids = [f'expert.{i}' for i in range(num_experts)]
     with background_server(expert_uids=all_expert_uids, device='cpu', optim_cls=SGD, hidden_dim=64,
                            num_handlers=1) as (server_endpoint, dht_endpoint):
-        dht = DHT(start=True, expiration=999, initial_peers=[dht_endpoint])
+        dht = DHT(start=True, initial_peers=[dht_endpoint])
 
         model = SwitchNetwork(dht, 64, 2, num_experts)
         opt = SGD(model.parameters(), lr=0.05)


### PR DESCRIPTION
- [x] modified .load_state_from_peers to handle network errors and ensure mpfuture is always set
- [x] removed dht.get/declare_experts from library, tests, benchmarks and examples
- [x] removed default `expiration=...` parameter in hivemind.DHT
- [x] removed stale TODOs and notifications
- [x] rollback Runtime.stop to a shutdown pipe -> server no longer hangs on shutdown (also: repaired benchmark_throughput)




__Note on `Runtime.stop`:__ the reason it didn't work was that when you trigger the server to shut down, it was usually awaiting for one of the pools in the selector ([source](https://github.com/learning-at-home/hivemind/blob/master/hivemind/server/runtime.py#L119)). Since new samples would never come, selector would never get triggered, the loop would never check on `self.stop` and server would be left in a deadlock.

For the same reason, `benchmark_throughput` would hang before printing results since #256 .

__Note 2:__ other applications of `.stop` work correctly because they do not await anything inside of `while self.stop.wait(...)` loop.



__master:__ (killed after hanging for several minutes)
![image](https://user-images.githubusercontent.com/3491902/117922853-c1081580-b2fb-11eb-9bce-5c222ebe1571.png)


__after patch:__
![image](https://user-images.githubusercontent.com/3491902/117922878-cf563180-b2fb-11eb-9baf-947ba7f1b1c2.png)

