### PR TITLE
Disable QUIC by default

### DIFF
--- a/examples/albert/arguments.py
+++ b/examples/albert/arguments.py
@@ -13,7 +13,7 @@ class BaseTrainingArguments:
         default_factory=list,
         metadata={
             "help": "Multiaddrs of the peers that will welcome you into the existing collaboration. "
-            "Example: /ip4/203.0.113.1/tcp/31337/p2p/XXXX /ip4/203.0.113.2/udp/7777/quic/p2p/YYYY"
+            "Example: /ip4/203.0.113.1/tcp/31337/p2p/XXXX /ip4/203.0.113.2/tcp/7777/p2p/YYYY"
         },
     )
     use_ipfs: bool = field(
@@ -24,11 +24,10 @@ class BaseTrainingArguments:
         },
     )
     host_maddrs: List[str] = field(
-        default_factory=lambda: ["/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"],
+        default_factory=lambda: ["/ip4/0.0.0.0/tcp/0"],
         metadata={
             "help": "Multiaddrs to listen for external connections from other p2p instances. "
-            "Defaults to all IPv4 interfaces with TCP and QUIC (over UDP) protocols: "
-            "/ip4/0.0.0.0/tcp/0 /ip4/0.0.0.0/udp/0/quic"
+            "Defaults to all IPv4 interfaces and the TCP protocol: /ip4/0.0.0.0/tcp/0"
         },
     )
     announce_maddrs: List[str] = field(

--- a/examples/albert/run_training_monitor.py
+++ b/examples/albert/run_training_monitor.py
@@ -156,7 +156,7 @@ if __name__ == "__main__":
         address = request.text
         logger.info(f"Received public IP address of this machine: {address}")
         version = ip_address(address).version
-        monitor_args.announce_maddrs += [f"/ip{version}/{address}/tcp/0", f"/ip{version}/{address}/udp/0/quic"]
+        monitor_args.announce_maddrs += [f"/ip{version}/{address}/tcp/0"]
 
     experiment_prefix = monitor_args.experiment_prefix
     validators, local_public_key = utils.make_validators(experiment_prefix)

--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -77,7 +77,7 @@ class P2P:
         use_ipfs: bool = False,
         host_maddrs: Optional[Sequence[Union[Multiaddr, str]]] = ("/ip4/127.0.0.1/tcp/0",),
         announce_maddrs: Optional[Sequence[Union[Multiaddr, str]]] = None,
-        quic: bool = True,
+        quic: bool = False,
         tls: bool = True,
         conn_manager: bool = True,
         dht_mode: str = "dht_server",


### PR DESCRIPTION
This resolves #351 by disabling QUIC, that is:

1. Removing it from `host_maddrs` (to prohibit incoming QUIC connections)
2. Setting the default `quic=False` in `P2P.__init__()` (to prohibit outgoing QUIC connections)

After this fix, Colab peers work with `--client_mode` enabled (but don't work without this).

__Future work for next PRs:__

- [ ] Find out if there is a way to speed up QUIC in Google Colab
- [ ] Add IPv6
- [ ] Shorten the suggested `--initial_peers` value by displaying `{/ip4/AAAA,/ip6/BBBB}/p2p/XXXX` instead of `/ip4/AAAA/p2p/XXXX`, `/ip6/BBBB/p2p/XXXX`, so a user has smaller text to copy
- [x] Fix minor issues we have observed while debugging #351