### PR TITLE
Implement state sharing priority

### DIFF
--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -565,30 +565,25 @@ class DecentralizedAverager(mp.Process, ServicerBase):
             yield message
 
     async def _declare_for_download_periodically(self):
-        return#TODO
         download_key = f"{self._matchmaking.group_key_manager.prefix}.all_averagers"
         sharing_was_allowed = self.allow_state_sharing
         while True:
-            self._should_redeclare_state_sharing.clear()
+            expiration_time = get_dht_time() + self.declare_state_period
             if self.allow_state_sharing or sharing_was_allowed:
                 # notify either if sharing is allowed or if it was just switched off (to overwrite previous message)
-                asyncio.create_task(
-                    asyncio.wait_for(
-                        self.dht.store(
-                            download_key,
-                            subkey=self.peer_id.to_bytes(),
-                            value=self.state_sharing_priority if self.allow_state_sharing else None,
-                            expiration_time=get_dht_time() + self.declare_state_period,
-                            return_future=True,
-                        ),
-                        timeout=self.declare_state_period - self.request_timeout,
-                    )
+                await self.dht.store(
+                    download_key,
+                    subkey=self.peer_id.to_bytes(),
+                    value=self.state_sharing_priority if self.allow_state_sharing else None,
+                    expiration_time=expiration_time,
+                    return_future=True,
                 )
                 sharing_was_allowed = self.allow_state_sharing
 
             # report again either in state_declare_period or after the field was changed by the user
+            self._should_redeclare_state_sharing.clear()
             await asyncio.get_event_loop().run_in_executor(
-                None, self._should_redeclare_state_sharing.wait, self.declare_state_period - self.request_timeout
+                None, self._should_redeclare_state_sharing.wait, max(0.0, expiration_time - get_dht_time())
             )
 
     async def rpc_download_state(

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -568,6 +568,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
         download_key = f"{self._matchmaking.group_key_manager.prefix}.all_averagers"
         sharing_was_allowed = self.allow_state_sharing
         while True:
+            self._should_redeclare_state_sharing.clear()
             expiration_time = get_dht_time() + self.declare_state_period
 
             if self.allow_state_sharing or sharing_was_allowed:
@@ -586,12 +587,11 @@ class DecentralizedAverager(mp.Process, ServicerBase):
                 )
                 sharing_was_allowed = self.allow_state_sharing
 
-            self._should_redeclare_state_sharing.clear()
-
             # report again either in state_declare_period or after the field was changed by the user
             await asyncio.get_event_loop().run_in_executor(
                 None, self._should_redeclare_state_sharing.wait, self.declare_state_period - self.request_timeout
             )
+
 
     async def rpc_download_state(
         self, _request: averaging_pb2.DownloadRequest, _context: P2PContext

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -582,10 +582,10 @@ class DecentralizedAverager(mp.Process, ServicerBase):
                             download_key,
                             subkey=self.peer_id.to_bytes(),
                             value=self.state_sharing_priority if self.allow_state_sharing else None,
-                            expiration_time=get_dht_time() + self.declare_state_period,
+                            expiration_time=expiration_time,
                             return_future=True,
                         ),
-                        timeout=self.declare_state_period - self.request_timeout,
+                        timeout=expiration_time - get_dht_time(),
                     )
                 )
                 sharing_was_allowed = self.allow_state_sharing

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -567,7 +567,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
     async def _declare_for_download_periodically(self):
         download_key = f"{self._matchmaking.group_key_manager.prefix}.all_averagers"
         sharing_was_allowed = self.allow_state_sharing
-        for i in range(3):#TODO limit iterations
+        while True:
             expiration_time = get_dht_time() + self.declare_state_period
             if self.allow_state_sharing or sharing_was_allowed:
                 # notify either if sharing is allowed or if it was just switched off (to overwrite previous message)
@@ -582,9 +582,10 @@ class DecentralizedAverager(mp.Process, ServicerBase):
 
             # report again either in state_declare_period or after the field was changed by the user
             self._should_redeclare_state_sharing.clear()
-            await asyncio.get_event_loop().run_in_executor(
-                None, self._should_redeclare_state_sharing.wait, max(0.0, expiration_time - get_dht_time())
-            )
+            #await asyncio.get_event_loop().run_in_executor(
+            #    None, self._should_redeclare_state_sharing.wait, max(0.0, expiration_time - get_dht_time())
+            #)
+            await asyncio.sleep(0.1)
 
     async def rpc_download_state(
         self, _request: averaging_pb2.DownloadRequest, _context: P2PContext

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -565,12 +565,11 @@ class DecentralizedAverager(mp.Process, ServicerBase):
             yield message
 
     async def _declare_for_download_periodically(self):
+        return#TODO
         download_key = f"{self._matchmaking.group_key_manager.prefix}.all_averagers"
         sharing_was_allowed = self.allow_state_sharing
         while True:
             self._should_redeclare_state_sharing.clear()
-            expiration_time = get_dht_time() + self.declare_state_period
-
             if self.allow_state_sharing or sharing_was_allowed:
                 # notify either if sharing is allowed or if it was just switched off (to overwrite previous message)
                 asyncio.create_task(
@@ -579,7 +578,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
                             download_key,
                             subkey=self.peer_id.to_bytes(),
                             value=self.state_sharing_priority if self.allow_state_sharing else None,
-                            expiration_time=expiration_time,
+                            expiration_time=get_dht_time() + self.declare_state_period,
                             return_future=True,
                         ),
                         timeout=self.declare_state_period - self.request_timeout,

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -191,8 +191,8 @@ class DecentralizedAverager(mp.Process, ServicerBase):
 
         self._inner_pipe, self._outer_pipe = mp.Pipe(duplex=True)  # a control pipe used to communicate with daemon
 
-        self._allow_state_sharing = mp.Value(ctypes.c_bool, 0)
-        self._state_sharing_priority = mp.Value(ctypes.c_double, 0)
+        self._allow_state_sharing = mp.Value(ctypes.c_bool, 0, lock=False)
+        self._state_sharing_priority = mp.Value(ctypes.c_double, 0, lock=False)
         self._should_redeclare_state_sharing = mp.Event()
 
         if allow_state_sharing is None:

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -238,7 +238,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
             raise ValueError("State sharing priority is unused: averager in client mode cannot share its state.")
         else:
             old_value, self._state_sharing_priority.value = self._state_sharing_priority.value, value
-            if value != old_value:
+            if self.allow_state_sharing and value != old_value:
                 self._should_redeclare_state_sharing.set()
 
     @property

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -191,8 +191,8 @@ class DecentralizedAverager(mp.Process, ServicerBase):
 
         self._inner_pipe, self._outer_pipe = mp.Pipe(duplex=True)  # a control pipe used to communicate with daemon
 
-        self._allow_state_sharing = mp.Value(ctypes.c_bool, 0, lock=False)
-        self._state_sharing_priority = mp.Value(ctypes.c_double, 0, lock=False)
+        self._allow_state_sharing = mp.Value(ctypes.c_bool, 0)
+        self._state_sharing_priority = mp.Value(ctypes.c_double, 0)
         self._should_redeclare_state_sharing = mp.Event()
 
         if allow_state_sharing is None:
@@ -567,7 +567,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
     async def _declare_for_download_periodically(self):
         download_key = f"{self._matchmaking.group_key_manager.prefix}.all_averagers"
         sharing_was_allowed = self.allow_state_sharing
-        while True:
+        for i in range(3):#TODO limit iterations
             expiration_time = get_dht_time() + self.declare_state_period
             if self.allow_state_sharing or sharing_was_allowed:
                 # notify either if sharing is allowed or if it was just switched off (to overwrite previous message)

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -573,12 +573,15 @@ class DecentralizedAverager(mp.Process, ServicerBase):
             if self.allow_state_sharing or sharing_was_allowed:
                 # notify either if sharing is allowed or if it was just switched off (to overwrite previous message)
                 asyncio.create_task(
-                    self.dht.store(
-                        download_key,
-                        subkey=self.peer_id.to_bytes(),
-                        value=self.state_sharing_priority if self.allow_state_sharing else None,
-                        expiration_time=expiration_time,
-                        return_future=True,
+                    asyncio.wait_for(
+                        self.dht.store(
+                            download_key,
+                            subkey=self.peer_id.to_bytes(),
+                            value=self.state_sharing_priority if self.allow_state_sharing else None,
+                            expiration_time=expiration_time,
+                            return_future=True,
+                        ),
+                        timeout=self.declare_state_period - self.request_timeout,
                     )
                 )
                 sharing_was_allowed = self.allow_state_sharing

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -592,7 +592,6 @@ class DecentralizedAverager(mp.Process, ServicerBase):
                 None, self._should_redeclare_state_sharing.wait, self.declare_state_period - self.request_timeout
             )
 
-
     async def rpc_download_state(
         self, _request: averaging_pb2.DownloadRequest, _context: P2PContext
     ) -> AsyncIterator[averaging_pb2.DownloadData]:

--- a/hivemind/optim/collaborative.py
+++ b/hivemind/optim/collaborative.py
@@ -320,9 +320,13 @@ class CollaborativeOptimizer(DecentralizedOptimizerBase):
             self.averager.local_step = current_step + 1
             self.collaboration_state_updated.set()
             self.update_scheduler()
+
             if grad_scaler is not None:
                 with grad_scaler.running_global_step():
                     assert grad_scaler.update()
+
+            if not self.averager.client_mode:
+                self.averager.state_sharing_priority = self.local_step
 
         logger.log(self.status_loglevel, f"Optimizer step: done!")
 

--- a/hivemind/optim/simple.py
+++ b/hivemind/optim/simple.py
@@ -86,6 +86,10 @@ class DecentralizedOptimizer(DecentralizedOptimizerBase):
             if self.local_step % self.averaging_step_period == 0:
                 self.update_event.set()
             self.averager.pending_updates_done.wait()
+
+            if not self.averager.client_mode:
+                self.averager.state_sharing_priority = get_dht_time()
+
             return loss
         finally:
             self.lock_parameters.acquire()

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -346,7 +346,7 @@ def test_overcrowded(num_peers=16):
     for process in averagers + dht_instances:
         process.shutdown()
 
-@pytest.mark.skip("TODO")
+
 @pytest.mark.forked
 def test_load_state_from_peers():
     num_calls = 0
@@ -411,7 +411,6 @@ def test_load_state_from_peers():
         instance.shutdown()
 
 
-@pytest.mark.skip("TODO")
 @pytest.mark.forked
 def test_load_state_priority():
     dht_instances = launch_dht_instances(4)

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -420,7 +420,7 @@ def test_load_state_priority():
             prefix="demo-run",
             target_group_size=2,
         )
-        averager.allow_state_sharing = (i != 2)
+        averager.allow_state_sharing = i != 2
         averager.state_sharing_priority = 5 - abs(3 - i)
         averagers.append(averager)
 

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -380,6 +380,9 @@ def test_load_state_from_peers():
         target_group_size=2,
     )
 
+    # wait until averager2 receives info on loading state
+    dht_instances[1].get("demo-run.all_averagers")
+
     assert num_calls == 0
     got_metadata, got_tensors = averager2.load_state_from_peers()
     assert num_calls == 1

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -429,21 +429,21 @@ def test_load_state_priority():
         averagers.append(averager)
 
     time.sleep(0.5)
-    metadata, tensors = averagers[0].load_state_from_peers()
+    metadata, tensors = averagers[0].load_state_from_peers(timeout=1)
     assert tensors[-1].item() == 3
 
-    metadata, tensors = averagers[3].load_state_from_peers()
+    metadata, tensors = averagers[3].load_state_from_peers(timeout=1)
     assert tensors[-1].item() == 4
 
     averagers[1].state_sharing_priority = 10
     time.sleep(0.2)
 
-    metadata, tensors = averagers[0].load_state_from_peers()
+    metadata, tensors = averagers[0].load_state_from_peers(timeout=1)
     assert tensors[-1].item() == 1
 
     averagers[1].allow_state_sharing = False
     averagers[3].allow_state_sharing = False
-    metadata, tensors = averagers[0].load_state_from_peers()
+    metadata, tensors = averagers[0].load_state_from_peers(timeout=1)
     assert tensors[-1].item() == 4
 
 

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -411,6 +411,7 @@ def test_load_state_from_peers():
         instance.shutdown()
 
 
+@pytest.mark.skip(reason="TODO checking that it's not github actions")
 @pytest.mark.forked
 def test_load_state_priority():
     dht_instances = launch_dht_instances(5)

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -372,6 +372,9 @@ def test_load_state_from_peers():
         target_group_size=2,
     )
 
+    # wait until averager2 receives info on loading state
+    dht_instances[1].get("demo-run.all_averagers")
+
     averager2 = TestAverager(
         [torch.randn(3), torch.rand(5)],
         dht=dht_instances[1],
@@ -379,9 +382,6 @@ def test_load_state_from_peers():
         prefix="demo-run",
         target_group_size=2,
     )
-
-    # wait until averager2 receives info on loading state
-    dht_instances[1].get("demo-run.all_averagers")
 
     assert num_calls == 0
     got_metadata, got_tensors = averager2.load_state_from_peers()

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -372,9 +372,6 @@ def test_load_state_from_peers():
         target_group_size=2,
     )
 
-    # wait until averager2 receives info on loading state
-    dht_instances[1].get("demo-run.all_averagers")
-
     averager2 = TestAverager(
         [torch.randn(3), torch.rand(5)],
         dht=dht_instances[1],
@@ -382,6 +379,8 @@ def test_load_state_from_peers():
         prefix="demo-run",
         target_group_size=2,
     )
+
+    time.sleep(0.5)
 
     assert num_calls == 0
     got_metadata, got_tensors = averager2.load_state_from_peers()
@@ -401,7 +400,9 @@ def test_load_state_from_peers():
 
     averager1.allow_state_sharing = False
     assert averager2.load_state_from_peers() is None
+
     averager1.allow_state_sharing = True
+    time.sleep(0.5)
     got_metadata, got_tensors = averager2.load_state_from_peers()
     assert num_calls == 3
     assert got_metadata == super_metadata

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -448,6 +448,8 @@ def test_load_state_priority():
 
     for averager in averagers:
         averager.shutdown()
+    for dht in dht_instances:
+        dht.shutdown()
 
 
 @pytest.mark.forked

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -423,8 +423,8 @@ def test_load_state_priority():
             start=True,
             prefix="demo-run",
             target_group_size=2,
+            allow_state_sharing=i != 2,
         )
-        averager.allow_state_sharing = i != 2
         averager.state_sharing_priority = 5 - abs(3 - i)
         averagers.append(averager)
 

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -446,6 +446,9 @@ def test_load_state_priority():
     metadata, tensors = averagers[0].load_state_from_peers(timeout=1)
     assert tensors[-1].item() == 4
 
+    for averager in averagers:
+        averager.shutdown()
+
 
 @pytest.mark.forked
 def test_getset_bits():

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -346,7 +346,7 @@ def test_overcrowded(num_peers=16):
     for process in averagers + dht_instances:
         process.shutdown()
 
-
+@pytest.mark.skip("TODO")
 @pytest.mark.forked
 def test_load_state_from_peers():
     num_calls = 0
@@ -411,6 +411,7 @@ def test_load_state_from_peers():
         instance.shutdown()
 
 
+@pytest.mark.skip("TODO")
 @pytest.mark.forked
 def test_load_state_priority():
     dht_instances = launch_dht_instances(4)

--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -427,6 +427,7 @@ def test_load_state_priority():
         averager.state_sharing_priority = 5 - abs(3 - i)
         averagers.append(averager)
 
+    time.sleep(0.5)
     metadata, tensors = averagers[0].load_state_from_peers()
     assert tensors[-1].item() == 3
 


### PR DESCRIPTION
Previously, peers would download state from an (effectively) random existing peer.
As a result, sometimes if many peers got out of sync, they would re-download state from another out-of-sync peer for many times before they got it right.

This PR prioritizes downloading state from "latest" peers, depending on the optimizer.

__Note:__ an intermediate version of this PR used a multiprocessing.Event to trigger re-declaring priority to the DHT. However, this turned out to **harm test performance for py39**. The slowdown was caused specifically by this one line: `await loop.run_in_executor(None, mp_event.wait, timeout_here)` in _declare_for_download_periodically. Other python versions are not affected. I have no idea why py39 reacts like this, but i ended up switching away from MP events just in case.