### PR TITLE
Remove use of packaging module to avoid installation errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ multiaddr>=0.0.9
 pymultihash>=0.8.2
 cryptography>=3.4.6
 pydantic>=1.8.1
-packaging>=20.9

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ import tarfile
 import tempfile
 import urllib.request
 
-from packaging import version
-from pkg_resources import parse_requirements
+from pkg_resources import parse_requirements, parse_version
 from setuptools import find_packages, setup
 from setuptools.command.develop import develop
 from setuptools.command.install import install
@@ -55,7 +54,7 @@ def libp2p_build_install():
 
     if m is None:
         raise FileNotFoundError('Could not find golang installation')
-    if version.parse(m.group(1)) < version.parse("1.13"):
+    if parse_version(m.group(1)) < parse_version("1.13"):
         raise EnvironmentError(f'Newer version of go required: must be >= 1.13, found {version}')
 
     with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
Currently, `setup.py` uses `packaging` module to parse Golang versions. This leads to errors in case of installing hivemind to a clean Python installation, since `packaging` is not a part of `setuptools` and is not installed by default.

#269 attempted to fix that, however this fix has no effect since the `packaging` module is imported in the beginning of `setup.py` before `requirements.txt` is even parsed.

The problem can be easily reproduced by creating a new virtualenv environment and trying to install hivemind inside it with `pip install -e .[dev]`.

This PR solves the problem by removing the usage of the `packaging` module completely.