### PR TITLE
Prefetch while reading rpc_aggregate_part() outputs

### DIFF
--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -33,7 +33,7 @@ class TensorPartContainer:
         peer_fractions: Sequence[float],
         compression_type: Union["CompressionType", Sequence["CompressionType"]] = CompressionType.NONE,
         part_size_bytes: int = DEFAULT_PART_SIZE_BYTES,
-        prefetch: int = 1,
+        prefetch: int = 5,
     ):
         if not isinstance(compression_type, Sequence):
             compression_type = [compression_type] * len(tensors)


### PR DESCRIPTION
Currently, rpc_aggregate_part() does not receive output parts and decompress them in parallel. This PR fixes it.

__Future work:__

- [ ] Implement prefetching outputs in `iterate_protobuf_handler()` instead.