### PR TITLE
Hotfix: load_state_from_peers with offload_optimizer

### DIFF
--- a/hivemind/optim/experimental/state_averager.py
+++ b/hivemind/optim/experimental/state_averager.py
@@ -631,7 +631,8 @@ class TrainingStateAverager(DecentralizedAverager):
         Attempt to download the latest optimizer state from peers and update trainer parameters/statistics.
         :returns: whether or the averager succeeded in loading parameters
         """
-        main_parameters_and_extras = tuple(chain(self.main_parameters, self.extra_tensors))
+        opt_parameters = tuple(param for param_group in self.optimizer.param_groups for param in param_group["params"])
+        main_parameters_and_extras = tuple(chain(opt_parameters, self.extra_tensors))
         num_parameters_and_extras = len(main_parameters_and_extras)
 
         loaded_state = super().load_state_from_peers(**kwargs)
@@ -661,6 +662,8 @@ class TrainingStateAverager(DecentralizedAverager):
 
         if self.offload_optimizer:
             self._apply_optimizer_parameters_()
+        if not self.reuse_tensors:
+            self._load_local_tensors_into_averager_()
 
         self.local_epoch = metadata["epoch"]
         self._update_scheduler()


### PR DESCRIPTION
hivemind.optim.experimental.Optimizer with offload_optimizer=True behaved incorrectly when loading state from peers.

It would load the state into local parameters, and then it was **meant to** write new parameters into the offloaded optimizer, but actually overriden the newly loaded parameters with old offloaded ones. The PR fixes this.

Demonstration 1: peers with uneven performance are now handled correctly (same as in CollaborativeOptimizer)
![image](https://user-images.githubusercontent.com/3491902/144333070-3f4d7f47-aacf-4ca3-886d-14f3bc536a2b.png)

Demonstration 2: peers that join late are now handled correctly even with offload_optimizer=True. In the demo below, the **orange peer** started late.
![image](https://user-images.githubusercontent.com/3491902/144333467-1d7fb33f-f07d-45f7-bfb0-6c3856e49345.png)

Before fix, late peers with offload_optimizer would have correct main parameters, but their optimizer would actually have wrong parameters
![image](https://user-images.githubusercontent.com/3491902/144333284-2a3e3cd2-b83e-4aa0-ba99-522c35b2d5db.png)

