### PR TITLE
Fix averager speed for TCP connections

### DIFF
--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -13,7 +13,7 @@ from hivemind.utils.asyncio import amap_in_executor
 from hivemind.utils.compression import get_nbytes_per_value, serialize_torch_tensor
 
 T = TypeVar("T")
-DEFAULT_PART_SIZE_BYTES = 2 ** 19
+DEFAULT_PART_SIZE_BYTES = 2 ** 16
 
 
 class TensorPartContainer:

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 
-P2PD_VERSION = "v0.3.4"
-P2PD_CHECKSUM = "194dca06116fdd36bc4b681d18f3b9cb"
+P2PD_VERSION = "v0.3.5"
+P2PD_CHECKSUM = "affea8ec63dbe2423ef7453718b5798d"
 LIBP2P_TAR_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/archive/refs/tags/{P2PD_VERSION}.tar.gz"
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Experimentally, we have found that these two changes fixes the averaging speed problem for TCP connections:

1. Change `DEFAULT_PART_SIZE_BYTES` from `2 ** 19` to `2 ** 16`
2. Revert the p2pd dependencies to the state of Jun 1, 2021