### PR TITLE
Fix flapping test_dht_node()

### DIFF
--- a/tests/test_dht_node.py
+++ b/tests/test_dht_node.py
@@ -324,10 +324,9 @@ def test_dht_node(
     assert not loop.run_until_complete(me.store(upper_key, subkey=subkey2, value=345, expiration_time=now + 10))
     assert loop.run_until_complete(me.store(upper_key, subkey=subkey2, value=567, expiration_time=now + 30))
     assert loop.run_until_complete(me.store(upper_key, subkey=subkey3, value=890, expiration_time=now + 50))
-    loop.run_until_complete(asyncio.sleep(0.1))  # wait for cache to refresh
 
     for node in [that_guy, me]:
-        value, time = loop.run_until_complete(node.get(upper_key))
+        value, time = loop.run_until_complete(node.get(upper_key, latest=True))
         assert isinstance(value, dict) and time == now + 50, (value, time)
         assert value[subkey1] == (123, now + 10)
         assert value[subkey2] == (567, now + 30)


### PR DESCRIPTION
Resolves flaps like [this](https://github.com/learning-at-home/hivemind/pull/343/checks?check_run_id=3222979414) by ensuring that we get the latest value from the DHT.