### PR TITLE
Update P2PD MD5 checksum

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools.command.develop import develop
 from setuptools.command.install import install
 
 P2PD_VERSION = 'v0.3.1'
-P2PD_CHECKSUM = '8810097959db720208cdc9f2945804a4'
+P2PD_CHECKSUM = '15292b880c6b31f5b3c36084b3acc17f'
 LIBP2P_TAR_URL = f'https://github.com/learning-at-home/go-libp2p-daemon/archive/refs/tags/{P2PD_VERSION}.tar.gz'
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
The [P2PD binary](https://github.com/learning-at-home/go-libp2p-daemon/releases/tag/v0.3.1) is now statically linked to avoid glibc compatibility issues, so the MD5 checksum has changed. Thus, we should update it the setup file.