### PR TITLE
Simplified all-reduce for asymmetric tcp

### DIFF
--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -608,7 +608,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
                     logger.info(f"Downloading parameters from peer {peer}")
                     try:
                         stub = self.get_stub(self._p2p, peer, namespace=self.prefix)
-                        stream = stub.rpc_download_state(averaging_pb2.DownloadRequest())
+                        stream = await stub.rpc_download_state(averaging_pb2.DownloadRequest())
                         current_tensor_parts, tensors = [], []
 
                         async for message in aiter_with_timeout(stream, timeout=self.request_timeout):

--- a/hivemind/averaging/matchmaking.py
+++ b/hivemind/averaging/matchmaking.py
@@ -180,7 +180,7 @@ class Matchmaking:
             async with self.lock_request_join_group:
                 leader_stub = self._servicer_type.get_stub(self._p2p, leader, namespace=self._prefix)
 
-                stream = leader_stub.rpc_join_group(
+                stream = await leader_stub.rpc_join_group(
                     averaging_pb2.JoinRequest(
                         schema_hash=self.schema_hash,
                         expiration=expiration_time,

--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -13,7 +13,7 @@ from hivemind.proto import runtime_pb2
 from hivemind.utils.asyncio import amap_in_executor
 
 T = TypeVar("T")
-DEFAULT_PART_SIZE_BYTES = 2 ** 16
+DEFAULT_PART_SIZE_BYTES = 2 ** 19
 
 
 class TensorPartContainer:

--- a/hivemind/p2p/servicer.py
+++ b/hivemind/p2p/servicer.py
@@ -90,13 +90,13 @@ class ServicerBase:
         # This method will be added to a new Stub type (a subclass of StubBase)
         if handler.stream_output:
 
-            def caller(
+            async def caller(
                 self: StubBase, input: input_type, timeout: None = None
             ) -> AsyncIterator[handler.response_type]:
                 if timeout is not None:
                     raise ValueError("Timeouts for handlers returning streams are not supported")
 
-                return self._p2p.iterate_protobuf_handler(
+                return await self._p2p.iterate_protobuf_handler(
                     self._peer,
                     cls._get_handle_name(self._namespace, handler.method_name),
                     input,

--- a/tests/test_p2p_servicer.py
+++ b/tests/test_p2p_servicer.py
@@ -67,9 +67,10 @@ async def test_unary_stream(server_client):
     servicer = ExampleServicer()
     await servicer.add_p2p_handlers(server)
     stub = ExampleServicer.get_stub(client, server.peer_id)
+    stream = await stub.rpc_count(test_pb2.TestRequest(number=10))
 
     i = 0
-    async for item in stub.rpc_count(test_pb2.TestRequest(number=10)):
+    async for item in stream:
         assert item == test_pb2.TestResponse(number=i)
         i += 1
     assert i == 10
@@ -94,8 +95,10 @@ async def test_stream_stream(server_client):
         for i in range(10):
             yield test_pb2.TestRequest(number=i)
 
+    stream = await stub.rpc_powers(generate_requests())
+
     i = 0
-    async for item in stub.rpc_powers(generate_requests()):
+    async for item in stream:
         if i % 2 == 0:
             assert item == test_pb2.TestResponse(number=(i // 2) ** 2)
         else:
@@ -140,7 +143,7 @@ async def test_unary_stream_cancel(server_client, cancel_reason):
         writer.close()
     elif cancel_reason == "close_generator":
         stub = ExampleServicer.get_stub(client, server.peer_id)
-        iter = stub.rpc_wait(test_pb2.TestRequest(number=10))
+        iter = await stub.rpc_wait(test_pb2.TestRequest(number=10))
 
         assert await anext(iter) == test_pb2.TestResponse(number=11)
         await asyncio.sleep(0.25)


### PR DESCRIPTION
* [x] add an option to run sequential all-reduce, wherein a runner receives results only after it finishes sending tensors
* [x] ensure that calling stream RPC begins sending inputs right away, instead of when awaiting the first output
* [ ] right before merging, run a performance test on colab+nora


Note: on some systems (e.g. colab), one can get faster _bidirectional_ throughput by using BBR congestion control:
```
sudo cat <<EOF > /etc/sysctl.d/10-custom-kernel-bbr.conf
net.core.default_qdisc=fq
net.ipv4.tcp_congestion_control=bbr
EOF

sudo sysctl --system
```

However, this did not work for kaggle and looks kind of hacky in the script.