### PR TITLE
Add minor tweaks learned from the NeurIPS demo run

### DIFF
--- a/hivemind/averaging/matchmaking.py
+++ b/hivemind/averaging/matchmaking.py
@@ -242,7 +242,7 @@ class Matchmaking:
             logger.debug(f"{self} - potential leader {leader} did not respond within {self.request_timeout}")
             return None
         except (P2PHandlerError, ControlFailure, DispatchFailure, StopAsyncIteration) as e:
-            logger.exception(f"{self} - failed to request potential leader {leader}:")
+            logger.debug(f"{self} - failed to request potential leader {leader}:")
             return None
 
         finally:

--- a/hivemind/averaging/matchmaking.py
+++ b/hivemind/averaging/matchmaking.py
@@ -16,6 +16,7 @@ from hivemind.averaging.group_info import GroupInfo
 from hivemind.averaging.key_manager import GroupKey, GroupKeyManager
 from hivemind.dht import DHT, DHTID, DHTExpiration
 from hivemind.p2p import P2P, P2PContext, P2PHandlerError, PeerID, ServicerBase
+from hivemind.p2p.p2p_daemon_bindings.utils import ControlFailure, DispatchFailure
 from hivemind.proto import averaging_pb2
 from hivemind.utils import TimedStorage, get_dht_time, get_logger, timed_storage
 from hivemind.utils.asyncio import anext, cancel_and_wait
@@ -240,7 +241,7 @@ class Matchmaking:
         except asyncio.TimeoutError:
             logger.debug(f"{self} - potential leader {leader} did not respond within {self.request_timeout}")
             return None
-        except (P2PHandlerError, StopAsyncIteration) as e:
+        except (P2PHandlerError, ControlFailure, DispatchFailure, StopAsyncIteration) as e:
             logger.exception(f"{self} - failed to request potential leader {leader}:")
             return None
 

--- a/hivemind/optim/experimental/progress_tracker.py
+++ b/hivemind/optim/experimental/progress_tracker.py
@@ -352,3 +352,7 @@ class ProgressTracker(threading.Thread):
             expiration_time=get_dht_time() + self.metadata_expiration,
             return_future=True,
         )
+
+    def __del__(self):
+        if self.is_alive():
+            self.shutdown()

--- a/hivemind/optim/experimental/progress_tracker.py
+++ b/hivemind/optim/experimental/progress_tracker.py
@@ -83,7 +83,7 @@ class ProgressTracker(threading.Thread):
         *,
         client_mode: Optional[bool] = None,
         min_refresh_period: float = 0.5,
-        max_refresh_period: float = 30,
+        max_refresh_period: float = 10,
         default_refresh_period: float = 3,
         expected_drift_peers: float = 3,
         expected_drift_rate: float = 0.2,


### PR DESCRIPTION
- if matchmaking encountered ControlFailure (dial failed), it would catch an error and restart completely. A more preferable behavior is to treat it as any other network errror
- awaiting for delayed updates to finish will no longer freeze forever if underlying update hanged
- rollback default max_refresh_timeout to 10 seconds

Previously, a dead peer would cause others to print errors incessently for 20-30 seconds trying to dial it
![image](https://user-images.githubusercontent.com/3491902/145660332-67f64a61-5cdc-4c96-be2d-bfe7678f9ac7.png)
