### PR TITLE
Add daemon termination support

### DIFF
--- a/hivemind/dht/protocol.py
+++ b/hivemind/dht/protocol.py
@@ -81,7 +81,7 @@ class DHTProtocol(ServicerBase):
 
     def __init__(self, *, _initialized_with_create=False):
         """Internal init method. Please use DHTProtocol.create coroutine to spawn new protocol instances"""
-        assert _initialized_with_create, " Please use DHTProtocol.create coroutine to spawn new protocol instances "
+        assert _initialized_with_create, "Please use DHTProtocol.create coroutine to spawn new protocol instances"
         super().__init__()
 
     def get_stub(self, peer: PeerID) -> AuthRPCWrapper:

--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -91,7 +91,7 @@ class P2P:
         use_auto_relay: bool = False,
         relay_hop_limit: int = 0,
         startup_timeout: float = 15,
-        idle_timeout: int = 0,
+        idle_timeout: float = 0,
     ) -> "P2P":
         """
         Start a new p2pd process and connect to it.

--- a/hivemind/p2p/p2p_daemon_bindings/control.py
+++ b/hivemind/p2p/p2p_daemon_bindings/control.py
@@ -80,7 +80,7 @@ class ControlClient:
         *,
         _initialized_with_create=False,
     ) -> None:
-        assert _initialized_with_create, "Please use ControlClient.create coroutine to spawn new control instances "
+        assert _initialized_with_create, "Please use ControlClient.create coroutine to spawn new control instances"
 
         self.listen_maddr = listen_maddr
         self.daemon_connector = daemon_connector

--- a/hivemind/p2p/p2p_daemon_bindings/control.py
+++ b/hivemind/p2p/p2p_daemon_bindings/control.py
@@ -74,8 +74,14 @@ class ControlClient:
     DEFAULT_LISTEN_MADDR = "/unix/tmp/p2pclient.sock"
 
     def __init__(
-        self, daemon_connector: DaemonConnector, listen_maddr: Multiaddr = Multiaddr(DEFAULT_LISTEN_MADDR)
+        self,
+        daemon_connector: DaemonConnector,
+        listen_maddr: Multiaddr = Multiaddr(DEFAULT_LISTEN_MADDR),
+        *,
+        _initialized_with_create=False,
     ) -> None:
+        assert _initialized_with_create, " Please use ControlClient.create coroutine to spawn new control instances "
+
         self.listen_maddr = listen_maddr
         self.daemon_connector = daemon_connector
         self.handlers: Dict[str, StreamHandler] = {}
@@ -83,13 +89,26 @@ class ControlClient:
         self._is_persistent_conn_open: bool = False
         self.unary_handlers: Dict[str, TUnaryHandler] = {}
 
-        self._ensure_conn_lock = asyncio.Lock()
         self._pending_messages: asyncio.Queue[p2pd_pb.PersistentConnectionRequest] = asyncio.Queue()
         self._pending_calls: Dict[CallID, asyncio.Future[bytes]] = {}
         self._handler_tasks: Dict[CallID, asyncio.Task] = {}
 
         self._read_task: Optional[asyncio.Task] = None
         self._write_task: Optional[asyncio.Task] = None
+
+    @classmethod
+    async def create(
+        cls,
+        daemon_connector: DaemonConnector,
+        listen_maddr: Multiaddr = Multiaddr(DEFAULT_LISTEN_MADDR),
+        do_connect: bool = True,
+    ) -> "ControlClient":
+        control = cls(daemon_connector, listen_maddr, _initialized_with_create=True)
+
+        if do_connect:
+            await control._ensure_persistent_conn()
+
+        return control
 
     async def _handler(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
         pb_stream_info = p2pd_pb.StreamInfo()  # type: ignore
@@ -184,19 +203,14 @@ class ControlClient:
         )
 
     async def _ensure_persistent_conn(self):
-        if not self._is_persistent_conn_open:
-            async with self._ensure_conn_lock:
-                if not self._is_persistent_conn_open:
-                    reader, writer = await self.daemon_connector.open_persistent_connection()
+        reader, writer = await self.daemon_connector.open_persistent_connection()
 
-                    self._read_task = asyncio.create_task(self._read_from_persistent_conn(reader))
-                    self._write_task = asyncio.create_task(self._write_to_persistent_conn(writer))
+        self._read_task = asyncio.create_task(self._read_from_persistent_conn(reader))
+        self._write_task = asyncio.create_task(self._write_to_persistent_conn(writer))
 
-                    self._is_persistent_conn_open = True
+        self._is_persistent_conn_open = True
 
     async def add_unary_handler(self, proto: str, handler: TUnaryHandler):
-        await self._ensure_persistent_conn()
-
         call_id = uuid.uuid4()
 
         add_unary_handler_req = p2pd_pb.AddUnaryHandlerRequest(proto=proto)
@@ -219,8 +233,6 @@ class ControlClient:
             callId=call_id.bytes,
             callUnary=call_unary_req,
         )
-
-        await self._ensure_persistent_conn()
 
         try:
             self._pending_calls[call_id] = asyncio.Future()

--- a/hivemind/p2p/p2p_daemon_bindings/control.py
+++ b/hivemind/p2p/p2p_daemon_bindings/control.py
@@ -80,7 +80,7 @@ class ControlClient:
         *,
         _initialized_with_create=False,
     ) -> None:
-        assert _initialized_with_create, " Please use ControlClient.create coroutine to spawn new control instances "
+        assert _initialized_with_create, "Please use ControlClient.create coroutine to spawn new control instances "
 
         self.listen_maddr = listen_maddr
         self.daemon_connector = daemon_connector

--- a/hivemind/p2p/p2p_daemon_bindings/control.py
+++ b/hivemind/p2p/p2p_daemon_bindings/control.py
@@ -101,11 +101,11 @@ class ControlClient:
         cls,
         daemon_connector: DaemonConnector,
         listen_maddr: Multiaddr = Multiaddr(DEFAULT_LISTEN_MADDR),
-        do_connect: bool = True,
+        use_persistent_conn: bool = True,
     ) -> "ControlClient":
         control = cls(daemon_connector, listen_maddr, _initialized_with_create=True)
 
-        if do_connect:
+        if use_persistent_conn:
             await control._ensure_persistent_conn()
 
         return control

--- a/hivemind/p2p/p2p_daemon_bindings/p2pclient.py
+++ b/hivemind/p2p/p2p_daemon_bindings/p2pclient.py
@@ -17,9 +17,17 @@ from hivemind.p2p.p2p_daemon_bindings.datastructures import PeerID, PeerInfo, St
 class Client:
     control: ControlClient
 
-    def __init__(self, control_maddr: Multiaddr = None, listen_maddr: Multiaddr = None) -> None:
+    def __init__(self) -> None:
+        self.control = None
+
+    @classmethod
+    async def create(cls, control_maddr: Multiaddr = None, listen_maddr: Multiaddr = None) -> "Client":
+        client = cls()
+
         daemon_connector = DaemonConnector(control_maddr=control_maddr)
-        self.control = ControlClient(daemon_connector=daemon_connector, listen_maddr=listen_maddr)
+        client.control = await ControlClient.create(daemon_connector=daemon_connector, listen_maddr=listen_maddr)
+
+        return client
 
     @asynccontextmanager
     async def listen(self) -> AsyncIterator["Client"]:

--- a/tests/test_p2p_daemon_bindings.py
+++ b/tests/test_p2p_daemon_bindings.py
@@ -210,14 +210,14 @@ async def test_control_client_ctor_listen_maddr(listen_maddr_str):
     c = await ControlClient.create(
         daemon_connector=DaemonConnector(),
         listen_maddr=Multiaddr(listen_maddr_str),
-        do_connect=False,
+        use_persistent_conn=False,
     )
     assert c.listen_maddr == Multiaddr(listen_maddr_str)
 
 
 @pytest.mark.asyncio
 async def test_control_client_ctor_default_listen_maddr():
-    c = await ControlClient.create(daemon_connector=DaemonConnector(), do_connect=False)
+    c = await ControlClient.create(daemon_connector=DaemonConnector(), use_persistent_conn=False)
     assert c.listen_maddr == Multiaddr(ControlClient.DEFAULT_LISTEN_MADDR)
 
 

--- a/tests/test_p2p_daemon_bindings.py
+++ b/tests/test_p2p_daemon_bindings.py
@@ -193,7 +193,8 @@ def test_parse_conn_protocol_invalid(maddr_str):
 
 
 @pytest.mark.parametrize("control_maddr_str", ("/unix/123", "/ip4/127.0.0.1/tcp/6666"))
-def test_client_ctor_control_maddr(control_maddr_str):
+@pytest.mark.asyncio
+async def test_client_ctor_control_maddr(control_maddr_str):
     c = DaemonConnector(Multiaddr(control_maddr_str))
     assert c.control_maddr == Multiaddr(control_maddr_str)
 
@@ -204,13 +205,19 @@ def test_client_ctor_default_control_maddr():
 
 
 @pytest.mark.parametrize("listen_maddr_str", ("/unix/123", "/ip4/127.0.0.1/tcp/6666"))
-def test_control_client_ctor_listen_maddr(listen_maddr_str):
-    c = ControlClient(daemon_connector=DaemonConnector(), listen_maddr=Multiaddr(listen_maddr_str))
+@pytest.mark.asyncio
+async def test_control_client_ctor_listen_maddr(listen_maddr_str):
+    c = await ControlClient.create(
+        daemon_connector=DaemonConnector(),
+        listen_maddr=Multiaddr(listen_maddr_str),
+        do_connect=False,
+    )
     assert c.listen_maddr == Multiaddr(listen_maddr_str)
 
 
-def test_control_client_ctor_default_listen_maddr():
-    c = ControlClient(daemon_connector=DaemonConnector())
+@pytest.mark.asyncio
+async def test_control_client_ctor_default_listen_maddr():
+    c = await ControlClient.create(daemon_connector=DaemonConnector(), do_connect=False)
     assert c.listen_maddr == Multiaddr(ControlClient.DEFAULT_LISTEN_MADDR)
 
 

--- a/tests/test_utils/p2p_daemon.py
+++ b/tests/test_utils/p2p_daemon.py
@@ -160,7 +160,7 @@ async def _make_p2pd_pair(
     )
     # wait for daemon ready
     await p2pd.wait_until_ready()
-    client = Client(control_maddr=control_maddr, listen_maddr=listen_maddr)
+    client = await Client.create(control_maddr=control_maddr, listen_maddr=listen_maddr)
     try:
         async with client.listen():
             yield DaemonTuple(daemon=p2pd, client=client)


### PR DESCRIPTION
Currently, there are situations in which the daemon's clients fail to send a SIGTERM, which leads to dangling p2pd instances. This PR fixes this issue by killing the daemon as soon as the persistent connection counter hits zero (but only if at least one has been open). The PR also adds an idleTimeout flag. If the timeout's been reached and no persistent connections have been opened, the daemon terminates itself.