### PR TITLE
Disable p2pd compilation by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           paths:
             - '~/.cache/pip'
       - run:
-          command: pip install -e .
+          command: pip install -e . --install-option="--buildgo"
           name: setup
       - run:
           command: pytest ./tests
@@ -50,7 +50,7 @@ jobs:
           paths:
             - '~/.cache/pip'
       - run:
-          command: pip install -e .
+          command: pip install -e . --install-option="--buildgo"
           name: setup
       - run:
           command: pytest ./tests
@@ -74,7 +74,7 @@ jobs:
           paths:
             - '~/.cache/pip'
       - run:
-          command: pip install -e .
+          command: pip install -e . --install-option="--buildgo"
           name: setup
       - run:
           command: pytest ./tests

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ class Install(install):
 
 
 class Develop(develop):
-    user_options = install.user_options + [('buildgo', None, None)]
+    user_options = develop.user_options + [('buildgo', None, None)]
 
     def initialize_options(self):
         super().initialize_options()

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def libp2p_download_install():
 
 
 class Install(install):
-    user_options = install.user_options + [('buildgo', None, None)]
+    user_options = install.user_options + [('buildgo', None, "Builds p2pd from source")]
 
     def initialize_options(self):
         super().initialize_options()

--- a/setup.py
+++ b/setup.py
@@ -92,9 +92,6 @@ class Install(install):
         super().initialize_options()
         self.buildgo = False
 
-    def finalize_options(self):
-        super().finalize_options()
-
     def run(self):
         if self.buildgo:
             libp2p_build_install()
@@ -110,9 +107,6 @@ class Develop(develop):
     def initialize_options(self):
         super().initialize_options()
         self.buildgo = False
-
-    def finalize_options(self):
-        super().finalize_options()
 
     def run(self):
         if self.buildgo:


### PR DESCRIPTION
After these changes, both `pip install hivemind` and `pip install -e hivemind` will use precompiled binary p2pd, and will not require Go installation.
To run with building it from source, one should use `pip install hivemind --install-option="--buildgo"` (with `-e`, optionally).

Also, fixes a minor bug with the exception in case of no Go installed.