### PR TITLE
Add less comparator for PeerID

### DIFF
--- a/hivemind/p2p/p2p_daemon_bindings/datastructures.py
+++ b/hivemind/p2p/p2p_daemon_bindings/datastructures.py
@@ -74,8 +74,11 @@ class PeerID:
         else:
             return False
 
-    def __less__(self, other: "PeerID") -> bool:
-        return self._bytes < other._bytes
+    def __less__(self, other: object) -> bool:
+        if not isinstance(other, PeerID):
+            raise ValueError(f"Can't order PeerID and {type(other)}")
+
+        return self.to_base58() < other.to_base58()
 
     def __hash__(self) -> int:
         return hash(self._bytes)

--- a/hivemind/p2p/p2p_daemon_bindings/datastructures.py
+++ b/hivemind/p2p/p2p_daemon_bindings/datastructures.py
@@ -76,7 +76,7 @@ class PeerID:
 
     def __less__(self, other: object) -> bool:
         if not isinstance(other, PeerID):
-            raise ValueError(f"Can't order PeerID and {type(other)}")
+            raise TypeError(f"'<' not supported between instances of 'PeerID' and '{type(other)}'")
 
         return self.to_base58() < other.to_base58()
 

--- a/hivemind/p2p/p2p_daemon_bindings/datastructures.py
+++ b/hivemind/p2p/p2p_daemon_bindings/datastructures.py
@@ -74,7 +74,7 @@ class PeerID:
         else:
             return False
 
-    def __less__(self, other: object) -> bool:
+    def __lt__(self, other: object) -> bool:
         if not isinstance(other, PeerID):
             raise TypeError(f"'<' not supported between instances of 'PeerID' and '{type(other)}'")
 

--- a/hivemind/p2p/p2p_daemon_bindings/datastructures.py
+++ b/hivemind/p2p/p2p_daemon_bindings/datastructures.py
@@ -74,6 +74,9 @@ class PeerID:
         else:
             return False
 
+    def __less__(self, other: "PeerID") -> bool:
+        return self._bytes < other._bytes
+
     def __hash__(self) -> int:
         return hash(self._bytes)
 

--- a/tests/test_p2p_daemon_bindings.py
+++ b/tests/test_p2p_daemon_bindings.py
@@ -144,6 +144,12 @@ def test_peer_id():
     peer_id_3 = PeerID.from_base58("QmbmfNDEth7Ucvjuxiw3SP3E4PoJzbk7g4Ge6ZDigbCsNp")
     assert PEER_ID != peer_id_3
 
+    a = PeerID.from_base58("bob")
+    b = PeerID.from_base58("eve")
+    assert a < b and b > a and not (b < a) and not (a > b)
+    with pytest.raises(TypeError):
+        assert a < object()
+
 
 def test_stream_info():
     proto = "123"


### PR DESCRIPTION
This PR implements a `__less__` comparator for PeerID.
![image](https://user-images.githubusercontent.com/22542643/129940926-13adbb4c-2ccc-4a12-8b5a-c1a922708c45.png)
