### PR TITLE
Make log handlers configurable, shorten entries

### DIFF
--- a/benchmarks/benchmark_averaging.py
+++ b/benchmarks/benchmark_averaging.py
@@ -80,7 +80,7 @@ def benchmark_averaging(
             with lock_stats:
                 successful_steps += int(success)
                 total_steps += 1
-            logger.info(f"Averager {index}: {'finished' if success else 'failed'} step {step}")
+            logger.info(f"Averager {index}: {'finished' if success else 'failed'} step #{step}")
         logger.info(f"Averager {index}: done.")
 
     threads = []

--- a/examples/albert/run_trainer.py
+++ b/examples/albert/run_trainer.py
@@ -22,7 +22,7 @@ from hivemind.utils.logging import get_logger, use_hivemind_log_style
 import utils
 from arguments import AlbertTrainingArguments, AveragerArguments, CollaborationArguments, DatasetArguments
 
-use_hivemind_log_style('everywhere')
+use_hivemind_log_style("everywhere")
 logger = get_logger()
 
 LRSchedulerBase = getattr(torch.optim.lr_scheduler, "_LRScheduler", None)

--- a/examples/albert/run_trainer.py
+++ b/examples/albert/run_trainer.py
@@ -17,12 +17,12 @@ from transformers.trainer import Trainer
 from transformers.trainer_utils import is_main_process
 
 import hivemind
-from hivemind.utils.logging import get_logger, use_hivemind_log_style
+from hivemind.utils.logging import get_logger, use_hivemind_log_format
 
 import utils
 from arguments import AlbertTrainingArguments, AveragerArguments, CollaborationArguments, DatasetArguments
 
-use_hivemind_log_style("everywhere")
+use_hivemind_log_format("in_root_logger")
 logger = get_logger()
 
 LRSchedulerBase = getattr(torch.optim.lr_scheduler, "_LRScheduler", None)

--- a/examples/albert/run_trainer.py
+++ b/examples/albert/run_trainer.py
@@ -17,12 +17,12 @@ from transformers.trainer import Trainer
 from transformers.trainer_utils import is_main_process
 
 import hivemind
-from hivemind.utils.logging import get_logger, use_hivemind_log_format
+from hivemind.utils.logging import get_logger, use_hivemind_log_handler
 
 import utils
 from arguments import AlbertTrainingArguments, AveragerArguments, CollaborationArguments, DatasetArguments
 
-use_hivemind_log_format("in_root_logger")
+use_hivemind_log_handler("in_root_logger")
 logger = get_logger()
 
 LRSchedulerBase = getattr(torch.optim.lr_scheduler, "_LRScheduler", None)

--- a/examples/albert/run_trainer.py
+++ b/examples/albert/run_trainer.py
@@ -138,7 +138,7 @@ class CollaborativeCallback(transformers.TrainerCallback):
                     loss=self.loss,
                     mini_steps=self.steps,
                 )
-                logger.info(f"Step {self.collaborative_optimizer.local_step}")
+                logger.info(f"Step #{self.collaborative_optimizer.local_step}")
                 logger.info(f"Your current contribution: {self.total_samples_processed} samples")
                 logger.info(f"Performance: {samples_per_second} samples per second.")
                 if self.steps:

--- a/examples/albert/run_trainer.py
+++ b/examples/albert/run_trainer.py
@@ -18,32 +18,20 @@ from transformers.trainer import Trainer
 from transformers.trainer_utils import is_main_process
 
 import hivemind
+from hivemind.utils.logging import get_logger
 
 import utils
 from arguments import AlbertTrainingArguments, AveragerArguments, CollaborationArguments, DatasetArguments
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 LRSchedulerBase = getattr(torch.optim.lr_scheduler, "_LRScheduler", None)
 
 
 def setup_logging(training_args):
-    logging.basicConfig(
-        format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
-        datefmt="%m/%d/%Y %H:%M:%S",
-        level=logging.INFO if is_main_process(training_args.local_rank) else logging.WARN,
-    )
-
-    # Log on each process the small summary:
-    logger.warning(
-        f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
-        + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
-    )
-    # Set the verbosity to info of the Transformers logger (on main process only):
     if is_main_process(training_args.local_rank):
         transformers.utils.logging.set_verbosity_info()
         transformers.utils.logging.enable_default_handler()
         transformers.utils.logging.enable_explicit_format()
-    logger.info("Training/evaluation parameters %s", training_args)
 
 
 def get_model(training_args, config, tokenizer):
@@ -221,6 +209,7 @@ def main():
         raise ValueError("Please specify at least one network endpoint in initial peers.")
 
     setup_logging(training_args)
+    logger.info(f"Training/evaluation parameters:\n{training_args}")
 
     # Set seed before initializing model.
     set_seed(training_args.seed)

--- a/examples/albert/run_trainer.py
+++ b/examples/albert/run_trainer.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import logging
 import os
 import pickle
 from dataclasses import asdict
@@ -18,16 +17,18 @@ from transformers.trainer import Trainer
 from transformers.trainer_utils import is_main_process
 
 import hivemind
-from hivemind.utils.logging import get_logger
+from hivemind.utils.logging import LoggingMode, get_logger, loglevel, set_logging_mode
 
 import utils
 from arguments import AlbertTrainingArguments, AveragerArguments, CollaborationArguments, DatasetArguments
 
+set_logging_mode(LoggingMode.PROGRAM_WIDE)
 logger = get_logger()
+
 LRSchedulerBase = getattr(torch.optim.lr_scheduler, "_LRScheduler", None)
 
 
-def setup_logging(training_args):
+def setup_transformers_logging(training_args):
     if is_main_process(training_args.local_rank):
         transformers.utils.logging.set_verbosity_info()
         transformers.utils.logging.disable_default_handler()
@@ -208,7 +209,7 @@ def main():
     if len(collaboration_args.initial_peers) == 0:
         raise ValueError("Please specify at least one network endpoint in initial peers.")
 
-    setup_logging(training_args)
+    setup_transformers_logging(training_args)
     logger.info(f"Training/evaluation parameters:\n{training_args}")
 
     # Set seed before initializing model.

--- a/examples/albert/run_trainer.py
+++ b/examples/albert/run_trainer.py
@@ -23,15 +23,15 @@ from hivemind.utils.logging import get_logger
 import utils
 from arguments import AlbertTrainingArguments, AveragerArguments, CollaborationArguments, DatasetArguments
 
-logger = get_logger(__name__)
+logger = get_logger()
 LRSchedulerBase = getattr(torch.optim.lr_scheduler, "_LRScheduler", None)
 
 
 def setup_logging(training_args):
     if is_main_process(training_args.local_rank):
         transformers.utils.logging.set_verbosity_info()
-        transformers.utils.logging.enable_default_handler()
-        transformers.utils.logging.enable_explicit_format()
+        transformers.utils.logging.disable_default_handler()
+        transformers.utils.logging.enable_propagation()
 
 
 def get_model(training_args, config, tokenizer):

--- a/examples/albert/run_trainer.py
+++ b/examples/albert/run_trainer.py
@@ -17,12 +17,12 @@ from transformers.trainer import Trainer
 from transformers.trainer_utils import is_main_process
 
 import hivemind
-from hivemind.utils.logging import LoggingMode, get_logger, loglevel, set_logging_mode
+from hivemind.utils.logging import get_logger, use_hivemind_log_style
 
 import utils
 from arguments import AlbertTrainingArguments, AveragerArguments, CollaborationArguments, DatasetArguments
 
-set_logging_mode(LoggingMode.PROGRAM_WIDE)
+use_hivemind_log_style('everywhere')
 logger = get_logger()
 
 LRSchedulerBase = getattr(torch.optim.lr_scheduler, "_LRScheduler", None)

--- a/examples/albert/run_trainer.py
+++ b/examples/albert/run_trainer.py
@@ -28,8 +28,8 @@ logger = get_logger()
 LRSchedulerBase = getattr(torch.optim.lr_scheduler, "_LRScheduler", None)
 
 
-def setup_transformers_logging(training_args):
-    if is_main_process(training_args.local_rank):
+def setup_transformers_logging(process_rank: int):
+    if is_main_process(process_rank):
         transformers.utils.logging.set_verbosity_info()
         transformers.utils.logging.disable_default_handler()
         transformers.utils.logging.enable_propagation()
@@ -209,7 +209,7 @@ def main():
     if len(collaboration_args.initial_peers) == 0:
         raise ValueError("Please specify at least one network endpoint in initial peers.")
 
-    setup_transformers_logging(training_args)
+    setup_transformers_logging(training_args.local_rank)
     logger.info(f"Training/evaluation parameters:\n{training_args}")
 
     # Set seed before initializing model.

--- a/examples/albert/run_training_monitor.py
+++ b/examples/albert/run_training_monitor.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import logging
 import time
 from dataclasses import asdict, dataclass, field
 from ipaddress import ip_address
@@ -13,11 +12,12 @@ from torch_optimizer import Lamb
 from transformers import AlbertConfig, AlbertForPreTraining, HfArgumentParser
 
 import hivemind
-from hivemind.utils.logging import get_logger
+from hivemind.utils.logging import LoggingMode, get_logger, set_logging_mode
 
 import utils
 from arguments import AveragerArguments, BaseTrainingArguments, CollaborativeOptimizerArguments
 
+set_logging_mode(LoggingMode.PROGRAM_WIDE)
 logger = get_logger()
 
 

--- a/examples/albert/run_training_monitor.py
+++ b/examples/albert/run_training_monitor.py
@@ -12,12 +12,12 @@ from torch_optimizer import Lamb
 from transformers import AlbertConfig, AlbertForPreTraining, HfArgumentParser
 
 import hivemind
-from hivemind.utils.logging import get_logger, use_hivemind_log_format
+from hivemind.utils.logging import get_logger, use_hivemind_log_handler
 
 import utils
 from arguments import AveragerArguments, BaseTrainingArguments, CollaborativeOptimizerArguments
 
-use_hivemind_log_format("in_root_logger")
+use_hivemind_log_handler("in_root_logger")
 logger = get_logger()
 
 

--- a/examples/albert/run_training_monitor.py
+++ b/examples/albert/run_training_monitor.py
@@ -18,7 +18,7 @@ from hivemind.utils.logging import get_logger
 import utils
 from arguments import AveragerArguments, BaseTrainingArguments, CollaborativeOptimizerArguments
 
-logger = get_logger(__name__)
+logger = get_logger()
 
 
 @dataclass

--- a/examples/albert/run_training_monitor.py
+++ b/examples/albert/run_training_monitor.py
@@ -140,7 +140,7 @@ class CheckpointHandler:
         self.model.push_to_hub(
             repo_name=self.repo_path,
             repo_url=self.repo_url,
-            commit_message=f"Step {current_step}, loss {current_loss:.3f}",
+            commit_message=f"Step #{current_step}, loss {current_loss:.3f}",
         )
         logger.info("Finished uploading to Model Hub")
 

--- a/examples/albert/run_training_monitor.py
+++ b/examples/albert/run_training_monitor.py
@@ -17,7 +17,7 @@ from hivemind.utils.logging import get_logger, use_hivemind_log_style
 import utils
 from arguments import AveragerArguments, BaseTrainingArguments, CollaborativeOptimizerArguments
 
-use_hivemind_log_style('everywhere')
+use_hivemind_log_style("everywhere")
 logger = get_logger()
 
 

--- a/examples/albert/run_training_monitor.py
+++ b/examples/albert/run_training_monitor.py
@@ -13,11 +13,12 @@ from torch_optimizer import Lamb
 from transformers import AlbertConfig, AlbertForPreTraining, HfArgumentParser
 
 import hivemind
+from hivemind.utils.logging import get_logger
 
 import utils
 from arguments import AveragerArguments, BaseTrainingArguments, CollaborativeOptimizerArguments
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/examples/albert/run_training_monitor.py
+++ b/examples/albert/run_training_monitor.py
@@ -12,12 +12,12 @@ from torch_optimizer import Lamb
 from transformers import AlbertConfig, AlbertForPreTraining, HfArgumentParser
 
 import hivemind
-from hivemind.utils.logging import get_logger, use_hivemind_log_style
+from hivemind.utils.logging import get_logger, use_hivemind_log_format
 
 import utils
 from arguments import AveragerArguments, BaseTrainingArguments, CollaborativeOptimizerArguments
 
-use_hivemind_log_style("everywhere")
+use_hivemind_log_format("in_root_logger")
 logger = get_logger()
 
 

--- a/examples/albert/run_training_monitor.py
+++ b/examples/albert/run_training_monitor.py
@@ -12,12 +12,12 @@ from torch_optimizer import Lamb
 from transformers import AlbertConfig, AlbertForPreTraining, HfArgumentParser
 
 import hivemind
-from hivemind.utils.logging import LoggingMode, get_logger, set_logging_mode
+from hivemind.utils.logging import get_logger, use_hivemind_log_style
 
 import utils
 from arguments import AveragerArguments, BaseTrainingArguments, CollaborativeOptimizerArguments
 
-set_logging_mode(LoggingMode.PROGRAM_WIDE)
+use_hivemind_log_style('everywhere')
 logger = get_logger()
 
 

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -237,7 +237,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
         if not self.collaboration_state.ready_for_step:
             return
 
-        logger.log(self.status_loglevel, f"Beginning global optimizer step {self.collaboration_state.optimizer_step}")
+        logger.log(self.status_loglevel, f"Beginning global optimizer step #{self.collaboration_state.optimizer_step}")
         self.collaboration_state = self._fetch_state()
         self.collaboration_state_updated.set()
 
@@ -288,7 +288,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
         if not self.collaboration_state.ready_for_step:
             return
 
-        logger.log(self.status_loglevel, f"Beginning global optimizer step {self.collaboration_state.optimizer_step}")
+        logger.log(self.status_loglevel, f"Beginning global optimizer step #{self.collaboration_state.optimizer_step}")
         self.collaboration_state = self._fetch_state()
         self.collaboration_state_updated.set()
 
@@ -453,7 +453,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
         logger.log(
             self.status_loglevel,
             f"{self.prefix} accumulated {total_samples_accumulated} samples from "
-            f"{num_peers} peers towards step {global_optimizer_step}. "
+            f"{num_peers} peers for step #{global_optimizer_step}. "
             f"ETA {estimated_time_to_next_step:.2f} sec (refresh in {time_to_next_fetch:.2f} sec)",
         )
         return CollaborationState(

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -153,7 +153,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
         self.performance_ema = PerformanceEMA(alpha=performance_ema_alpha)
         self.last_step_time = None
 
-        self.collaboration_state = self.fetch_collaboration_state()
+        self.collaboration_state = self._fetch_state()
         self.lock_collaboration_state, self.collaboration_state_updated = Lock(), Event()
         self.lock_local_progress, self.should_report_progress = Lock(), Event()
         self.progress_reporter = Thread(target=self.report_training_progress, daemon=True, name=f"{self}.reporter")
@@ -238,7 +238,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
             return
 
         logger.log(self.status_loglevel, f"Beginning global optimizer step {self.collaboration_state.optimizer_step}")
-        self.collaboration_state = self.fetch_collaboration_state()
+        self.collaboration_state = self._fetch_state()
         self.collaboration_state_updated.set()
 
         if not self.is_synchronized:
@@ -289,7 +289,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
             return
 
         logger.log(self.status_loglevel, f"Beginning global optimizer step {self.collaboration_state.optimizer_step}")
-        self.collaboration_state = self.fetch_collaboration_state()
+        self.collaboration_state = self._fetch_state()
         self.collaboration_state_updated.set()
 
         with self.lock_collaboration_state:
@@ -392,9 +392,9 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
                 continue  # if state was updated externally, reset timer
 
             with self.lock_collaboration_state:
-                self.collaboration_state = self.fetch_collaboration_state()
+                self.collaboration_state = self._fetch_state()
 
-    def fetch_collaboration_state(self) -> CollaborationState:
+    def _fetch_state(self) -> CollaborationState:
         """Read performance statistics reported by peers, estimate progress towards next batch"""
         response, _expiration = self.dht.get(self.training_progress_key, latest=True) or (None, -float("inf"))
         current_time = get_dht_time()

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -452,7 +452,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
         )
         logger.log(
             self.status_loglevel,
-            f"Collaboration accumulated {total_samples_accumulated} samples from "
+            f"{self.prefix} accumulated {total_samples_accumulated} samples from "
             f"{num_peers} peers; ETA {estimated_time_to_next_step:.2f} seconds "
             f"(refresh in {time_to_next_fetch:.2f}s.)",
         )

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -453,8 +453,8 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
         logger.log(
             self.status_loglevel,
             f"{self.prefix} accumulated {total_samples_accumulated} samples from "
-            f"{num_peers} peers; ETA {estimated_time_to_next_step:.2f} seconds "
-            f"(refresh in {time_to_next_fetch:.2f}s.)",
+            f"{num_peers} peers towards step {global_optimizer_step}. "
+            f"ETA {estimated_time_to_next_step:.2f} sec (refresh in {time_to_next_fetch:.2f} sec)",
         )
         return CollaborationState(
             global_optimizer_step,

--- a/hivemind/utils/logging.py
+++ b/hivemind/utils/logging.py
@@ -15,6 +15,10 @@ if _env_colors is not None:
 else:
     use_colors = sys.stderr.isatty()
 
+_init_lock = threading.RLock()
+_current_mode = HandlerMode.NOWHERE  # This is the initial state before module initialization but not an actual default
+_default_handler = None
+
 
 class TextStyle:
     """
@@ -32,9 +36,6 @@ class TextStyle:
         # Set the constants above to empty strings
         _codes = locals()
         _codes.update({_name: "" for _name in list(_codes) if _name.isupper()})
-
-
-_PACKAGE_NAME = __name__.split(".")[0]
 
 
 class CustomFormatter(logging.Formatter):
@@ -72,11 +73,6 @@ class HandlerMode(Enum):
     NOWHERE = 0
     IN_HIVEMIND = 1
     IN_ROOT_LOGGER = 2
-
-
-_init_lock = threading.RLock()
-_current_mode = HandlerMode.NOWHERE  # This is the initial state before module initialization but not an actual default
-_default_handler = None
 
 
 def _initialize_if_necessary():
@@ -142,14 +138,14 @@ def use_hivemind_log_handler(where: Union[HandlerMode, str]) -> None:
         where = HandlerMode[where.upper()]
 
     if _current_mode == HandlerMode.IN_HIVEMIND:
-        _disable_default_handler(_PACKAGE_NAME)
+        _disable_default_handler("hivemind")
     elif _current_mode == HandlerMode.IN_ROOT_LOGGER:
         _disable_default_handler(None)
 
     _current_mode = where
 
     if _current_mode == HandlerMode.IN_HIVEMIND:
-        _enable_default_handler(_PACKAGE_NAME)
+        _enable_default_handler("hivemind")
     elif _current_mode == HandlerMode.IN_ROOT_LOGGER:
         _enable_default_handler(None)
 

--- a/hivemind/utils/logging.py
+++ b/hivemind/utils/logging.py
@@ -34,6 +34,9 @@ class TextStyle:
         _codes.update({_name: "" for _name in list(_codes) if _name.isupper()})
 
 
+_PACKAGE_NAME = __name__.split(".")[0]
+
+
 class CustomFormatter(logging.Formatter):
     """
     A formatter that allows a log time and caller info to be overridden via
@@ -56,7 +59,7 @@ class CustomFormatter(logging.Formatter):
 
         if not hasattr(record, "caller"):
             module_path = record.name.split(".")
-            if module_path[0] == "hivemind":
+            if module_path[0] == _PACKAGE_NAME:
                 module_path = module_path[1:]
             record.caller = f"{'.'.join(module_path)}.{record.funcName}:{record.lineno}"
 
@@ -68,7 +71,11 @@ class CustomFormatter(logging.Formatter):
         return super().format(record)
 
 
-_PACKAGE_NAME = __name__.split(".")[0]
+class HandlerMode(Enum):
+    NOWHERE = 0
+    IN_HIVEMIND = 1
+    IN_ROOT_LOGGER = 2
+
 
 _init_lock = threading.RLock()
 _current_mode = HandlerMode.NOWHERE  # This is the initial state before module initialization but not an actual default
@@ -114,12 +121,6 @@ def _disable_default_handler(name: str) -> None:
     logger.removeHandler(_default_handler)
     logger.propagate = True
     logger.setLevel(logging.NOTSET)
-
-
-class HandlerMode(Enum):
-    NOWHERE = 0
-    IN_HIVEMIND = 1
-    IN_ROOT_LOGGER = 2
 
 
 def use_hivemind_log_handler(where: Union[HandlerMode, str]) -> None:

--- a/hivemind/utils/logging.py
+++ b/hivemind/utils/logging.py
@@ -3,7 +3,7 @@ import os
 import sys
 import threading
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union
 
 logging.addLevelName(logging.WARNING, "WARN")
 
@@ -89,8 +89,8 @@ def _initialize_if_necessary():
         _default_handler = logging.StreamHandler()
         _default_handler.setFormatter(formatter)
 
-        _current_mode = LoggingMode.PROPAGATE  # Corresponds to the initial logger state
-        set_logging_mode(LoggingMode.PACKAGE_WIDE)  # Overriding it to the desired default
+        _current_mode = StyleMode.NOWHERE  # Corresponds to the initial logger state
+        use_hivemind_log_style(StyleMode.AMONG_HIVEMIND)  # Overriding it to the desired default
 
 
 def get_logger(name: Optional[str] = None) -> logging.Logger:
@@ -112,25 +112,29 @@ def _disable_default_handler(name: str) -> None:
     logger.setLevel(logging.NOTSET)
 
 
-class LoggingMode(Enum):
-    PACKAGE_WIDE = 0
-    PROGRAM_WIDE = 1
-    PROPAGATE = 2
+class StyleMode(Enum):
+    NOWHERE = 0
+    AMONG_HIVEMIND = 1
+    EVERYWHERE = 2
 
 
-def set_logging_mode(mode: LoggingMode) -> None:
+def use_hivemind_log_style(where: Union[StyleMode, str]) -> None:
     global _current_mode
 
-    if _current_mode == LoggingMode.PACKAGE_WIDE:
+    if isinstance(where, str):
+        # We allow `where` to be a string, so a developer does not have to import the enum for one usage
+        where = StyleMode[where.upper()]
+
+    if _current_mode == StyleMode.AMONG_HIVEMIND:
         _disable_default_handler(_PACKAGE_NAME)
-    elif _current_mode == LoggingMode.PROGRAM_WIDE:
+    elif _current_mode == StyleMode.EVERYWHERE:
         _disable_default_handler(None)
 
-    _current_mode = mode
+    _current_mode = where
 
-    if _current_mode == LoggingMode.PACKAGE_WIDE:
+    if _current_mode == StyleMode.AMONG_HIVEMIND:
         _enable_default_handler(_PACKAGE_NAME)
-    elif _current_mode == LoggingMode.PROGRAM_WIDE:
+    elif _current_mode == StyleMode.EVERYWHERE:
         _enable_default_handler(None)
 
 

--- a/hivemind/utils/logging.py
+++ b/hivemind/utils/logging.py
@@ -58,10 +58,7 @@ class CustomFormatter(logging.Formatter):
             record.msecs = (record.created - int(record.created)) * 1000
 
         if not hasattr(record, "caller"):
-            module_path = record.name.split(".")
-            if module_path[0] == _PACKAGE_NAME:
-                module_path = module_path[1:]
-            record.caller = f"{'.'.join(module_path)}.{record.funcName}:{record.lineno}"
+            record.caller = f"{record.name}.{record.funcName}:{record.lineno}"
 
         # Aliases for the format argument
         record.levelcolor = self._LEVEL_TO_COLOR[record.levelno]

--- a/hivemind/utils/logging.py
+++ b/hivemind/utils/logging.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from typing import Optional
 
 logging.addLevelName(logging.WARNING, "WARN")
 
@@ -65,8 +66,8 @@ class CustomFormatter(logging.Formatter):
         return super().format(record)
 
 
-def get_logger(module_name: str) -> logging.Logger:
-    logger = logging.getLogger(module_name)
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    logger = logging.getLogger(name)
     logger.setLevel(loglevel)
     logger.propagate = False
 

--- a/hivemind/utils/logging.py
+++ b/hivemind/utils/logging.py
@@ -5,6 +5,13 @@ import threading
 from enum import Enum
 from typing import Optional, Union
 
+
+class HandlerMode(Enum):
+    NOWHERE = 0
+    IN_HIVEMIND = 1
+    IN_ROOT_LOGGER = 2
+
+
 logging.addLevelName(logging.WARNING, "WARN")
 
 loglevel = os.getenv("LOGLEVEL", "INFO")
@@ -67,12 +74,6 @@ class CustomFormatter(logging.Formatter):
         record.reset = TextStyle.RESET
 
         return super().format(record)
-
-
-class HandlerMode(Enum):
-    NOWHERE = 0
-    IN_HIVEMIND = 1
-    IN_ROOT_LOGGER = 2
 
 
 def _initialize_if_necessary():

--- a/hivemind/utils/logging.py
+++ b/hivemind/utils/logging.py
@@ -71,6 +71,7 @@ class CustomFormatter(logging.Formatter):
 _PACKAGE_NAME = __name__.split(".")[0]
 
 _init_lock = threading.RLock()
+_current_mode = StyleMode.NOWHERE  # This is the initial state before module initialization but not an actual default
 _default_handler = None
 
 
@@ -89,8 +90,7 @@ def _initialize_if_necessary():
         _default_handler = logging.StreamHandler()
         _default_handler.setFormatter(formatter)
 
-        _current_mode = StyleMode.NOWHERE  # Corresponds to the initial logger state
-        use_hivemind_log_style(StyleMode.AMONG_HIVEMIND)  # Overriding it to the desired default
+        use_hivemind_log_format(StyleMode.IN_HIVEMIND)  # Overriding it to the desired default
 
 
 def get_logger(name: Optional[str] = None) -> logging.Logger:
@@ -114,27 +114,27 @@ def _disable_default_handler(name: str) -> None:
 
 class StyleMode(Enum):
     NOWHERE = 0
-    AMONG_HIVEMIND = 1
-    EVERYWHERE = 2
+    IN_HIVEMIND = 1
+    IN_ROOT_LOGGER = 2
 
 
-def use_hivemind_log_style(where: Union[StyleMode, str]) -> None:
+def use_hivemind_log_format(where: Union[StyleMode, str]) -> None:
     global _current_mode
 
     if isinstance(where, str):
         # We allow `where` to be a string, so a developer does not have to import the enum for one usage
         where = StyleMode[where.upper()]
 
-    if _current_mode == StyleMode.AMONG_HIVEMIND:
+    if _current_mode == StyleMode.IN_HIVEMIND:
         _disable_default_handler(_PACKAGE_NAME)
-    elif _current_mode == StyleMode.EVERYWHERE:
+    elif _current_mode == StyleMode.IN_ROOT_LOGGER:
         _disable_default_handler(None)
 
     _current_mode = where
 
-    if _current_mode == StyleMode.AMONG_HIVEMIND:
+    if _current_mode == StyleMode.IN_HIVEMIND:
         _enable_default_handler(_PACKAGE_NAME)
-    elif _current_mode == StyleMode.EVERYWHERE:
+    elif _current_mode == StyleMode.IN_ROOT_LOGGER:
         _enable_default_handler(None)
 
 


### PR DESCRIPTION
## Preliminaries

The current implementation of `hivemind.utils.logging` has several problems (they are not related to the colored logging and exist for a long time):

1. __Bugs:__ Sometimes, one message is logged multiple times. This due to the combination of the bugs:

    - If `name` stays the same, `logging.getLogger(name)` always returns the same logger instance. We expect the same behavior from hivemind's `get_logger(name)`, however it adds a new `logging.StreamHandler` to the logger instance every time. If it is called N times, you will have N stream handlers and each message will be repeated N times.
 
    - hivemind's `get_logger(name)` trims the first item in the module path. While this is intended to make the log line shorter by trimming the `hivemind.` string, this actually forces all modules at the root scope (e.g. `utils.py` and `huggingface_auth.py` at [tanmoyai/sahajbert](https://github.com/tanmoyio/sahajbert)) to use the same logger. Because of the previous bug, we end up logging the same message multiple times even if we use different `name`s.

2. It is not obvious how to force other libraries (such as `transformers`) to use our logging style, so we have __inconsistent log line styles__ in the example. Screenshot:

    <img width="700" alt="Screen Shot 2021-09-04 at 6 35 08 AM" src="https://user-images.githubusercontent.com/8748943/132081140-763b8a2b-31f2-4430-b02b-bb7b25b6ef8c.png">

3. Since `hivemind` is a library, a developer may want to use it but keep the existing logging style in their application (i.e. force hivemind to follow it). Currently, there is no way to do it since `get_logger()` does not use message propagation to the application loggers.

## Solution

1. First, we fix the bugs above, making `get_logger()` be idempotent and trim the `hivemind.` prefix only while displaying lines.

2. Next, we note that there are 3 possible use cases:

    - _(default)_ A user tries importing hivemind. It uses its own logging style among the package.
    - A user likes the hivemind logging style and wants to use it among their application (e.g. force other libraries to follow it).
    - A user does not like the hivemind logging style and wants to force it to follow another existing style.

    We give a user a straightforward way to switch between these use cases via a special function:

    ```python
    use_hivemind_log_handler("in_hivemind")     # Option 1 (default)
    use_hivemind_log_handler("in_root_logger")  # Option 2, make the root logger to use hivemind style
    use_hivemind_log_handler("nowhere")         # Option 3, propagate hivemind logs to the existing root logger
    ```

    __Note:__ This approach is inspired by the `transformers.logging` module ([docs](https://huggingface.co/transformers/main_classes/logging.html), [source](https://github.com/huggingface/transformers/blob/master/src/transformers/utils/logging.py)). The module allows to enable/disable the propagation to the root logger and enable/disable the `transformers` default log style. However, our API is even higher-level.

3. We enable the `in_root_logger` mode in `examples/albert`, so that all messages (from `__main__`, `transformers`, and `hivemind` itself) consistently follow the hivemind style. Screenshot:

    <img width="700" alt="Screen Shot 2021-09-04 at 6 33 03 AM" src="https://user-images.githubusercontent.com/8748943/132081093-ecefb96a-01ff-4861-a26c-3c9bde458dd6.png">

4. We change some log messages to improve their presentation.