### PR TITLE
Implement protobuf-based stream handlers over libp2p backend

### DIFF
--- a/hivemind/dht/protocol.py
+++ b/hivemind/dht/protocol.py
@@ -7,7 +7,7 @@ from typing import Optional, List, Tuple, Dict, Sequence, Union, Collection
 from hivemind.dht.crypto import DHTRecord, RecordValidatorBase
 from hivemind.dht.routing import RoutingTable, DHTID, BinaryDHTValue, Subkey
 from hivemind.dht.storage import DHTLocalStorage, DictionaryDHTValue
-from hivemind.p2p import P2P, P2PContext, PeerID, Servicer
+from hivemind.p2p import P2P, P2PContext, PeerID, ServicerBase
 from hivemind.proto import dht_pb2
 from hivemind.utils import get_logger, MSGPackSerializer
 from hivemind.utils.auth import AuthRole, AuthRPCWrapper, AuthorizerBase
@@ -21,7 +21,7 @@ from hivemind.utils.timed_storage import (
 logger = get_logger(__name__)
 
 
-class DHTProtocol(Servicer):
+class DHTProtocol(ServicerBase):
     # fmt:off
     p2p: P2P
     node_id: DHTID; bucket_size: int; num_replicas: int; wait_timeout: float; node_info: dht_pb2.NodeInfo

--- a/hivemind/p2p/__init__.py
+++ b/hivemind/p2p/__init__.py
@@ -1,3 +1,3 @@
 from hivemind.p2p.p2p_daemon import P2P, P2PContext, P2PHandlerError
 from hivemind.p2p.p2p_daemon_bindings.datastructures import PeerID, PeerInfo
-from hivemind.p2p.servicer import Servicer
+from hivemind.p2p.servicer import ServicerBase, StubBase

--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -404,7 +404,7 @@ class P2P:
                 async for input in requests:
                     count += 1
                 if count != 1:
-                    raise ValueError(f'Got {count} requests for handler {name} instead of one')
+                    raise ValueError(f"Got {count} requests for handler {name} instead of one")
 
             output = handler(input, context)
 
@@ -448,7 +448,7 @@ class P2P:
             async for response in responses:
                 count += 1
             if count != 1:
-                raise ValueError(f'Got {count} responses from handler {name} instead of one')
+                raise ValueError(f"Got {count} responses from handler {name} instead of one")
             return response
 
         return _take_one_response()

--- a/hivemind/p2p/servicer.py
+++ b/hivemind/p2p/servicer.py
@@ -85,7 +85,7 @@ class ServicerBase:
                 if timeout is not None:
                     raise ValueError("Timeouts for handlers returning streams are not supported")
 
-                return self._p2p.call_unary_handler(
+                return self._p2p.call_protobuf_handler(
                     self._peer,
                     handler.handle_name,
                     in_value,
@@ -100,7 +100,7 @@ class ServicerBase:
                 self: StubBase, in_value: in_type, timeout: Optional[float] = None
             ) -> handler.response_type:
                 return await asyncio.wait_for(
-                    self._p2p.call_unary_handler(
+                    self._p2p.call_protobuf_handler(
                         self._peer,
                         handler.handle_name,
                         in_value,
@@ -116,7 +116,7 @@ class ServicerBase:
     async def add_p2p_handlers(self, p2p: P2P, wrapper: Any = None) -> None:
         servicer = self if wrapper is None else wrapper
         for handler in self._rpc_handlers:
-            await p2p.add_unary_handler(
+            await p2p.add_protobuf_handler(
                 handler.handle_name,
                 getattr(servicer, handler.method_name),
                 handler.request_type,

--- a/hivemind/p2p/servicer.py
+++ b/hivemind/p2p/servicer.py
@@ -62,8 +62,9 @@ class ServicerBase:
                 request_type, stream_input = self._strip_iterator_hint(request_type)
                 response_type, stream_output = self._strip_iterator_hint(response_type)
 
-                self._rpc_handlers.append(RPCHandler(
-                    method_name, handle_name, request_type, response_type, stream_input, stream_output))
+                self._rpc_handlers.append(
+                    RPCHandler(method_name, handle_name, request_type, response_type, stream_input, stream_output)
+                )
 
         self._stub_type = type(
             f"{class_name}Stub",
@@ -77,19 +78,35 @@ class ServicerBase:
 
         # This method will be added to a new Stub type (a subclass of StubBase)
         if handler.stream_output:
-            def caller(self: StubBase, in_value: in_type, timeout: None = None) -> AsyncIterator[handler.response_type]:
-                if timeout is not None:
-                    raise ValueError('Timeouts for handlers returning streams are not supported')
 
-                return self._p2p.call_unary_handler(self._peer, handler.handle_name, in_value, handler.response_type,
-                                                    stream_input=handler.stream_input, stream_output=True)
+            def caller(
+                self: StubBase, in_value: in_type, timeout: None = None
+            ) -> AsyncIterator[handler.response_type]:
+                if timeout is not None:
+                    raise ValueError("Timeouts for handlers returning streams are not supported")
+
+                return self._p2p.call_unary_handler(
+                    self._peer,
+                    handler.handle_name,
+                    in_value,
+                    handler.response_type,
+                    stream_input=handler.stream_input,
+                    stream_output=True,
+                )
+
         else:
+
             async def caller(
                 self: StubBase, in_value: in_type, timeout: Optional[float] = None
             ) -> handler.response_type:
                 return await asyncio.wait_for(
-                    self._p2p.call_unary_handler(self._peer, handler.handle_name, in_value, handler.response_type,
-                                                 stream_input=handler.stream_input),
+                    self._p2p.call_unary_handler(
+                        self._peer,
+                        handler.handle_name,
+                        in_value,
+                        handler.response_type,
+                        stream_input=handler.stream_input,
+                    ),
                     timeout=timeout,
                 )
 
@@ -112,7 +129,7 @@ class ServicerBase:
 
     @staticmethod
     def _strip_iterator_hint(hint: type) -> Tuple[type, bool]:
-        if hasattr(hint, '_name') and hint._name == 'AsyncIterator':
+        if hasattr(hint, "_name") and hint._name == "AsyncIterator":
             return hint.__args__[0], True
 
         return hint, False

--- a/hivemind/p2p/servicer.py
+++ b/hivemind/p2p/servicer.py
@@ -129,7 +129,7 @@ class ServicerBase:
 
     @staticmethod
     def _strip_iterator_hint(hint: type) -> Tuple[type, bool]:
-        if hasattr(hint, "_name") and hint._name == "AsyncIterator":
+        if hasattr(hint, "_name") and hint._name in ("AsyncIterator", "AsyncIterable"):
             return hint.__args__[0], True
 
         return hint, False

--- a/hivemind/proto/p2pd.proto
+++ b/hivemind/proto/p2pd.proto
@@ -162,5 +162,5 @@ message PSResponse {
 }
 
 message RPCError {
-  required string message = 1;
+  optional string message = 1;
 }

--- a/hivemind/proto/test.proto
+++ b/hivemind/proto/test.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+message TestRequest {
+    int32 number = 1;
+}
+
+message TestResponse {
+    int32 number = 1;
+}

--- a/tests/test_p2p_daemon.py
+++ b/tests/test_p2p_daemon.py
@@ -118,7 +118,9 @@ async def test_call_protobuf_handler(should_cancel, replicate, handle_name="hand
         await asyncio.sleep(0.25)
         assert handler_cancelled
     else:
-        actual_response = await client.call_protobuf_handler(server.id, handle_name, ping_request, dht_pb2.PingResponse)
+        actual_response = await client.call_protobuf_handler(
+            server.id, handle_name, ping_request, dht_pb2.PingResponse
+        )
         assert actual_response == expected_response
         assert not handler_cancelled
 

--- a/tests/test_p2p_daemon.py
+++ b/tests/test_p2p_daemon.py
@@ -109,7 +109,8 @@ async def test_call_unary_handler(should_cancel, replicate, handle_name="handle"
 
     if should_cancel:
         call_task = asyncio.create_task(
-            client.call_unary_handler(server.id, handle_name, ping_request, dht_pb2.PingResponse))
+            client.call_unary_handler(server.id, handle_name, ping_request, dht_pb2.PingResponse)
+        )
         await asyncio.sleep(0.25)
 
         call_task.cancel()

--- a/tests/test_p2p_servicer.py
+++ b/tests/test_p2p_servicer.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import AsyncIterable
+from typing import AsyncIterator
 
 import pytest
 
@@ -33,7 +33,7 @@ async def test_unary_unary(server_client):
 @pytest.mark.asyncio
 async def test_stream_unary(server_client):
     class ExampleServicer(ServicerBase):
-        async def rpc_sum(self, request: AsyncIterable[test_pb2.TestRequest], _: P2PContext) -> test_pb2.TestResponse:
+        async def rpc_sum(self, request: AsyncIterator[test_pb2.TestRequest], _: P2PContext) -> test_pb2.TestResponse:
             result = 0
             async for item in request:
                 result += item.number
@@ -44,7 +44,7 @@ async def test_stream_unary(server_client):
     await servicer.add_p2p_handlers(server)
     stub = servicer.get_stub(client, server.id)
 
-    async def generate_requests() -> AsyncIterable[test_pb2.TestRequest]:
+    async def generate_requests() -> AsyncIterator[test_pb2.TestRequest]:
         for i in range(10):
             yield test_pb2.TestRequest(number=i)
 
@@ -54,7 +54,7 @@ async def test_stream_unary(server_client):
 @pytest.mark.asyncio
 async def test_unary_stream(server_client):
     class ExampleServicer(ServicerBase):
-        async def rpc_count(self, request: test_pb2.TestRequest, _: P2PContext) -> AsyncIterable[test_pb2.TestResponse]:
+        async def rpc_count(self, request: test_pb2.TestRequest, _: P2PContext) -> AsyncIterator[test_pb2.TestResponse]:
             for i in range(request.number):
                 yield test_pb2.TestResponse(number=i)
 
@@ -73,8 +73,8 @@ async def test_unary_stream(server_client):
 @pytest.mark.asyncio
 async def test_stream_stream(server_client):
     class ExampleServicer(ServicerBase):
-        async def rpc_powers(self, request: AsyncIterable[test_pb2.TestRequest],
-                             _: P2PContext) -> AsyncIterable[test_pb2.TestResponse]:
+        async def rpc_powers(self, request: AsyncIterator[test_pb2.TestRequest],
+                             _: P2PContext) -> AsyncIterator[test_pb2.TestResponse]:
             async for item in request:
                 yield test_pb2.TestResponse(number=item.number ** 2)
                 yield test_pb2.TestResponse(number=item.number ** 3)
@@ -84,7 +84,7 @@ async def test_stream_stream(server_client):
     await servicer.add_p2p_handlers(server)
     stub = servicer.get_stub(client, server.id)
 
-    async def generate_requests() -> AsyncIterable[test_pb2.TestRequest]:
+    async def generate_requests() -> AsyncIterator[test_pb2.TestRequest]:
         for i in range(10):
             yield test_pb2.TestRequest(number=i)
 
@@ -105,7 +105,7 @@ async def test_unary_stream_cancel(server_client, cancel_reason):
     handler_cancelled = False
 
     class ExampleServicer(ServicerBase):
-        async def rpc_wait(self, request: test_pb2.TestRequest, _: P2PContext) -> AsyncIterable[test_pb2.TestResponse]:
+        async def rpc_wait(self, request: test_pb2.TestRequest, _: P2PContext) -> AsyncIterator[test_pb2.TestResponse]:
             try:
                 yield test_pb2.TestResponse(number=request.number + 1)
                 await asyncio.sleep(2)

--- a/tests/test_p2p_servicer.py
+++ b/tests/test_p2p_servicer.py
@@ -36,9 +36,6 @@ async def test_stream_unary(server_client):
         async def rpc_sum(self, request: AsyncIterable[test_pb2.TestRequest], _: P2PContext) -> test_pb2.TestResponse:
             result = 0
             async for item in request:
-                if item.number == -1:
-                    break
-
                 result += item.number
             return test_pb2.TestResponse(number=result)
 
@@ -50,7 +47,6 @@ async def test_stream_unary(server_client):
     async def generate_requests() -> AsyncIterable[test_pb2.TestRequest]:
         for i in range(10):
             yield test_pb2.TestRequest(number=i)
-        yield test_pb2.TestRequest(number=-1)
 
     assert await stub.rpc_sum(generate_requests()) == test_pb2.TestResponse(number=45)
 

--- a/tests/test_p2p_servicer.py
+++ b/tests/test_p2p_servicer.py
@@ -1,0 +1,74 @@
+import asyncio
+from typing import AsyncIterable
+
+import pytest
+
+from hivemind.p2p import P2P, P2PContext, ServicerBase
+from hivemind.proto import test_pb2
+
+
+@pytest.fixture
+async def server_client():
+    server = await P2P.create()
+    client = await P2P.create(initial_peers=await server.get_visible_maddrs())
+    yield server, client
+
+    await asyncio.gather(server.shutdown(), client.shutdown())
+
+
+@pytest.mark.asyncio
+async def test_unary_unary(server_client):
+    class ExampleServicer(ServicerBase):
+        async def rpc_square(self, request: test_pb2.TestRequest, _: P2PContext) -> test_pb2.TestResponse:
+            return test_pb2.TestResponse(number=request.number ** 2)
+
+    server, client = server_client
+    servicer = ExampleServicer()
+    await servicer.add_p2p_handlers(server)
+    stub = servicer.get_stub(client, server.id)
+
+    assert await stub.rpc_square(test_pb2.TestRequest(number=10)) == test_pb2.TestResponse(number=100)
+
+
+@pytest.mark.asyncio
+async def test_stream_unary(server_client):
+    class ExampleServicer(ServicerBase):
+        async def rpc_sum(self, request: AsyncIterable[test_pb2.TestRequest], _: P2PContext) -> test_pb2.TestResponse:
+            result = 0
+            async for item in request:
+                if item.number == -1:
+                    break
+
+                result += item.number
+            return test_pb2.TestResponse(number=result)
+
+    server, client = server_client
+    servicer = ExampleServicer()
+    await servicer.add_p2p_handlers(server)
+    stub = servicer.get_stub(client, server.id)
+
+    async def generate_requests() -> AsyncIterable[test_pb2.TestRequest]:
+        for i in range(10):
+            yield test_pb2.TestRequest(number=i)
+        yield test_pb2.TestRequest(number=-1)
+
+    assert await stub.rpc_sum(generate_requests()) == test_pb2.TestResponse(number=45)
+
+
+@pytest.mark.asyncio
+async def test_unary_stream(server_client):
+    class ExampleServicer(ServicerBase):
+        async def rpc_count(self, request: test_pb2.TestRequest, _: P2PContext) -> AsyncIterable[test_pb2.TestResponse]:
+            for i in range(request.number):
+                yield test_pb2.TestResponse(number=i)
+
+    server, client = server_client
+    servicer = ExampleServicer()
+    await servicer.add_p2p_handlers(server)
+    stub = servicer.get_stub(client, server.id)
+
+    i = 0
+    async for item in stub.rpc_count(test_pb2.TestRequest(number=10)):
+        assert item == test_pb2.TestResponse(number=i)
+        i += 1
+    assert i == 10

--- a/tests/test_p2p_servicer.py
+++ b/tests/test_p2p_servicer.py
@@ -54,7 +54,9 @@ async def test_stream_unary(server_client):
 @pytest.mark.asyncio
 async def test_unary_stream(server_client):
     class ExampleServicer(ServicerBase):
-        async def rpc_count(self, request: test_pb2.TestRequest, _: P2PContext) -> AsyncIterator[test_pb2.TestResponse]:
+        async def rpc_count(
+            self, request: test_pb2.TestRequest, _: P2PContext
+        ) -> AsyncIterator[test_pb2.TestResponse]:
             for i in range(request.number):
                 yield test_pb2.TestResponse(number=i)
 
@@ -73,8 +75,9 @@ async def test_unary_stream(server_client):
 @pytest.mark.asyncio
 async def test_stream_stream(server_client):
     class ExampleServicer(ServicerBase):
-        async def rpc_powers(self, request: AsyncIterator[test_pb2.TestRequest],
-                             _: P2PContext) -> AsyncIterator[test_pb2.TestResponse]:
+        async def rpc_powers(
+            self, request: AsyncIterator[test_pb2.TestRequest], _: P2PContext
+        ) -> AsyncIterator[test_pb2.TestResponse]:
             async for item in request:
                 yield test_pb2.TestResponse(number=item.number ** 2)
                 yield test_pb2.TestResponse(number=item.number ** 3)
@@ -98,7 +101,8 @@ async def test_stream_stream(server_client):
 
 
 @pytest.mark.parametrize(
-    "cancel_reason", ['close_connection', 'close_generator'],
+    "cancel_reason",
+    ["close_connection", "close_generator"],
 )
 @pytest.mark.asyncio
 async def test_unary_stream_cancel(server_client, cancel_reason):
@@ -119,8 +123,8 @@ async def test_unary_stream_cancel(server_client, cancel_reason):
     servicer = ExampleServicer()
     await servicer.add_p2p_handlers(server)
 
-    if cancel_reason == 'close_connection':
-        _, reader, writer = await client.call_stream_handler(server.id, 'ExampleServicer.rpc_wait')
+    if cancel_reason == "close_connection":
+        _, reader, writer = await client.call_stream_handler(server.id, "ExampleServicer.rpc_wait")
         await P2P.send_protobuf(test_pb2.TestRequest(number=10), writer)
         await P2P.send_protobuf(P2P.END_OF_STREAM, writer)
 
@@ -129,7 +133,7 @@ async def test_unary_stream_cancel(server_client, cancel_reason):
         await asyncio.sleep(0.25)
 
         writer.close()
-    elif cancel_reason == 'close_generator':
+    elif cancel_reason == "close_generator":
         stub = servicer.get_stub(client, server.id)
         iter = stub.rpc_wait(test_pb2.TestRequest(number=10)).__aiter__()
 
@@ -138,7 +142,7 @@ async def test_unary_stream_cancel(server_client, cancel_reason):
 
         await iter.aclose()
     else:
-        assert False, f'Unknown cancel_reason = `{cancel_reason}`'
+        assert False, f"Unknown cancel_reason = `{cancel_reason}`"
 
     await asyncio.sleep(0.25)
     assert handler_cancelled

--- a/tests/test_p2p_servicer.py
+++ b/tests/test_p2p_servicer.py
@@ -68,3 +68,30 @@ async def test_unary_stream(server_client):
         assert item == test_pb2.TestResponse(number=i)
         i += 1
     assert i == 10
+
+
+@pytest.mark.asyncio
+async def test_stream_stream(server_client):
+    class ExampleServicer(ServicerBase):
+        async def rpc_powers(self, request: AsyncIterable[test_pb2.TestRequest],
+                             _: P2PContext) -> AsyncIterable[test_pb2.TestResponse]:
+            async for item in request:
+                yield test_pb2.TestResponse(number=item.number ** 2)
+                yield test_pb2.TestResponse(number=item.number ** 3)
+
+    server, client = server_client
+    servicer = ExampleServicer()
+    await servicer.add_p2p_handlers(server)
+    stub = servicer.get_stub(client, server.id)
+
+    async def generate_requests() -> AsyncIterable[test_pb2.TestRequest]:
+        for i in range(10):
+            yield test_pb2.TestRequest(number=i)
+
+    i = 0
+    async for item in stub.rpc_powers(generate_requests()):
+        if i % 2 == 0:
+            assert item == test_pb2.TestResponse(number=(i // 2) ** 2)
+        else:
+            assert item == test_pb2.TestResponse(number=(i // 2) ** 3)
+        i += 1

--- a/tests/test_p2p_servicer.py
+++ b/tests/test_p2p_servicer.py
@@ -124,7 +124,7 @@ async def test_unary_stream_cancel(server_client, cancel_reason):
     await servicer.add_p2p_handlers(server)
 
     if cancel_reason == "close_connection":
-        _, reader, writer = await client.call_stream_handler(server.id, "ExampleServicer.rpc_wait")
+        _, reader, writer = await client.call_binary_stream_handler(server.id, "ExampleServicer.rpc_wait")
         await P2P.send_protobuf(test_pb2.TestRequest(number=10), writer)
         await P2P.send_protobuf(P2P.END_OF_STREAM, writer)
 


### PR DESCRIPTION
**Current status:** Finished.

This PR implements protobuf-based stream handlers over libp2p backend (including unary-stream, stream-unary, and stream-stream). Similarly to gRPC, they can be used through the `Servicer` interface:

```python
class ExampleServicer(ServicerBase):
    async def rpc_sum(self, request: AsyncIterator[TestRequest], _: P2PContext) -> TestResponse:
        result = 0
        async for item in request:
            result += item.number
        return TestResponse(number=result)

    async def rpc_count(self, request: TestRequest, _: P2PContext) -> AsyncIterator[TestResponse]:
        for i in range(request.number):
            yield TestResponse(number=i)
```

__Future work:__

- [ ] Consider adding timeout to a server waiting for the request data from client. May be useful to prevent resource leaks in case of hard client disconnects.