### PR TITLE
Apply averager updates asynchronously

### DIFF
--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -450,7 +450,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
                         self.last_updated = get_dht_time()
                     else:
                         async for _ in allreduce:  # trigger all-reduce by iterating
-                            assert False, "aux peers should not receive averaged tensors"
+                            raise ValueError("aux peers should not receive averaged tensors")
 
                 return allreduce.gathered
         except BaseException as e:


### PR DESCRIPTION
The baseline averager would first compute all updates and hold them in memory, then apply them to self.averaged_tensors.

The new version applies updates immediately upon receiving them.

This does not affect the rest of the code because asynchronous updates can only be received after you've sent the corresponding part to the averager.

This saves ~400mb ram in sahajbert2

