### PR TITLE
Make target group size optional

### DIFF
--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -112,7 +112,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
         *,
         start: bool,
         prefix: str,
-        target_group_size: int = 2 ** 63 - 1,
+        target_group_size: Optional[int] = None,
         min_group_size: int = 2,
         initial_group_bits: str = "",
         averaging_expiration: Optional[float] = None,
@@ -137,8 +137,6 @@ class DecentralizedAverager(mp.Process, ServicerBase):
         assert bandwidth is None or (
             bandwidth >= 0 and np.isfinite(np.float32(bandwidth))
         ), "bandwidth must be a non-negative float32"
-        if not is_power_of_two(target_group_size):
-            logger.warning("It is recommended to set target_group_size to a power of 2.")
         assert all(bit in "01" for bit in initial_group_bits)
         assert not client_mode or not auxiliary, "auxiliary peers must accept incoming connections"
 
@@ -695,11 +693,6 @@ class DecentralizedAverager(mp.Process, ServicerBase):
         except Exception as e:
             if not future.done():
                 future.set_exception(e)
-
-
-def is_power_of_two(n):
-    """Check whether n is a power of 2"""
-    return (n != 0) and (n & (n - 1) == 0)
 
 
 def _background_thread_fetch_current_state(

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -112,7 +112,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
         *,
         start: bool,
         prefix: str,
-        target_group_size: int,
+        target_group_size: int = 2 ** 63 - 1,
         min_group_size: int = 2,
         initial_group_bits: str = "",
         averaging_expiration: Optional[float] = None,

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -428,7 +428,6 @@ def test_averaging_trigger():
         hivemind.averaging.DecentralizedAverager(
             averaged_tensors=[torch.randn(3)],
             dht=dht,
-            target_group_size=4,
             min_matchmaking_time=0.5,
             request_timeout=0.3,
             prefix="mygroup",


### PR DESCRIPTION
This pull-request makes target_group_size optional, to avoid bothering user with setting it.
The rationale here is that in most cases we ended up using `target_group_size=some_very_large_number_please_be_large_enough`.
Therefore, it would make sense to make this a default choice to avoid concerning users with the extra low-level kwarg.