### PR TITLE
Add p2pd to package_data

### DIFF
--- a/hivemind/__init__.py
+++ b/hivemind/__init__.py
@@ -5,4 +5,4 @@ from hivemind.server import *
 from hivemind.utils import *
 from hivemind.optim import *
 
-__version__ = '0.9.9'
+__version__ = "0.9.9.post1"

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setup(
     author_email='mryabinin0@gmail.com',
     url="https://github.com/learning-at-home/hivemind",
     packages=find_packages(exclude=['tests']),
-    package_data={'hivemind': ['proto/*']},
+    package_data={'hivemind': ['proto/*', 'hivemind_cli/*']},
     include_package_data=True,
     license='MIT',
     setup_requires=['grpcio-tools'],


### PR DESCRIPTION
Previously, we did not include compiled p2pd in the built version of hivemind; as a result, wheels published to PyPI do not contain the installation of p2pd. This PR ensures that the installation includes p2pd by adding it (and other contents of hivemind_cli) to package_data. The following commands succeed now:

```
$ pip install -U --extra-index-url https://pypi.org/simple -i https://test.pypi.org/simple/ hivemind==0.9.9.post1
Looking in indexes: https://test.pypi.org/simple/, https://pypi.org/simple
Collecting hivemind==0.9.9.post1
  Downloading https://test-files.pythonhosted.org/packages/ba/3f/d44dd71843717a51784048c3de86a5fc047e5ad5823c4e0800a4d8b6057b/hivemind-0.9.9.post1-py3-none-any.whl (14.3 MB)
     |████████████████████████████████| 14.3 MB 6.6 MB/s
[omitted for brevity]
Installing collected packages: hivemind
  Attempting uninstall: hivemind
    Found existing installation: hivemind 0.9.9
    Uninstalling hivemind-0.9.9:
      Successfully uninstalled hivemind-0.9.9
Successfully installed hivemind-0.9.9.post1
$ python -m asyncio
asyncio REPL 3.8.8 (default, Feb 24 2021, 21:46:12)
[GCC 7.3.0] on linux
Use "await" directly instead of "asyncio.run()".
Type "help", "copyright", "credits" or "license" for more information.
>>> import asyncio
>>> import hivemind
>>> p2p=await hivemind.p2p.P2P.create()
Control socket: /ip4/127.0.0.1/tcp/42347
Peer ID: Qmexc5u96H7qt8WnXDxnKT3DDPkmtvRvVnRViaKCFcqr1p
Peer Addrs:
/ip4/172.27.77.70/udp/48885/quic
/ip4/127.0.0.1/udp/48885/quic
/ip4/172.27.77.70/tcp/48885
/ip4/127.0.0.1/tcp/48885
>>>
```