### PR TITLE
Fix schema typing

### DIFF
--- a/hivemind/dht/schema.py
+++ b/hivemind/dht/schema.py
@@ -18,9 +18,7 @@ class SchemaValidator(RecordValidatorBase):
     This allows to enforce types, min/max values, require a subkey to contain a public key, etc.
     """
 
-    def __init__(
-        self, schema: Type[pydantic.BaseModel], *, allow_extra_keys: bool = True, prefix: Optional[str] = None
-    ):
+    def __init__(self, schema: Type[pydantic.BaseModel], allow_extra_keys: bool = True, prefix: Optional[str] = None):
         """
         :param schema: The Pydantic model (a subclass of pydantic.BaseModel).
 


### PR DESCRIPTION
This PR changes the expected type of schema from BaseModel **instance** to BaseModel **class** because that is how it is used.

This fixes the following error:
![image](https://user-images.githubusercontent.com/3491902/138772707-88a15f94-72d1-46b8-bc89-e29ee815e8d1.png)
