### PR TITLE
Refactor daemon control protocol

### DIFF
--- a/hivemind/proto/p2pd.proto
+++ b/hivemind/proto/p2pd.proto
@@ -15,7 +15,7 @@ message Request {
     DHT                      = 4;
     LIST_PEERS               = 5;
     CONNMANAGER              = 6;
-    DISCONNECT               = 7;      
+    DISCONNECT               = 7;
     PUBSUB                   = 8;
 
     PERSISTENT_CONN_UPGRADE  = 9;
@@ -33,10 +33,28 @@ message Request {
   optional ConnManagerRequest connManager = 6;
   optional DisconnectRequest disconnect = 7;
   optional PSRequest pubsub = 8;
+}
 
-  optional CallUnaryRequest callUnary = 9;
-  optional AddUnaryHandlerRequest addUnaryHandler = 10;
-  optional CallUnaryResponse sendResponseToRemote = 11;
+// Persistent connection request
+message PCRequest {
+  required bytes callId = 1;
+
+  oneof message {
+    AddUnaryHandlerRequest addUnaryHandler = 2;
+    CallUnaryRequest  callUnary = 3;
+    CallUnaryResponse unaryResponse = 4;
+  }
+}
+
+// Persistent connection response
+message PCResponse {
+  required bytes callId = 1;
+
+  oneof message {
+    CallUnaryResponse callUnaryResponse = 2;
+    CallUnaryRequest requestHandling = 3;
+    DaemonError daemonError = 4;
+  }
 }
 
 message Response {
@@ -52,9 +70,6 @@ message Response {
   optional DHTResponse dht = 5;
   repeated PeerInfo peers = 6;
   optional PSResponse pubsub = 7;
-
-  optional CallUnaryResponse callUnaryResponse = 8;
-  optional CallUnaryRequest requestHandling = 9;
 }
 
 message IdentifyResponse {
@@ -160,7 +175,7 @@ message PSRequest {
 }
 
 message PSMessage {
-  optional bytes from_id = 1;
+  optional bytes from = 1;
   optional bytes data = 2;
   optional bytes seqno = 3;
   repeated string topicIDs = 4;
@@ -173,24 +188,26 @@ message PSResponse {
   repeated bytes peerIDs = 2;
 }
 
-message RPCError {
-  optional string message = 1;
-}
-
 message CallUnaryRequest {
   required bytes peer = 1;
   required string proto = 2;
   required bytes data = 3;
-  required bytes callId = 4;
-  optional int64 timeout = 5;
+  optional int64 timeout = 4;
 }
 
 message CallUnaryResponse {
-  required bytes callId = 1;
-  optional bytes result = 2;
-  optional bytes error = 3;
+  optional bytes result = 1;
+  optional bytes error = 2;
 }
 
 message AddUnaryHandlerRequest {
   required string proto = 1;
+}
+
+message DaemonError {
+  optional string message = 1;
+}
+
+message RPCError {
+  optional string message = 1;
 }

--- a/hivemind/proto/p2pd.proto
+++ b/hivemind/proto/p2pd.proto
@@ -41,7 +41,7 @@ message PCRequest {
 
   oneof message {
     AddUnaryHandlerRequest addUnaryHandler = 2;
-    CallUnaryRequest  callUnary = 3;
+    CallUnaryRequest callUnary = 3;
     CallUnaryResponse unaryResponse = 4;
   }
 }


### PR DESCRIPTION
This PR implements separate proto messages for the persistent daemon connection (`PCRequest` and `PCResponse`).