### PR TITLE
Implement colored logs

### DIFF
--- a/hivemind/utils/logging.py
+++ b/hivemind/utils/logging.py
@@ -1,8 +1,14 @@
 import logging
 import os
+import sys
 
 loglevel = os.getenv("LOGLEVEL", "INFO")
-use_colors = os.getenv("HIVEMIND_COLORS", "true").lower() != "false"
+
+_env_colors = os.getenv("HIVEMIND_COLORS")
+if _env_colors is not None:
+    use_colors = (_env_colors.lower() == "true")
+else:
+    use_colors = sys.stderr.isatty()
 
 
 class CustomFormatter(logging.Formatter):


### PR DESCRIPTION
This PR implements:

- __Colored logs without extra dependencies.__
    - The log level is colored depending on message severity. The log level and caller info are displayed in bold (see the screenshots).
    - By default, colors are disabled if stderr is redirected to a file/pipe. This can be overridden via the env variable.
- __Shorter log format.__ This allows more messages to fit into one terminal line and makes the message easier to read.
    - The date became shorter by excluding the year. Since the `09/02` notation becomes ambiguous in this case, it is changed to `Sep 02` (which, in my opinion, also improves readability).
    - The square brackets are removed.

## Screenshots

### 1. Google Colab

<img width="1165" alt="Screen Shot 2021-09-02 at 4 24 18 AM" src="https://user-images.githubusercontent.com/8748943/131767437-9b3199f0-ee70-42e5-bf6b-06ab3d0c11b4.png">

### 2. macOS terminal

![Screen Shot 2021-09-02 at 4 13 29 AM](https://user-images.githubusercontent.com/8748943/131767396-ddab02af-0dd7-4f5a-9071-3e1a5b0eea08.png)

### 3. Jupyter terminal

<img width="1157" alt="Screen Shot 2021-09-02 at 4 46 06 AM" src="https://user-images.githubusercontent.com/8748943/131768171-039a16df-94a3-471b-ab36-2df6bdf9aa72.png">

