### PR TITLE
Propagate startup errors from DHT and averager processes

### DIFF
--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 import contextlib
 import ctypes
 import multiprocessing as mp
 import os
 import threading
 import weakref
+from concurrent.futures.thread import ThreadPoolExecutor
 from dataclasses import asdict
 from typing import Any, AsyncIterator, Dict, Optional, Sequence, Tuple, Union
 
@@ -211,7 +211,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
         """Serve DecentralizedAverager forever. This function will not return until the averager is shut down"""
         loop = switch_to_uvloop()
         # initialize asyncio synchronization primitives in this event loop
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pipe_awaiter:
+        with ThreadPoolExecutor(max_workers=1) as pipe_awaiter:
 
             async def _run():
                 try:
@@ -259,10 +259,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
             self.wait_until_ready(timeout)
 
     def wait_until_ready(self, timeout: Optional[float] = None) -> None:
-        try:
-            self._ready.result(timeout=timeout)
-        except concurrent.futures.TimeoutError:
-            raise TimeoutError(f"Averager failed to start in {timeout:.1f} seconds")
+        self._ready.result(timeout=timeout)
 
     def shutdown(self) -> None:
         """Shut down the averager process"""

--- a/hivemind/dht/__init__.py
+++ b/hivemind/dht/__init__.py
@@ -15,9 +15,9 @@ The code is organized as follows:
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 import multiprocessing as mp
 import os
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from typing import Awaitable, Callable, Iterable, List, Optional, Sequence, TypeVar, Union
 
@@ -101,7 +101,7 @@ class DHT(mp.Process):
         """Serve DHT forever. This function will not return until DHT node is shut down"""
         loop = switch_to_uvloop()
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pipe_awaiter:
+        with ThreadPoolExecutor(max_workers=1) as pipe_awaiter:
 
             async def _run():
                 try:
@@ -138,10 +138,7 @@ class DHT(mp.Process):
             self.wait_until_ready(timeout)
 
     def wait_until_ready(self, timeout: Optional[float] = None) -> None:
-        try:
-            self._ready.result(timeout=timeout)
-        except concurrent.futures.TimeoutError:
-            raise TimeoutError(f"DHT failed to start in {timeout:.1f} seconds")
+        self._ready.result(timeout=timeout)
 
     def shutdown(self) -> None:
         """Shut down a running dht process"""

--- a/tests/test_dht.py
+++ b/tests/test_dht.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import random
 import time
 
@@ -20,7 +21,7 @@ async def test_startup_error():
         )
 
     dht = hivemind.DHT(start=True, await_ready=False)
-    with pytest.raises(TimeoutError):
+    with pytest.raises(concurrent.futures.TimeoutError):
         dht.wait_until_ready(timeout=0.1)
     dht.shutdown()
 

--- a/tests/test_dht.py
+++ b/tests/test_dht.py
@@ -6,8 +6,23 @@ import pytest
 from multiaddr import Multiaddr
 
 import hivemind
+from hivemind.utils.networking import get_free_port
 
 from test_utils.dht_swarms import launch_dht_instances
+
+
+@pytest.mark.asyncio
+async def test_startup_error():
+    with pytest.raises(hivemind.p2p.P2PDaemonError, match=r"Failed to connect to bootstrap peers"):
+        hivemind.DHT(
+            initial_peers=[f"/ip4/127.0.0.1/tcp/{get_free_port()}/p2p/QmdaK4LUeQaKhqSFPRu9N7MvXUEWDxWwtCvPrS444tCgd1"],
+            start=True,
+        )
+
+    dht = hivemind.DHT(start=True, await_ready=False)
+    with pytest.raises(TimeoutError):
+        dht.wait_until_ready(timeout=0.1)
+    dht.shutdown()
 
 
 @pytest.mark.forked

--- a/tests/test_utils/dht_swarms.py
+++ b/tests/test_utils/dht_swarms.py
@@ -94,7 +94,7 @@ def launch_dht_instances(n_peers: int, **kwargs) -> List[DHT]:
     initial_peers = dhts[0].get_visible_maddrs()
 
     dhts.extend(DHT(initial_peers=initial_peers, start=True, await_ready=False, **kwargs) for _ in range(n_peers - 1))
-    for instance in dhts[1:]:
-        instance.ready.wait()
+    for process in dhts[1:]:
+        process.wait_until_ready()
 
     return dhts


### PR DESCRIPTION
Currently, startup failure of DHT and/or averager (e.g. when `initial_peers` are unreachable) leads to a deadlock in the parent process. The exception message is printed to stdout but the parent process does not stop, and this is not nice for tests and end users.

This PR makes startup errors to be propagated to the parent process.