### PR TITLE
Fix some warnings related to asyncio

### DIFF
--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -331,7 +331,9 @@ class P2P:
                         await P2P.send_protobuf(response, writer)
                 except Exception as e:
                     logger.warning("Exception while processing stream and sending responses:", exc_info=True)
-                    await P2P.send_protobuf(RPCError(message=str(e)), writer)
+                    # Sometimes `e` is a connection error, so we won't be able to report the error to the caller
+                    with suppress(Exception):
+                        await P2P.send_protobuf(RPCError(message=str(e)), writer)
 
             with closing(writer):
                 processing_task = asyncio.create_task(_process_stream())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import gc
 import multiprocessing as mp
 from contextlib import suppress
@@ -9,6 +10,22 @@ from hivemind.utils.logging import get_logger
 from hivemind.utils.mpfuture import MPFuture, SharedBytes
 
 logger = get_logger(__name__)
+
+
+@pytest.fixture
+def event_loop():
+    """
+    This overrides the ``event_loop`` fixture from pytest-asyncio
+    (e.g. to make it compatible with ``asyncio.subprocess``).
+
+    This fixture is identical to the original one but does not call ``loop.close()`` in the end.
+    Indeed, at this point, the loop is already stopped (i.e. next tests are free to create new loops).
+    However, finalizers of objects created in the current test may reference the current loop and fail if it is closed.
+    For example, this happens while using ``asyncio.subprocess`` (the ``asyncio.subprocess.Process`` finalizer
+    fails if the loop is closed, but works if the loop is only stopped).
+    """
+
+    yield asyncio.get_event_loop()
 
 
 @pytest.fixture(autouse=True, scope="session")


### PR DESCRIPTION
This PR includes the following fixes (see comments in the code for details):

1. The change in `conftest.py` fixes warnings like the following:

    ```python
    Traceback (most recent call last):
      File "/usr/local/lib/python3.9/asyncio/base_subprocess.py", line 126, in __del__
        self.close()
      File "/usr/local/lib/python3.9/asyncio/base_subprocess.py", line 104, in close
        proto.pipe.close()
      File "/usr/local/lib/python3.9/asyncio/unix_events.py", line 536, in close
        self._close(None)
      File "/usr/local/lib/python3.9/asyncio/unix_events.py", line 560, in _close
        self._loop.call_soon(self._call_connection_lost, exc)
      File "/usr/local/lib/python3.9/asyncio/base_events.py", line 746, in call_soon
        self._check_closed()
      File "/usr/local/lib/python3.9/asyncio/base_events.py", line 510, in _check_closed
        raise RuntimeError('Event loop is closed')
    RuntimeError: Event loop is closed
    ```

    I think this may fix mass warnings on @deniskamazur's laptop as well.

2. The change in `p2p_daemon.py` fixes warnings like the following:

    ```python
    [2021/08/03 04:48:55.672][ERROR][asyncio.default_exception_handler:1738] Task exception was never retrieved
    future: <Task finished name='Task-35' coro=<P2P._add_protobuf_stream_handler.<locals>._handle_stream.<locals>._process_stream() done, defined at /home/
    borzunov/hivemind/hivemind/p2p/p2p_daemon.py:306> exception=ConnectionResetError('Connection lost')>
    Traceback (most recent call last):
      File "/home/borzunov/hivemind/hivemind/p2p/p2p_daemon.py", line 309, in _process_stream
        await P2P.send_protobuf(response, writer)
      File "/home/borzunov/hivemind/hivemind/p2p/p2p_daemon.py", line 252, in send_protobuf
        await P2P.send_raw_data(protobuf.SerializeToString(), writer)
      File "/home/borzunov/hivemind/hivemind/p2p/p2p_daemon.py", line 234, in send_raw_data
        await writer.drain()
      File "/usr/local/lib/python3.9/asyncio/streams.py", line 387, in drain
        await self._protocol._drain_helper()
      File "/usr/local/lib/python3.9/asyncio/streams.py", line 190, in _drain_helper
        raise ConnectionResetError('Connection lost')
    ConnectionResetError: Connection lost
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/home/borzunov/hivemind/hivemind/p2p/p2p_daemon.py", line 312, in _process_stream
        await P2P.send_protobuf(RPCError(message=str(e)), writer)
      File "/home/borzunov/hivemind/hivemind/p2p/p2p_daemon.py", line 252, in send_protobuf
        await P2P.send_raw_data(protobuf.SerializeToString(), writer)
      File "/home/borzunov/hivemind/hivemind/p2p/p2p_daemon.py", line 234, in send_raw_data
        await writer.drain()
      File "/usr/local/lib/python3.9/asyncio/streams.py", line 387, in drain
        await self._protocol._drain_helper()
      File "/usr/local/lib/python3.9/asyncio/streams.py", line 190, in _drain_helper
        raise ConnectionResetError('Connection lost')
    ConnectionResetError: Connection lost
    ```