### PR TITLE
Fix step_tolerance in CollaborativeOptimizer

### DIFF
--- a/examples/albert/arguments.py
+++ b/examples/albert/arguments.py
@@ -49,7 +49,7 @@ class AveragerArguments:
         default=5.0, metadata={"help": "Averaging group will wait for stragglers for at most this many seconds"}
     )
     averaging_timeout: float = field(
-        default=30.0, metadata={"help": "Give up on averaging step after this many seconds"}
+        default=60.0, metadata={"help": "Give up on averaging step after this many seconds"}
     )
     min_refresh_period: float = field(
         default=0.5, metadata={"help": "Wait for at least this many seconds before fetching new collaboration state"}

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -451,7 +451,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
 
         for state in valid_peer_states:
             total_samples_per_second += state.samples_per_second
-            if state.step >= self.local_step and current_time - state.time < self.staleness_timeout:
+            if state.step == self.local_step and current_time - state.time < self.staleness_timeout:
                 total_samples_accumulated += state.samples_accumulated
                 estimated_current_samples += (
                     state.samples_accumulated + max(0, current_time - state.time) * state.samples_per_second

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -179,10 +179,6 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
     def local_step(self) -> int:
         return self.averager.local_step
 
-    @local_step.setter
-    def local_step(self, new_value: int):
-        self.averager.local_step = new_value
-
     @property
     def is_synchronized(self) -> bool:
         return self.local_step >= self.collaboration_state.optimizer_step

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -451,11 +451,10 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
 
         for state in valid_peer_states:
             total_samples_per_second += state.samples_per_second
-            delta_time = current_time - state.time
-            if state.step >= global_optimizer_step - self.step_tolerance and delta_time > self.staleness_timeout:
+            if state.step >= global_optimizer_step and current_time - state.time < self.staleness_timeout:
                 total_samples_accumulated += state.samples_accumulated
                 estimated_current_samples += (
-                    state.samples_accumulated + max(0, delta_time) * state.samples_per_second
+                    state.samples_accumulated + max(0, current_time - state.time) * state.samples_per_second
                 )
             # note: we deliberately count only valid peers for samples_accumulated, but all peers for performance;
             # the rationale behind this is that outdated peers will synchronize and begin contributing shortly.

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -425,9 +425,9 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
 
         if not isinstance(response, dict) or len(response) == 0:
             logger.log(self.status_loglevel, f"Found no active peers: {response}")
-            local_eta_next_step = (
-                    max(0, self.target_batch_size - self.local_updates_accumulated) / self.performance_ema.samples_per_second
-            )
+            samples_left_to_target_batch_size = max(0, self.target_batch_size - self.local_samples_accumulated)
+            local_eta_next_step = samples_left_to_target_batch_size / self.performance_ema.samples_per_second
+
             return CollaborationState(
                 self.local_step,
                 self.local_samples_accumulated,

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -118,7 +118,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
         metadata_expiration: float = 60.0,
         averaging_timeout: Optional[float] = None,
         load_state_timeout: float = 600.0,
-        staleness_timeout: float = 15.0,
+        staleness_timeout: float = 30.0,
         step_tolerance: int = 1,
         reuse_grad_buffers: bool = False,
         accumulate_grads_on: Optional[torch.device] = None,

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -255,7 +255,8 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
                 weight = self.local_samples_accumulated / mean_samples_per_worker
                 try:
                     group_info = self.averager.step(
-                        weight=weight, gather=current_step, timeout=self.averaging_timeout, **kwargs)
+                        weight=weight, gather=current_step, timeout=self.averaging_timeout, **kwargs
+                    )
                     if group_info:
                         logger.log(self.status_loglevel, f"Averaged tensors successfully with {len(group_info)} peers")
 

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -254,7 +254,8 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
                 mean_samples_per_worker = self.target_batch_size / self.collaboration_state.num_peers
                 weight = self.local_samples_accumulated / mean_samples_per_worker
                 try:
-                    group_info = self.averager.step(weight=weight, timeout=self.averaging_timeout, **kwargs)
+                    group_info = self.averager.step(
+                        weight=weight, gather=current_step, timeout=self.averaging_timeout, **kwargs)
                     if group_info:
                         logger.log(self.status_loglevel, f"Averaged tensors successfully with {len(group_info)} peers")
 

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -451,7 +451,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
 
         for state in valid_peer_states:
             if current_time - state.time > self.staleness_timeout:
-                logger.debug(f"Peer record {state} was discarded because it is too old: {current_time - state.time} s.")
+                logger.debug(f"Ignoring record {state} because it is too old: {current_time - state.time} seconds.")
                 continue
             total_samples_per_second += state.samples_per_second
             if state.step >= global_optimizer_step - self.step_tolerance:

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -81,6 +81,8 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
       refresh the collaboration-wide statistics (to avoid missing the moment when to run the next step)
     :param bandwidth: peer's network bandwidth for the purpose of load balancing (recommended: internet speed in mbps)
     :param step_tolerance: a peer can temporarily be delayed by this many steps without being deemed out of sync
+    :param staleness_timeout: peers that reported gradients this many seconds ago or earlier do not count
+      toward progress for the current step (but do count toward other statistics, such as the collaboraiton size)
     :param performance_ema_alpha: smoothing value used to estimate this peer's performance (training samples per second)
     :param averaging_expiration: peer's requests for averaging will be valid for this many seconds
     :param metadata_expiration: peer's metadata (e.g. samples processed) is stored onto DHT for this many seconds
@@ -116,6 +118,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
         metadata_expiration: float = 60.0,
         averaging_timeout: Optional[float] = None,
         load_state_timeout: float = 600.0,
+        staleness_timeout: float = 30.0,
         step_tolerance: int = 1,
         reuse_grad_buffers: bool = False,
         accumulate_grads_on: Optional[torch.device] = None,
@@ -139,6 +142,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
             default_refresh_period,
         )
         self.expected_drift_peers, self.expected_drift_rate = expected_drift_peers, expected_drift_rate
+        self.staleness_timeout = staleness_timeout
         self.averaging_timeout = averaging_timeout
         self.load_state_timeout = load_state_timeout
         self.metadata_expiration = metadata_expiration
@@ -447,10 +451,11 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
 
         for state in valid_peer_states:
             total_samples_per_second += state.samples_per_second
-            if state.step >= global_optimizer_step - self.step_tolerance:
+            delta_time = current_time - state.time
+            if state.step >= global_optimizer_step - self.step_tolerance and delta_time > self.staleness_timeout:
                 total_samples_accumulated += state.samples_accumulated
                 estimated_current_samples += (
-                    state.samples_accumulated + max(0, current_time - state.time) * state.samples_per_second
+                    state.samples_accumulated + max(0, delta_time) * state.samples_per_second
                 )
             # note: we deliberately count only valid peers for samples_accumulated, but all peers for performance;
             # the rationale behind this is that outdated peers will synchronize and begin contributing shortly.

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -81,8 +81,6 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
       refresh the collaboration-wide statistics (to avoid missing the moment when to run the next step)
     :param bandwidth: peer's network bandwidth for the purpose of load balancing (recommended: internet speed in mbps)
     :param step_tolerance: a peer can temporarily be delayed by this many steps without being deemed out of sync
-    :param staleness_timeout: peers that reported gradients this many seconds ago or earlier do not count
-      toward progress for the current step (but do count toward other statistics, such as the collaboraiton size)
     :param performance_ema_alpha: smoothing value used to estimate this peer's performance (training samples per second)
     :param averaging_expiration: peer's requests for averaging will be valid for this many seconds
     :param metadata_expiration: peer's metadata (e.g. samples processed) is stored onto DHT for this many seconds
@@ -118,7 +116,6 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
         metadata_expiration: float = 60.0,
         averaging_timeout: Optional[float] = None,
         load_state_timeout: float = 600.0,
-        staleness_timeout: float = 30.0,
         step_tolerance: int = 1,
         reuse_grad_buffers: bool = False,
         accumulate_grads_on: Optional[torch.device] = None,
@@ -142,7 +139,6 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
             default_refresh_period,
         )
         self.expected_drift_peers, self.expected_drift_rate = expected_drift_peers, expected_drift_rate
-        self.staleness_timeout = staleness_timeout
         self.averaging_timeout = averaging_timeout
         self.load_state_timeout = load_state_timeout
         self.metadata_expiration = metadata_expiration
@@ -451,7 +447,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
 
         for state in valid_peer_states:
             total_samples_per_second += state.samples_per_second
-            if state.step == self.local_step and current_time - state.time < self.staleness_timeout:
+            if state.step == self.local_step:
                 total_samples_accumulated += state.samples_accumulated
                 estimated_current_samples += (
                     state.samples_accumulated + max(0, current_time - state.time) * state.samples_per_second

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -450,8 +450,9 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
         total_samples_accumulated = estimated_current_samples = total_samples_per_second = 0
 
         for state in valid_peer_states:
-            if current_time - state.time < self.staleness_timeout:
+            if current_time - state.time > self.staleness_timeout:
                 logger.debug(f"Peer record {state} was discarded because it is too old: {current_time - state.time} s.")
+                continue
             total_samples_per_second += state.samples_per_second
             if state.step >= global_optimizer_step - self.step_tolerance:
                 total_samples_accumulated += state.samples_accumulated

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -451,7 +451,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
 
         for state in valid_peer_states:
             total_samples_per_second += state.samples_per_second
-            if state.step >= global_optimizer_step and current_time - state.time < self.staleness_timeout:
+            if state.step >= self.local_step and current_time - state.time < self.staleness_timeout:
                 total_samples_accumulated += state.samples_accumulated
                 estimated_current_samples += (
                     state.samples_accumulated + max(0, current_time - state.time) * state.samples_per_second

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -81,6 +81,8 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
       refresh the collaboration-wide statistics (to avoid missing the moment when to run the next step)
     :param bandwidth: peer's network bandwidth for the purpose of load balancing (recommended: internet speed in mbps)
     :param step_tolerance: a peer can temporarily be delayed by this many steps without being deemed out of sync
+    :param staleness_timeout: peers that reported gradients this many seconds ago or earlier do not count
+      toward progress for the current step (but do count toward other statistics, such as the collaboraiton size)
     :param performance_ema_alpha: smoothing value used to estimate this peer's performance (training samples per second)
     :param averaging_expiration: peer's requests for averaging will be valid for this many seconds
     :param metadata_expiration: peer's metadata (e.g. samples processed) is stored onto DHT for this many seconds
@@ -116,6 +118,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
         metadata_expiration: float = 60.0,
         averaging_timeout: Optional[float] = None,
         load_state_timeout: float = 600.0,
+        staleness_timeout: float = 15.0,
         step_tolerance: int = 1,
         reuse_grad_buffers: bool = False,
         accumulate_grads_on: Optional[torch.device] = None,
@@ -139,6 +142,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
             default_refresh_period,
         )
         self.expected_drift_peers, self.expected_drift_rate = expected_drift_peers, expected_drift_rate
+        self.staleness_timeout = staleness_timeout
         self.averaging_timeout = averaging_timeout
         self.load_state_timeout = load_state_timeout
         self.metadata_expiration = metadata_expiration
@@ -446,6 +450,8 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
         total_samples_accumulated = estimated_current_samples = total_samples_per_second = 0
 
         for state in valid_peer_states:
+            if current_time - state.time < self.staleness_timeout:
+                logger.debug(f"Peer record {state} was discarded because it is too old: {current_time - state.time} s.")
             total_samples_per_second += state.samples_per_second
             if state.step >= global_optimizer_step - self.step_tolerance:
                 total_samples_accumulated += state.samples_accumulated

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -455,7 +455,7 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
 
         for state in valid_peer_states:
             total_samples_per_second += state.samples_per_second
-            if state.step >= global_optimizer_step:
+            if state.step == global_optimizer_step:
                 total_samples_accumulated += state.samples_accumulated
                 estimated_current_samples += (
                     state.samples_accumulated + max(0, current_time - state.time) * state.samples_per_second


### PR DESCRIPTION
This PR fixes a bug found by @yhn112 in our internal experiments

When a one peer have inadvertently ended up once step ahead of others, it would cause the following cycle:
- old peers would not load state from new ones because the new peer is still within step_tolerance
- old peers would not contribute to training minibatches because we did not account for step tolerance there
- new peers will maintain the 1-step distance from others because they made steps concurrently with the rest

In practice, this resulted in significant performance degradations for several (~10) steps infrequently during training

__new behavior:__ if a peer detects another peer who is ahead, but _within tolerance_, it will attempt to jump to that peer's step.

__Other changes:__
* changed default timeout from 30s to 1 minute to ensure that users will be able to run *something* even with a slow connection
* fixed a minor bug that caused wrong ETA to next step when collaboration consisted of exactly 1 peer