### PR TITLE
Integrate p2pd logs and outputs into hivemind logging

### DIFF
--- a/examples/albert/run_trainer.py
+++ b/examples/albert/run_trainer.py
@@ -204,7 +204,6 @@ class NoOpScheduler(LRSchedulerBase):
             return self.optimizer.scheduler.print_lr(*args, **kwargs)
 
     def step(self):
-        logger.debug("Called NoOpScheduler.step")
         self._last_lr = self.get_lr()
 
     def state_dict(self):

--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -3,6 +3,7 @@ import logging
 import json
 import os
 import secrets
+import shlex
 from collections.abc import AsyncIterable as AsyncIterableABC
 from contextlib import closing, suppress
 from dataclasses import dataclass
@@ -173,6 +174,7 @@ class P2P:
         env.setdefault("GOLOG_LOG_LEVEL", python_level_to_golog(loglevel))
         env["GOLOG_LOG_FMT"] = "json"
 
+        logger.debug(f"Launching {shlex.join(proc_args)}")
         self._child = await asyncio.subprocess.create_subprocess_exec(
             *proc_args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT, env=env
         )

--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -1,6 +1,6 @@
 import asyncio
-import logging
 import json
+import logging
 import os
 import secrets
 import shlex

--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -7,10 +7,10 @@ import shlex
 from collections.abc import AsyncIterable as AsyncIterableABC
 from contextlib import closing, suppress
 from dataclasses import dataclass
+from datetime import datetime
 from importlib.resources import path
 from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional, Sequence, Tuple, Type, TypeVar, Union
 
-import dateutil.parser
 from google.protobuf.message import Message
 from multiaddr import Multiaddr
 
@@ -592,7 +592,7 @@ class P2P:
                 level,
                 message,
                 extra={
-                    "origin_created": dateutil.parser.isoparse(record["ts"]).timestamp(),
+                    "origin_created": datetime.strptime(record["ts"], "%Y-%m-%dT%H:%M:%S.%f%z").timestamp(),
                     "caller": record["caller"],
                 },
             )

--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -576,7 +576,7 @@ class P2P:
             ready.set_exception(P2PDaemonError(f"Daemon failed to start: {last_line}"))
 
     # These Go loggers are excessively verbose, so we downgrade their message severity to DEBUG unless it is >= ERROR
-    _DOWNGRADED_LOGGERS = ["rtrefresh/rt_refresh_manager.go"]
+    _DOWNGRADED_LOGGERS = ["basic/natmgr.go", "rtrefresh/rt_refresh_manager.go"]
 
     @staticmethod
     def _log_p2pd_message(line: str) -> None:

--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import secrets
-import shlex
 from collections.abc import AsyncIterable as AsyncIterableABC
 from contextlib import closing, suppress
 from dataclasses import dataclass
@@ -176,7 +175,7 @@ class P2P:
         env.setdefault("GOLOG_LOG_LEVEL", python_level_to_golog(loglevel))
         env["GOLOG_LOG_FMT"] = "json"
 
-        logger.debug(f"Launching {shlex.join(proc_args)}")
+        logger.debug(f"Launching {proc_args}")
         self._child = await asyncio.subprocess.create_subprocess_exec(
             *proc_args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT, env=env
         )

--- a/hivemind/utils/logging.py
+++ b/hivemind/utils/logging.py
@@ -2,21 +2,64 @@ import logging
 import os
 
 
-def get_logger(module_name: str) -> logging.Logger:
-    # trim package name
-    name_without_prefix = ".".join(module_name.split(".")[1:])
-    loglevel = os.getenv("LOGLEVEL", "INFO")
+class OverridableLogger(logging.Logger):
+    """
+    A logger that permits to override LogRecord properties via the ``extra`` dictionary.
+    Used when reporting log messages originated elsewhere (e.g. in p2pd).
+    Example: ``logger.debug("message", extra={"funcName": "new_value"})``
+    """
 
-    logging.addLevelName(logging.WARNING, "WARN")
+    def makeRecord(self, name, level, fn, lno, msg, args, exc_info,
+                   func=None, extra=None, sinfo=None):
+        factory = logging.getLogRecordFactory()
+        rv = factory(name, level, fn, lno, msg, args, exc_info, func, sinfo)
+        rv.caller = f'{rv.name}.{rv.funcName}:{rv.lineno}'
+        if extra is not None:
+            rv.__dict__.update(extra)
+        return rv
+
+
+logging.setLoggerClass(OverridableLogger)
+logging.addLevelName(logging.WARNING, "WARN")
+loglevel = os.getenv("LOGLEVEL", "INFO")
+
+
+def get_logger(module_name: str) -> logging.Logger:
     formatter = logging.Formatter(
-        fmt="[{asctime}.{msecs:03.0f}][{levelname}][{name}.{funcName}:{lineno}] {message}",
+        fmt="[{asctime}.{msecs:03.0f}][{levelname}][{caller}] {message}",
         style="{",
         datefmt="%Y/%m/%d %H:%M:%S",
     )
+
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
+
+    name_without_prefix = ".".join(module_name.split(".")[1:])
     logger = logging.getLogger(name_without_prefix)
     logger.setLevel(loglevel)
     logger.addHandler(handler)
     logger.propagate = False
+
     return logger
+
+
+def golog_level_to_python(level: str) -> int:
+    level = level.upper()
+    if level in ["DPANIC", "PANIC", "FATAL"]:
+        return logging.CRITICAL
+
+    level = logging.getLevelName(level)
+    if not isinstance(level, int):
+        raise ValueError(f"Unknown go-log level: {level}")
+    return level
+
+
+def python_level_to_golog(level: str) -> str:
+    if not isinstance(level, str):
+        raise ValueError('`level` is expected to be a Python log level in the string form')
+
+    if level == 'CRITICAL':
+        return 'FATAL'
+    if level == 'WARNING':
+        return 'WARN'
+    return level

--- a/hivemind/utils/logging.py
+++ b/hivemind/utils/logging.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-
 loglevel = os.getenv("LOGLEVEL", "INFO")
 
 

--- a/hivemind/utils/logging.py
+++ b/hivemind/utils/logging.py
@@ -2,44 +2,42 @@ import logging
 import os
 
 
-class OverridableLogger(logging.Logger):
-    """
-    A logger that permits to override LogRecord properties via the ``extra`` dictionary.
-    Used when reporting log messages originated elsewhere (e.g. in p2pd).
-    Example: ``logger.debug("message", extra={"funcName": "new_value"})``
-    """
-
-    def makeRecord(self, name, level, fn, lno, msg, args, exc_info,
-                   func=None, extra=None, sinfo=None):
-        factory = logging.getLogRecordFactory()
-        rv = factory(name, level, fn, lno, msg, args, exc_info, func, sinfo)
-        rv.caller = f'{rv.name}.{rv.funcName}:{rv.lineno}'
-        if extra is not None:
-            rv.__dict__.update(extra)
-        return rv
-
-
-logging.setLoggerClass(OverridableLogger)
-logging.addLevelName(logging.WARNING, "WARN")
 loglevel = os.getenv("LOGLEVEL", "INFO")
 
 
+class CustomFormatter(logging.Formatter):
+    """
+    A formatter that allows a log time and caller info to be overridden via
+    ``logger.log(level, message, extra={"origin_created": ..., "caller": ...})``.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        if hasattr(record, "origin_created"):
+            record.created = record.origin_created
+            record.msecs = (record.created - int(record.created)) * 1000
+
+        if not hasattr(record, "caller"):
+            record.caller = f"{record.name}.{record.funcName}:{record.lineno}"
+
+        return super().format(record)
+
+
 def get_logger(module_name: str) -> logging.Logger:
-    formatter = logging.Formatter(
+    # trim package name
+    name_without_prefix = ".".join(module_name.split(".")[1:])
+
+    logging.addLevelName(logging.WARNING, "WARN")
+    formatter = CustomFormatter(
         fmt="[{asctime}.{msecs:03.0f}][{levelname}][{caller}] {message}",
         style="{",
         datefmt="%Y/%m/%d %H:%M:%S",
     )
-
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
-
-    name_without_prefix = ".".join(module_name.split(".")[1:])
     logger = logging.getLogger(name_without_prefix)
     logger.setLevel(loglevel)
     logger.addHandler(handler)
     logger.propagate = False
-
     return logger
 
 
@@ -56,10 +54,10 @@ def golog_level_to_python(level: str) -> int:
 
 def python_level_to_golog(level: str) -> str:
     if not isinstance(level, str):
-        raise ValueError('`level` is expected to be a Python log level in the string form')
+        raise ValueError("`level` is expected to be a Python log level in the string form")
 
-    if level == 'CRITICAL':
-        return 'FATAL'
-    if level == 'WARNING':
-        return 'WARN'
+    if level == "CRITICAL":
+        return "FATAL"
+    if level == "WARNING":
+        return "WARN"
     return level

--- a/hivemind/utils/mpfuture.py
+++ b/hivemind/utils/mpfuture.py
@@ -180,8 +180,10 @@ class MPFuture(base.Future, Generic[ResultType]):
                     future = future_ref()
 
                 if future is None:
-                    logger.debug(f"Ignoring update to future with uid={uid}: the future is already done or destroyed")
-                elif update_type == UpdateType.RESULT:
+                    # The MPFuture instance is already destroyed in this process
+                    # (the caller is not interested in the result)
+                    continue
+                if update_type == UpdateType.RESULT:
                     future.set_result(payload)
                 elif update_type == UpdateType.EXCEPTION:
                     future.set_exception(payload)


### PR DESCRIPTION
This PR:

1. Gets all p2pd log messages and integrates them into hivemind logging, keeping the original log time and caller info. The Go source file and line number are now displayed __at the same place__ as the Python line numbers. Levels <= `WARNING` are downgraded to `DEBUG`, the others are kept as is.
2. Gets other p2pd outputs (e.g. the line where it prints a peer ID) and logs it as `[DEBUG][p2pd]` messages.

Example with `LOGLEVEL=DEBUG`:

```
[2021/09/01 21:01:44.393][DEBUG][utils.mpfuture._initialize_mpfuture_backend:151] Initializing MPFuture backend for pid 140781
[2021/09/01 21:01:44.394][DEBUG][asyncio.__init__:59] Using selector: EpollSelector
[2021/09/01 21:01:44.405][DEBUG][p2p.p2p_daemon.create:173] Launching /home/borzunov/hivemind/hivemind/hivemind_cli/p2pd -autoRelay=0 -autonat=1 -b=0 -connManager=1 -idleTimeout=30s -listen=/unix/tmp/hivemind-p2pd-dgqxcQrSeao.sock -
natPortMap=1 -quic=0 -relay=1 -relayDiscovery=0 -relayHop=0 -relayHopLimit=0 -tls=1 -dhtServer=1 -hostAddrs=/ip4/0.0.0.0/tcp/0 -id=/home/borzunov/go-libp2p-daemon/p2p-keygen/identity
[2021/09/01 21:01:44.565][DEBUG][basic/basic_host.go:820] failed to resolve listen addrs: failed to specify addrs: []
[2021/09/01 21:01:44.583][DEBUG][p2pd] Control socket: /unix/tmp/hivemind-p2pd-dgqxcQrSeao.sock
[2021/09/01 21:01:44.583][DEBUG][p2pd] Peer ID: QmbuucoqXGLLK6FtH8DdjkxMECkrXeTX71cX2beJZGpBeD
[2021/09/01 21:01:44.583][DEBUG][p2pd] Peer Addrs:
[2021/09/01 21:01:44.583][DEBUG][go-addr-util@v0.0.2/addr.go:64] adding resolved addr:/ip4/0.0.0.0/tcp/36585 /ip4/192.168.1.2/tcp/36585 [/ip4/192.168.1.2/tcp/36585]
[2021/09/01 21:01:44.583][DEBUG][go-addr-util@v0.0.2/addr.go:64] adding resolved addr:/ip4/0.0.0.0/tcp/36585 /ip4/192.168.1.2/tcp/36585 [/ip4/192.168.1.2/tcp/36585]
[2021/09/01 21:01:44.583][DEBUG][go-addr-util@v0.0.2/addr.go:64] adding resolved addr:/ip4/0.0.0.0/tcp/36585 /ip4/127.0.0.1/tcp/36585 [/ip4/192.168.1.2/tcp/36585 /ip4/127.0.0.1/tcp/36585]
[2021/09/01 21:01:44.583][DEBUG][go-addr-util@v0.0.2/addr.go:64] adding resolved addr:/ip4/0.0.0.0/tcp/36585 /ip4/127.0.0.1/tcp/36585 [/ip4/192.168.1.2/tcp/36585 /ip4/127.0.0.1/tcp/36585]
[2021/09/01 21:01:44.583][DEBUG][go-addr-util@v0.0.2/addr.go:109] ResolveUnspecifiedAddresses:[/ip4/0.0.0.0/tcp/36585 /p2p-circuit] [/ip4/192.168.1.2 /ip4/127.0.0.1 /ip6/::1] [/ip4/192.168.1.2/tcp/36585 /ip4/127.0.0.1/tcp/36585 /p2p
-circuit]
[2021/09/01 21:01:44.583][DEBUG][go-addr-util@v0.0.2/addr.go:109] ResolveUnspecifiedAddresses:[/p2p-circuit /ip4/0.0.0.0/tcp/36585] [/ip4/192.168.1.2 /ip4/127.0.0.1 /ip6/::1] [/p2p-circuit /ip4/192.168.1.2/tcp/36585 /ip4/127.0.0.1/t
cp/36585]
[2021/09/01 21:01:44.585][DEBUG][p2pd] /ip4/192.168.1.2/tcp/36585
[2021/09/01 21:01:44.585][DEBUG][p2pd] /ip4/127.0.0.1/tcp/36585
[2021/09/01 21:01:44.583][DEBUG][go-libp2p-daemon/daemon.go:165] incoming connection
[2021/09/01 21:01:44.585][DEBUG][go-libp2p-daemon/conn.go:38] request
[2021/09/01 21:01:44.585][DEBUG][go-libp2p-daemon/daemon.go:165] incoming connection
[2021/09/01 21:01:44.585][DEBUG][go-libp2p-daemon/conn.go:38] request
[2021/09/01 21:01:44.585][DEBUG][go-addr-util@v0.0.2/addr.go:64] adding resolved addr:/ip4/0.0.0.0/tcp/36585 /ip4/192.168.1.2/tcp/36585 [/ip4/192.168.1.2/tcp/36585]
[2021/09/01 21:01:44.585][DEBUG][go-addr-util@v0.0.2/addr.go:64] adding resolved addr:/ip4/0.0.0.0/tcp/36585 /ip4/127.0.0.1/tcp/36585 [/ip4/192.168.1.2/tcp/36585 /ip4/127.0.0.1/tcp/36585]
[2021/09/01 21:01:44.602][DEBUG][p2p.p2p_daemon._ping_daemon:234] Launched p2pd with peer id = QmbuucoqXGLLK6FtH8DdjkxMECkrXeTX71cX2beJZGpBeD, host multiaddrs = (<Multiaddr /ip4/192.168.1.2/tcp/36585>, <Multiaddr /ip4/127.0.0.1/tcp/
36585>)
[2021/09/01 21:01:44.586][DEBUG][go-addr-util@v0.0.2/addr.go:109] ResolveUnspecifiedAddresses:[/p2p-circuit /ip4/0.0.0.0/tcp/36585] [/ip4/192.168.1.2 /ip4/127.0.0.1 /ip6/::1] [/p2p-circuit /ip4/192.168.1.2/tcp/36585 /ip4/127.0.0.1/t
cp/36585]
```