### PR TITLE
Fix logger warning in P2P

### DIFF
--- a/hivemind/p2p/p2p_daemon_bindings/control.py
+++ b/hivemind/p2p/p2p_daemon_bindings/control.py
@@ -169,7 +169,7 @@ class ControlClient:
                     remote_exc = P2PHandlerError(resp.callUnaryResponse.error.decode(errors="ignore"))
                     self._pending_calls[call_id].set_exception(remote_exc)
                 else:
-                    logger.debug("received unexpected unary call:", resp)
+                    logger.debug(f"Received unexpected unary call: {resp}")
 
             elif resp.HasField("requestHandling"):
                 handler_task = asyncio.create_task(self._handle_persistent_request(call_id, resp.requestHandling))

--- a/hivemind/p2p/p2p_daemon_bindings/control.py
+++ b/hivemind/p2p/p2p_daemon_bindings/control.py
@@ -186,7 +186,7 @@ class ControlClient:
                 self._pending_calls[call_id].set_result(None)
 
             else:
-                logger.warning("Received unexpected response from daemon:", resp)
+                logger.warning(f"Received unexpected response from daemon: {resp}")
 
     async def _write_to_persistent_conn(self, writer: asyncio.StreamWriter):
         with closing(writer):


### PR DESCRIPTION
This PR fixes a warning message in P2P's `control.py`.

Fixes verbose messages like that:
![2021-08-24 20 57 02](https://user-images.githubusercontent.com/8748943/130666248-72bc7b19-f814-4e9f-82d8-5f5160931c45.jpg)
