### PR TITLE
Fix loglevel for a message in _read_from_persistent_conn()

### DIFF
--- a/hivemind/p2p/p2p_daemon_bindings/control.py
+++ b/hivemind/p2p/p2p_daemon_bindings/control.py
@@ -186,7 +186,7 @@ class ControlClient:
                 self._pending_calls[call_id].set_result(None)
 
             else:
-                logger.warning(f"Received unexpected response from daemon: {resp}")
+                logger.debug(f"Received unexpected response from daemon: {resp}")
 
     async def _write_to_persistent_conn(self, writer: asyncio.StreamWriter):
         with closing(writer):


### PR DESCRIPTION
This PR hides the following harmless log message:

```
[2021/08/25 19:15:06.997][WARN][p2p.p2p_daemon_bindings.control._read_from_persistent_conn:189] Received unexpected response from daemon: callId: ":h\234\204\210\250@\233\223J\013V\232\033z\246"
daemonError {
  message: "context canceled"
}
```

It happens on every cancelled unary call. A better fix (never send a response to a cancelled call) will be implemented in the next p2p daemon release by @deniskamazur.