### PR TITLE
[hotfix] replace StepControl.can_modify with began_allreduce

### DIFF
--- a/hivemind/averaging/control.py
+++ b/hivemind/averaging/control.py
@@ -103,7 +103,7 @@ class StepControl(MPFuture):
     @stage.setter
     def stage(self, stage: AveragingStage):
         if stage == AveragingStage.RUNNING_ALLREDUCE:
-            self.can_modify = False
+            self.began_allreduce = True
         self._shared_buffer[StepControl._STAGE] = stage.value
 
     @property


### PR DESCRIPTION
This PR fixes an edge case: previously, DecentralizedAverager would not set began_allreduce correctly when actually running all-reduce. It had mistakenly set can_modify=False instead of the actual property began_allreduce=True.