### PR TITLE
Improve All-Reduce fault-tolerance

### DIFF
--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -209,7 +209,7 @@ class AllReduceRunner(ServicerBase):
 
                 def _try_deserialize(msg):
                     if msg.code != averaging_pb2.AVERAGED_PART:
-                        return AllreduceException(f"Peer {peer_id} sent {averaging_pb2.MessageCode.Name(msg.code)}")
+                        return AllreduceException(f"{peer_id} sent {averaging_pb2.MessageCode.Name(msg.code)}"), msg
                     try:
                         return deserialize_torch_tensor(msg.tensor_part), msg
                     except Exception as e:

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -149,7 +149,7 @@ class AllReduceRunner(ServicerBase):
         """Run all-reduce, return differences between averaged and original tensors as they are computed"""
         pending_tasks = set()
         if self.sender_timeout is not None:
-            asyncio.create_task(self._handle_missing_senders())
+            pending_tasks.add(asyncio.create_task(self._handle_missing_senders()))
         try:
             if len(self.sender_peer_ids) == 0:
                 logger.debug(f"{self} - finished all-reduce early: all peers are auxiliaries ({self.modes})")

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -149,6 +149,7 @@ class AllReduceRunner(ServicerBase):
         """Run all-reduce, return differences between averaged and original tensors as they are computed"""
         pending_tasks = set()
 
+        handle_missing_senders = None
         if self.tensor_part_container.num_parts_by_peer[self.ordered_peer_ids.index(self.peer_id)] != 0:
             handle_missing_senders = asyncio.create_task(self._handle_missing_senders())
             pending_tasks.add(handle_missing_senders)
@@ -166,8 +167,9 @@ class AllReduceRunner(ServicerBase):
                 async for averaged_tensor_delta in self.tensor_part_container.iterate_output_tensors():
                     yield averaged_tensor_delta  # delta = averaged_tensor - original_tensor
 
-                await handle_missing_senders  # wait for all senders to open a connection or fail(timeout).
-                # If we do not wait, some client-only senders may open connection too late and get BAD_GROUP_ID'd
+                if handle_missing_senders is not None:
+                    await handle_missing_senders  # wait for all senders to open a connection or fail(timeout).
+                    # If we do not wait, some client-only senders may open connection too late and get BAD_GROUP_ID'd
                 self.finalize()
 
             else:  # auxiliary peer

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -168,6 +168,9 @@ class AllReduceRunner(ServicerBase):
                 self.finalize()
 
         except BaseException as e:
+            self.finalize(exception=e)
+            raise
+        finally:
             for task in pending_tasks:
                 task.cancel()
                 try:
@@ -176,8 +179,6 @@ class AllReduceRunner(ServicerBase):
                     pass
                 except Exception as inner_exc:
                     logger.debug(f"Task {task} failed with {inner_exc}", exc_info=True)
-            self.finalize(exception=e)
-            raise
 
     async def _handle_missing_senders(self):
         """Detect senders that should have sent tensors for averaging, but did not send anything within timeout"""

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -113,10 +113,18 @@ class AllReduceRunner(ServicerBase):
                 self.sender_peer_ids.append(peer_id)
 
         self.sender_timeout, self.reducer_timeout = sender_timeout, reducer_timeout
-        self.active_senders: Set[PeerID] = {self.peer_id}  # peers that began sending data via rpc_aggregate_part
         self.all_senders_started = asyncio.Event()
         self.banned_senders: Set[PeerID] = set()  # peers that did not send data by next_chunk_timeout
         self.banlock = asyncio.Lock()
+
+        self.active_senders: Set[PeerID] = set()  # peers that began sending data via rpc_aggregate_part
+        if self.peer_id in self.sender_peer_ids:
+            self.active_senders.add(self.peer_id)
+        if len(self.active_senders) == len(self.sender_peer_ids):
+            self.all_senders_started.set()
+
+
+
 
         peer_id_index = self.ordered_peer_ids.index(self.peer_id)
         self.tensor_part_container = TensorPartContainer(tensors, peer_fractions, return_deltas=True, **kwargs)

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -123,9 +123,6 @@ class AllReduceRunner(ServicerBase):
         if len(self.active_senders) == len(self.sender_peer_ids):
             self.all_senders_started.set()
 
-
-
-
         peer_id_index = self.ordered_peer_ids.index(self.peer_id)
         self.tensor_part_container = TensorPartContainer(tensors, peer_fractions, return_deltas=True, **kwargs)
         self.parts_for_local_averaging = self.tensor_part_container.get_raw_input_parts(peer_id_index)

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -196,7 +196,6 @@ class AllReduceRunner(ServicerBase):
 
         else:
             try:
-                code = None
                 done_sending = asyncio.Event()
                 inputs_aiter = attach_event_on_finished(self._generate_input_for_peer(peer_index), done_sending)
                 stream = await self._get_peer_stub(peer_id).rpc_aggregate_part(inputs_aiter)

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -187,7 +187,6 @@ class AllReduceRunner(ServicerBase):
 
     async def _handle_missing_senders(self):
         """Detect senders that should have sent tensors for averaging, but did not send anything within timeout"""
-        assert self.sender_timeout is not None
         try:
             await asyncio.wait_for(self.all_senders_started.wait(), self.sender_timeout)
         except asyncio.TimeoutError:

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -170,8 +170,12 @@ class AllReduceRunner(ServicerBase):
         except BaseException as e:
             for task in pending_tasks:
                 task.cancel()
-                if task.done() and not task.cancelled():
-                    logger.debug(f"Task {task} failed with {task.exception()}", exc_info=True)
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except Exception as inner_exc:
+                    logger.debug(f"Task {task} failed with {inner_exc}", exc_info=True)
             self.finalize(exception=e)
             raise
 

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -172,7 +172,7 @@ class AllReduceRunner(ServicerBase):
             for task in pending_tasks:
                 task.cancel()
                 if task.done() and not task.cancelled():
-                    logger.debug(f"Task {task} failed with {task.exception()}.")
+                    logger.debug(f"Task {task} failed with {task.exception()}", exc_info=True)
             self.finalize(exception=e)
             raise
 

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -208,11 +208,8 @@ class AllReduceRunner(ServicerBase):
 
                 def _try_deserialize(msg):
                     if msg.code != averaging_pb2.AVERAGED_PART:
-                        return AllreduceException(f"{peer_id} sent {averaging_pb2.MessageCode.Name(msg.code)}"), msg
-                    try:
-                        return deserialize_torch_tensor(msg.tensor_part), msg
-                    except Exception as e:
-                        return e, msg
+                        raise AllreduceException(f"{peer_id} sent {averaging_pb2.MessageCode.Name(msg.code)}")
+                    return deserialize_torch_tensor(msg.tensor_part), msg
 
                 async for delta_or_error, msg in amap_in_executor(
                     _try_deserialize,

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -82,10 +82,10 @@ class AllReduceRunner(ServicerBase):
         self.peer_id = p2p.peer_id
         assert self.peer_id in ordered_peer_ids, "peer_id is not a part of the group"
         if reducer_timeout is not None and (sender_timeout is None or reducer_timeout <= sender_timeout):
-                raise ValueError(
-                    "If reducer_timeout is enabled, sender_timeout must be shorter than reducer_timeout. "
-                    "Otherwise, there is a chance that reducers will be banned while they await senders."
-                )
+            raise ValueError(
+                "If reducer_timeout is enabled, sender_timeout must be shorter than reducer_timeout. "
+                "Otherwise, there is a chance that reducers will be banned while they await senders."
+            )
 
         if not issubclass(servicer_type, ServicerBase):
             raise TypeError("`servicer_type` is expected to be a ServicerBase subclass")

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -170,6 +170,7 @@ class AllReduceRunner(ServicerBase):
         except BaseException as e:
             self.finalize(exception=e)
             raise
+
         finally:
             for task in pending_tasks:
                 task.cancel()

--- a/hivemind/averaging/allreduce.py
+++ b/hivemind/averaging/allreduce.py
@@ -118,7 +118,7 @@ class AllReduceRunner(ServicerBase):
         self.banlock = asyncio.Lock()
 
         peer_id_index = self.ordered_peer_ids.index(self.peer_id)
-        self.tensor_part_container = TensorPartContainer(tensors, peer_fractions, **kwargs)
+        self.tensor_part_container = TensorPartContainer(tensors, peer_fractions, return_deltas=True, **kwargs)
         self.parts_for_local_averaging = self.tensor_part_container.get_raw_input_parts(peer_id_index)
         self.tensor_part_reducer = TensorPartReducer(
             tuple(part.shape for part in self.parts_for_local_averaging),

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -546,7 +546,8 @@ class DecentralizedAverager(mp.Process, ServicerBase):
 
                 return allreduce.gathered
         except BaseException as e:
-            logger.exception(e)
+            if isinstance(e, Exception):
+                logger.exception(e)
             raise MatchmakingException(f"Unable to run All-Reduce: {e}")
 
     @contextlib.contextmanager

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -92,7 +92,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
     :param sender_timeout: during all_reduce, any sender that fails to send tensor chunk within this many seconds from
       previous chunk will be marked as failed and excluded from averaging. default: equal to next_chunk_timeout
     :param reducer_timeout: during all_reduce, any reducer that fails to send results chunk within this many seconds
-      from previous chunk will be marked as failed and excluded from averaging. default: 2 x sender_timeout
+      from previous chunk will be marked as failed and excluded from averaging. default: 2 * sender_timeout
     :param shutdown_timeout: when calling .shutdown, wait for up to this many seconds before terminating
 
     Example:

--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -10,10 +10,11 @@ import torch
 
 from hivemind.compression import CompressionBase, CompressionInfo, NoCompression
 from hivemind.proto import runtime_pb2
-from hivemind.utils.asyncio import amap_in_executor, as_aiter
+from hivemind.utils import amap_in_executor, as_aiter, get_logger
 
 T = TypeVar("T")
 DEFAULT_PART_SIZE_BYTES = 2 ** 19
+logger = get_logger(__name__)
 
 
 class TensorPartContainer:
@@ -248,7 +249,7 @@ class TensorPartReducer:
             if self.num_parts != 0 and self.num_senders != 0:
                 parts_expected, parts_received = (self.num_parts * self.num_senders), sum(self.num_parts_received)
                 if parts_expected != parts_received:
-                    print(f"Reducer: {parts_received / parts_expected * 100:.1f}% of tensors received successfully.")
+                    logger.info(f"Reducer: received {parts_received / parts_expected * 100:.1f}% of tensors.")
 
     def __del__(self):
         self.finalize()

--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -122,8 +122,8 @@ class TensorPartContainer:
         """
         a given peer failed to aggregate a certain part, use our local part instead, keep track of failed parts
         """
-        while len(self._output_parts_by_peer[peer_index]) != len(self._input_parts_by_peer[peer_index]):
-            part_and_info = self._input_parts_by_peer[peer_index][self._outputs_registered_by_peer[peer_index]]
+        while self._outputs_registered_by_peer[peer_index] < self.num_parts_by_peer[peer_index]:
+            part_and_info = self._input_parts_by_peer[peer_index][len(self._output_parts_by_peer[peer_index])]
             self._output_parts_by_peer[peer_index].append(part_and_info[0])
             self._outputs_registered_by_peer[peer_index] += 1
             self._output_part_available[peer_index].set()
@@ -160,8 +160,6 @@ class TensorPartContainer:
         if not self.finished.is_set():
             for peer_index in range(self.group_size):
                 self._inputs_consumed_by_peer[peer_index] = True
-                self._input_parts_by_peer[peer_index].clear()
-                self._output_parts_by_peer[peer_index].clear()
                 self._output_part_available[peer_index].set()
             self._outputs_consumed = True
             self.finished.set()

--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -123,10 +123,9 @@ class TensorPartContainer:
         a given peer failed to aggregate a certain part, use our local part instead, keep track of failed parts
         """
         while self._outputs_registered_by_peer[peer_index] < self.num_parts_by_peer[peer_index]:
-            part_and_info = self._input_parts_by_peer[peer_index][len(self._output_parts_by_peer[peer_index])]
-            self._output_parts_by_peer[peer_index].append(part_and_info[0])
-            self._outputs_registered_by_peer[peer_index] += 1
-            self._output_part_available[peer_index].set()
+            part_index = len(self._output_parts_by_peer[peer_index])
+            part_and_info = self._input_parts_by_peer[peer_index][part_index]
+            self.register_processed_part(peer_index, part_index, part_and_info[0])
 
     async def iterate_output_tensors(self) -> AsyncIterable[torch.Tensor]:
         """iterate over the outputs of averaging (whether they are average, delta or other aggregation result)"""

--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -186,8 +186,7 @@ class TensorPartReducer:
 
         self.num_parts_received = [0 for _ in range(self.num_senders)]
         self.sender_failed_after = [float("inf") for _ in range(self.num_senders)]
-        self.\
-            num_current_senders = self.num_senders
+        self.num_current_senders = self.num_senders
 
         self.reset_accumulators()
 
@@ -201,7 +200,9 @@ class TensorPartReducer:
         self.current_part_index += 1
         self.current_part_accumulated_from = 0
         self.current_part_future = asyncio.Future()
-        self.num_current_senders = sum(self.current_part_index < failed_index for failed_index in self.sender_failed_after)
+        self.num_current_senders = sum(
+            self.current_part_index < failed_index for failed_index in self.sender_failed_after
+        )
         self.accumulator = torch.zeros(self.part_shapes[self.current_part_index])
         self.denominator = 0.0
 

--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -27,7 +27,7 @@ class TensorPartContainer:
     :param compression: optionally compress tensors with this compression algorithm before sending them to peers
     :param part_size_bytes: greedily split tensors into parts of up to this many bytes (after compression)
     :param tensor_infos: CompressionInfo for each respective tensor; this determines how the tensor will be comressed
-    :param return_deltas: if True, treat outputs as differences (aggregated tensor - local tensor)
+    :param return_deltas: if True, output tensors are differences (aggregated tensor - local tensor)
     :param prefetch: when compressing, pre-compute this many compressed tensors in background
     """
 

--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -247,7 +247,8 @@ class TensorPartReducer:
             self.finished.set()
 
             if self.num_parts != 0 and self.num_senders != 0:
-                parts_expected, parts_received = (self.num_parts * self.num_senders), sum(self.num_parts_received)
+                parts_expected = self.num_parts * self.num_senders
+                parts_received = sum(self.num_parts_received)
                 if parts_expected != parts_received:
                     logger.info(f"Reducer: received {parts_received / parts_expected * 100:.1f}% of tensors.")
 

--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -170,7 +170,7 @@ class TensorPartContainer:
                 self._input_parts_by_peer[peer_index].clear()
                 self._output_parts_by_peer[peer_index].clear()
             if self.failed_size != 0:
-                logger.warning(f"Averaging: received {1. - self.failed_size / self.total_size * 100:.1}% of results")
+                logger.warning(f"Averaging: received {(1. - self.failed_size / self.total_size) * 100:.1f}% results")
             self._outputs_consumed = True
             self.finished.set()
 

--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -21,6 +21,7 @@ class TensorPartContainer:
     """
     Auxiliary data structure for averaging, responsible for splitting tensors into parts and reassembling them.
     The class is designed to avoid excessive memory allocation and run all heavy computation in background
+
     :param tensors: local tensors to be split and aggregated
     :param peer_fractions: for each peer, a target fraction of vector elements that this peer should average
     :param compression: optionally compress tensors with this compression algorithm before sending them to peers

--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -254,7 +254,7 @@ class TensorPartReducer:
                 parts_expected = self.num_parts * self.num_senders
                 parts_received = sum(self.num_parts_received)
                 if parts_expected != parts_received:
-                    logger.info(f"Reducer: received {parts_received / parts_expected * 100:.1f}% of tensors.")
+                    logger.info(f"Reducer: received {parts_received / parts_expected * 100:.1f}% of tensors")
 
     def __del__(self):
         self.finalize()

--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -161,6 +161,8 @@ class TensorPartContainer:
             for peer_index in range(self.group_size):
                 self._inputs_consumed_by_peer[peer_index] = True
                 self._output_part_available[peer_index].set()
+                self._input_parts_by_peer[peer_index].clear()
+                self._output_parts_by_peer[peer_index].clear()
             self._outputs_consumed = True
             self.finished.set()
 

--- a/hivemind/averaging/partition.py
+++ b/hivemind/averaging/partition.py
@@ -183,7 +183,7 @@ class TensorPartReducer:
         self.finished = asyncio.Event()
 
         self.num_parts_received = [0 for _ in range(self.num_senders)]
-        self.sender_failed_after = [float('inf') for _ in range(self.num_senders)]
+        self.sender_failed_after = [float("inf") for _ in range(self.num_senders)]
         self.current_senders = self.num_senders
 
         self.reset_accumulators()

--- a/hivemind/optim/experimental/optimizer.py
+++ b/hivemind/optim/experimental/optimizer.py
@@ -427,6 +427,8 @@ class Optimizer(torch.optim.Optimizer):
 
             if self.use_gradient_averaging:
                 logger.log(self.status_loglevel, f"Beginning optimizer step #{self.local_epoch}")
+                self.state_averager.step(wait_for_delayed_updates=True)
+
                 began_averaging_gradients = self._begin_averaging_gradients(grad_scaler)
                 if not began_averaging_gradients:
                     pass  # failed to start gradient averaging due to an internal error
@@ -534,10 +536,6 @@ class Optimizer(torch.optim.Optimizer):
         assert self.use_gradient_averaging
         if self.tracker.estimated_next_update_time - get_dht_time() <= self.matchmaking_time:
             if self.scheduled_grads is None or self.scheduled_grads.triggered or self.scheduled_grads.done():
-                if self.delay_grad_averaging:
-                    # wait for previous averaging to finish before starting a new one
-                    self.state_averager.step(wait_for_delayed_updates=True)
-
                 eta_seconds = self.tracker.estimated_next_update_time - get_dht_time()
                 eta_seconds = max(eta_seconds, self.grad_averager.matchmaking_kwargs["min_matchmaking_time"])
                 logger.log(self.status_loglevel, f"Pre-scheduling gradient averaging round in {eta_seconds:.2f} sec")

--- a/hivemind/optim/experimental/optimizer.py
+++ b/hivemind/optim/experimental/optimizer.py
@@ -543,12 +543,13 @@ class Optimizer(torch.optim.Optimizer):
 
     def _maybe_schedule_state_averaging(self) -> None:
         """If next epoch is coming soon, schedule the next state averaging at estimated parameter averaging start"""
-        return
         next_epoch = max(self.local_epoch + 1, self.tracker.global_epoch)
         if next_epoch % self.average_state_every != 0:
             return  # averaging is not performed at this epoch
         if self.state_averager.averaging_in_progress:
             return  # previous run is still in progress
+        if self.delay_before_state_averaging.num_updates == 0:
+            return  # not enough data to accurately pre-schedule
 
         estimated_time = self.tracker.estimated_next_update_time
         estimated_time += self.delay_before_state_averaging.ema_seconds_per_sample

--- a/hivemind/optim/experimental/optimizer.py
+++ b/hivemind/optim/experimental/optimizer.py
@@ -432,7 +432,8 @@ class Optimizer(torch.optim.Optimizer):
 
             if self.use_gradient_averaging:
                 logger.log(self.status_loglevel, f"Beginning optimizer step #{self.local_epoch}")
-                self.state_averager.step(wait_for_delayed_updates=True)
+                if self.delay_optimizer_step:
+                    self.state_averager.step(wait_for_delayed_updates=True)
 
                 began_averaging_gradients = self._begin_averaging_gradients(grad_scaler)
                 if not began_averaging_gradients:

--- a/hivemind/optim/experimental/optimizer.py
+++ b/hivemind/optim/experimental/optimizer.py
@@ -175,6 +175,7 @@ class Optimizer(torch.optim.Optimizer):
         matchmaking_time: Optional[float] = 15.0,
         averaging_timeout: Optional[float] = 60.0,
         allreduce_timeout: Optional[float] = None,
+        next_chunk_timeout: Optional[float] = None,
         load_state_timeout: float = 600.0,
         reuse_grad_buffers: bool = False,
         offload_optimizer: Optional[bool] = None,
@@ -200,6 +201,7 @@ class Optimizer(torch.optim.Optimizer):
         delay_optimizer_step = delay_optimizer_step if delay_optimizer_step is not None else delay_grad_averaging
         offload_optimizer = offload_optimizer if offload_optimizer is not None else (params is not None)
         allreduce_timeout = allreduce_timeout if allreduce_timeout is not None else averaging_timeout
+        next_chunk_timeout = next_chunk_timeout if next_chunk_timeout is not None else matchmaking_time
         assert not delay_grad_averaging or delay_optimizer_step, "delay_grad_averaging requires delay_optimizer_step"
         assert not (client_mode and auxiliary), "Client-mode peers cannot serve as auxiliaries"
         assert not auxiliary or batch_size_per_step is None, "Auxiliary peers should not accumulate batches"
@@ -230,6 +232,7 @@ class Optimizer(torch.optim.Optimizer):
 
         self.averaging_timeout, self.allreduce_timeout = averaging_timeout, allreduce_timeout
         self.load_state_timeout, self.shutdown_timeout = load_state_timeout, shutdown_timeout
+        self.next_chunk_timeout = next_chunk_timeout
 
         self.status_loglevel = logging.INFO if verbose else logging.DEBUG
         self.scheduled_grads: Optional[StepControl] = None
@@ -252,7 +255,7 @@ class Optimizer(torch.optim.Optimizer):
         )
         if not use_local_updates:
             self.grad_averager = self._make_gradient_averager(
-                reuse_grad_buffers=reuse_grad_buffers, compression=grad_compression, **averager_opts or {}
+                reuse_grad_buffers=reuse_grad_buffers, compression=grad_compression, **averager_opts or {},
             )
         else:
             self.grad_averager = None
@@ -279,6 +282,7 @@ class Optimizer(torch.optim.Optimizer):
             offload_optimizer=self.offload_optimizer,
             custom_gradients=self.offload_optimizer,
             status_loglevel=self.status_loglevel,
+            next_chunk_timeout=self.next_chunk_timeout,
             client_mode=self.client_mode,
             auxiliary=self.auxiliary,
             start=True,
@@ -294,6 +298,7 @@ class Optimizer(torch.optim.Optimizer):
             min_matchmaking_time=self.matchmaking_time,
             allreduce_timeout=self.allreduce_timeout,
             shutdown_timeout=self.shutdown_timeout,
+            next_chunk_timeout=self.next_chunk_timeout,
             client_mode=self.client_mode,
             auxiliary=self.auxiliary,
             start=True,

--- a/hivemind/optim/experimental/optimizer.py
+++ b/hivemind/optim/experimental/optimizer.py
@@ -255,7 +255,7 @@ class Optimizer(torch.optim.Optimizer):
         )
         if not use_local_updates:
             self.grad_averager = self._make_gradient_averager(
-                reuse_grad_buffers=reuse_grad_buffers, compression=grad_compression, **averager_opts or {},
+                reuse_grad_buffers=reuse_grad_buffers, compression=grad_compression, **averager_opts or {}
             )
         else:
             self.grad_averager = None

--- a/hivemind/p2p/p2p_daemon_bindings/datastructures.py
+++ b/hivemind/p2p/p2p_daemon_bindings/datastructures.py
@@ -56,10 +56,10 @@ class PeerID:
         return f"<libp2p.peer.id.ID ({self.to_base58()})>"
 
     def __str__(self):
-        return self.to_base58()[-8:]
+        return self.to_base58()
 
     def pretty(self):
-        return self.to_base58()[-8:]
+        return self.to_base58()
 
     def to_string(self):
         return self.to_base58()

--- a/hivemind/p2p/p2p_daemon_bindings/datastructures.py
+++ b/hivemind/p2p/p2p_daemon_bindings/datastructures.py
@@ -56,10 +56,10 @@ class PeerID:
         return f"<libp2p.peer.id.ID ({self.to_base58()})>"
 
     def __str__(self):
-        return self.to_base58()
+        return self.to_base58()[-8:]
 
     def pretty(self):
-        return self.to_base58()
+        return self.to_base58()[-8:]
 
     def to_string(self):
         return self.to_base58()

--- a/hivemind/utils/asyncio.py
+++ b/hivemind/utils/asyncio.py
@@ -136,7 +136,7 @@ async def amap_in_executor(
             task.exception()
 
 
-async def aiter_with_timeout(iterable: AsyncIterable[T], timeout: float) -> AsyncIterator[T]:
+async def aiter_with_timeout(iterable: AsyncIterable[T], timeout: Optional[float]) -> AsyncIterator[T]:
     """Iterate over an async iterable, raise TimeoutError if another portion of data does not arrive within timeout"""
     # based on https://stackoverflow.com/a/50245879
     iterator = iterable.__aiter__()

--- a/hivemind/utils/asyncio.py
+++ b/hivemind/utils/asyncio.py
@@ -133,8 +133,6 @@ async def amap_in_executor(
         await task
     finally:
         task.cancel()
-        if task.done() and not task.cancelled():
-            task.exception()
 
 
 async def aiter_with_timeout(iterable: AsyncIterable[T], timeout: Optional[float]) -> AsyncIterator[T]:

--- a/hivemind/utils/asyncio.py
+++ b/hivemind/utils/asyncio.py
@@ -130,9 +130,12 @@ async def amap_in_executor(
         while future is not None:
             yield await future
             future = await queue.get()
-        await task
     finally:
         task.cancel()
+        try:
+            await task
+        except Exception as e:
+            logger.debug(f"Caught {e} while iterating over inputs", exc_info=True)
 
 
 async def aiter_with_timeout(iterable: AsyncIterable[T], timeout: Optional[float]) -> AsyncIterator[T]:

--- a/hivemind/utils/asyncio.py
+++ b/hivemind/utils/asyncio.py
@@ -119,7 +119,7 @@ async def amap_in_executor(
                 await queue.put(loop.run_in_executor(executor, func, *args))
             await queue.put(None)
         except BaseException as e:
-            await queue.put(e)  # note: there is no chance that iterables
+            await queue.put(e)
             raise
 
     task = asyncio.create_task(_put_items())

--- a/hivemind/utils/asyncio.py
+++ b/hivemind/utils/asyncio.py
@@ -138,6 +138,9 @@ async def amap_in_executor(
             pass
         except Exception as e:
             logger.debug(f"Caught {e} while iterating over inputs", exc_info=True)
+        while not queue.empty():
+            future = queue.get_nowait()
+            future.cancel()
 
 
 async def aiter_with_timeout(iterable: AsyncIterable[T], timeout: Optional[float]) -> AsyncIterator[T]:

--- a/hivemind/utils/asyncio.py
+++ b/hivemind/utils/asyncio.py
@@ -140,7 +140,8 @@ async def amap_in_executor(
             logger.debug(f"Caught {e} while iterating over inputs", exc_info=True)
         while not queue.empty():
             future = queue.get_nowait()
-            future.cancel()
+            if future is not None:
+                future.cancel()
 
 
 async def aiter_with_timeout(iterable: AsyncIterable[T], timeout: Optional[float]) -> AsyncIterator[T]:

--- a/hivemind/utils/asyncio.py
+++ b/hivemind/utils/asyncio.py
@@ -134,6 +134,8 @@ async def amap_in_executor(
         task.cancel()
         try:
             await task
+        except asyncio.CancelledError:
+            pass
         except Exception as e:
             logger.debug(f"Caught {e} while iterating over inputs", exc_info=True)
 

--- a/hivemind/utils/asyncio.py
+++ b/hivemind/utils/asyncio.py
@@ -121,6 +121,7 @@ async def amap_in_executor(
         except BaseException as e:
             await queue.put(e)  # note: there is no chance that iterables
             raise
+
     task = asyncio.create_task(_put_items())
     try:
         future_or_exception = await queue.get()

--- a/tests/test_allreduce_fault_tolerance.py
+++ b/tests/test_allreduce_fault_tolerance.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import asyncio
+from enum import Enum, auto
+from typing import AsyncIterator
+
+import pytest
+import torch
+
+import hivemind
+from hivemind.averaging.allreduce import AllReduceRunner, AveragingMode
+from hivemind.averaging.averager import *
+from hivemind.averaging.group_info import GroupInfo
+from hivemind.averaging.load_balancing import load_balance_peers
+from hivemind.averaging.matchmaking import MatchmakingException
+from hivemind.proto import averaging_pb2
+from hivemind.utils.asyncio import as_aiter, azip, enter_asynchronously
+from hivemind.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class Fault(Enum):
+    NONE = auto()
+    FAIL_BEFORE = auto()
+    FAIL_SENDING = auto()
+    FAIL_REDUCING = auto()
+    CANCEL = auto()
+
+
+class FaultyAverager(hivemind.DecentralizedAverager):
+    def __init__(self, *args, fault: Fault = Fault.NONE, **kwargs):
+        self.fault = fault
+        super().__init__(*args, **kwargs)
+
+    async def _run_allreduce(self, group_info: GroupInfo, min_vector_size: int, **kwargs) -> GatheredData:
+        """Run All-Reduce in a given group and update tensors in place, return gathered metadata"""
+        try:
+            bandwidths, mode_ids, user_gathered_bytes = zip(*map(self.serializer.loads, group_info.gathered))
+            user_gathered = dict(zip(group_info.peer_ids, map(self.serializer.loads, user_gathered_bytes)))
+            modes = tuple(map(AveragingMode, mode_ids))
+            download_bandwidths = [
+                thr if mode != AveragingMode.CLIENT else 0.0 for thr, mode in zip(bandwidths, modes)
+            ]
+            peer_fractions = await asyncio.get_event_loop().run_in_executor(
+                None, load_balance_peers, self.total_size, download_bandwidths, min_vector_size
+            )
+
+            if self.fault == Fault.FAIL_BEFORE:
+                raise Exception("Oops, I failed!")
+
+            async with enter_asynchronously(self.get_tensors()) as local_tensors:
+                allreduce = FaultyAllReduceRunner(
+                    p2p=self._p2p,
+                    servicer_type=type(self),
+                    prefix=self.prefix,
+                    group_id=group_info.group_id,
+                    tensors=local_tensors,
+                    ordered_peer_ids=group_info.peer_ids,
+                    peer_fractions=peer_fractions,
+                    gathered=user_gathered,
+                    modes=modes,
+                    fault=self.fault,
+                    **kwargs,
+                )
+
+                with self.register_allreduce_group(group_info.group_id, allreduce):
+                    if modes[group_info.peer_ids.index(self.peer_id)] != AveragingMode.AUX:
+                        async for tensor, update in azip(as_aiter(*local_tensors), allreduce):
+                            # all-reduce is performed asynchronously while iterating
+                            tensor.add_(update, alpha=self._averaging_alpha)
+                        self._state_updated.set()
+
+                    else:
+                        async for _ in allreduce:  # trigger all-reduce by iterating
+                            raise ValueError("aux peers should not receive averaged tensors")
+
+                return allreduce.gathered
+        except BaseException as e:
+            logger.exception(e)
+            raise MatchmakingException(f"Unable to run All-Reduce: {e}")
+
+
+class FaultyAllReduceRunner(AllReduceRunner):
+    def __init__(self, *args, fault: Fault, **kwargs):
+        self.fault = fault
+        super().__init__(*args, **kwargs)
+
+    async def rpc_aggregate_part(self, stream, context) -> AsyncIterator[averaging_pb2.AveragingData]:
+        if self.fault == Fault.FAIL_REDUCING:
+            yield averaging_pb2.AveragingData(code=averaging_pb2.INTERNAL_ERROR)
+        elif self.fault == Fault.CANCEL:
+            yield averaging_pb2.AveragingData(code=averaging_pb2.CANCELLED)
+        else:
+            async for message in super().rpc_aggregate_part(stream, context):
+                yield message
+
+    async def _generate_input_for_peer(self, peer_index: int) -> AsyncIterator[averaging_pb2.AveragingData]:
+        parts_aiter = self.tensor_part_container.iterate_input_parts_for(peer_index)
+
+        first_part = await anext(parts_aiter)
+        yield averaging_pb2.AveragingData(
+            code=averaging_pb2.PART_FOR_AVERAGING,
+            group_id=self.group_id,
+            tensor_part=first_part,
+            weight=self.weight,
+        )
+        if self.fault == Fault.FAIL_SENDING:
+            last_reducer_index = self.group_size - 1 - (self.tensor_part_container.num_parts_by_peer[-1] == 0)
+            if peer_index == last_reducer_index:
+                raise Exception("Oops, I failed!")
+        async for part in parts_aiter:
+            yield averaging_pb2.AveragingData(tensor_part=part, weight=self.weight)
+
+
+@pytest.mark.forked
+@pytest.mark.parametrize(
+    "fault0, fault1",
+    [
+        (Fault.NONE, Fault.FAIL_BEFORE),
+        (Fault.FAIL_BEFORE, Fault.FAIL_BEFORE),
+        (Fault.FAIL_SENDING, Fault.FAIL_SENDING),
+        (Fault.FAIL_SENDING, Fault.FAIL_BEFORE),
+        (Fault.FAIL_SENDING, Fault.FAIL_REDUCING),
+        (Fault.NONE, Fault.CANCEL),
+    ],
+)
+def test_fault_tolerance(fault0: Fault.NONE, fault1: Fault.NONE):
+    def _make_tensors():
+        return [torch.rand(16, 1024), -torch.rand(3, 8192), 2 * torch.randn(4, 4, 4), torch.randn(1024, 1024)]
+
+    dht = hivemind.DHT(start=True)
+
+    averagers = []
+    for i in range(5):
+        averager = FaultyAverager(
+            _make_tensors(),
+            hivemind.DHT(initial_peers=dht.get_visible_maddrs(), start=True),
+            prefix="test",
+            request_timeout=0.3,
+            min_matchmaking_time=1.0,
+            next_chunk_timeout=0.5,
+            allreduce_timeout=5,
+            part_size_bytes=2 ** 16,
+            client_mode=(i == 1),
+            start=True,
+            fault=fault0 if i == 0 else fault1 if i == 1 else Fault.NONE,
+        )
+        averagers.append(averager)
+
+    ref_numerators = [0, 0, 0, 0]
+    ref_denominator = 0
+
+    for averager in averagers:
+        if averager.fault not in (Fault.FAIL_BEFORE, Fault.CANCEL):
+            with averager.get_tensors() as tensors:
+                for i, tensor in enumerate(tensors):
+                    ref_numerators[i] = ref_numerators[i] + tensor.clone()
+                ref_denominator += 1
+
+    ref_tensors = [ref_numerator / ref_denominator for ref_numerator in ref_numerators]
+    flat_ref = torch.cat(list(map(torch.flatten, ref_tensors)))
+
+    futures = [averager.step(timeout=5, wait=False, allow_retries=False) for averager in averagers]
+    for i, averager in enumerate(averagers):
+        if averager.fault == Fault.CANCEL:
+            futures[i].cancel()
+
+    for future in futures[2:]:
+        assert future.result()
+
+    for averager in averagers[2:]:
+        with averager.get_tensors() as tensors:
+            flat_tensors = torch.cat(list(map(torch.flatten, tensors)))
+        diff = flat_ref - flat_tensors
+
+        if all(fault == Fault.FAIL_SENDING for fault in (fault0, fault1)):
+            assert fault0 != Fault.FAIL_REDUCING and fault1 != Fault.FAIL_REDUCING
+            assert abs(diff[: len(diff) // 2]).max() < 1e-5
+        elif fault0 == Fault.NONE:  # only peer1 in client mode may have failed
+            assert abs(diff).max() < 1e-5
+        else:
+            assert (abs(diff) < 1e-5).numpy().mean() > 0.5
+
+    for averager in averagers:
+        averager.shutdown()

--- a/tests/test_allreduce_fault_tolerance.py
+++ b/tests/test_allreduce_fault_tolerance.py
@@ -99,7 +99,6 @@ class FaultyAllReduceRunner(AllReduceRunner):
             async for message in super().rpc_aggregate_part(stream, context):
                 yield message
 
-
     async def _generate_input_for_peer(self, peer_index: int) -> AsyncIterator[averaging_pb2.AveragingData]:
         parts_aiter = self.tensor_part_container.iterate_input_parts_for(peer_index)
 
@@ -130,7 +129,7 @@ class FaultyAllReduceRunner(AllReduceRunner):
         (Fault.NONE, Fault.CANCEL),
     ],
 )
-def test_fault_tolerance(fault0: Fault.NONE, fault1: Fault.NONE):
+def test_fault_tolerance(fault0: Fault, fault1: Fault):
     def _make_tensors():
         return [torch.rand(16, 1024), -torch.rand(3, 8192), 2 * torch.randn(4, 4, 4), torch.randn(1024, 1024)]
 

--- a/tests/test_allreduce_fault_tolerance.py
+++ b/tests/test_allreduce_fault_tolerance.py
@@ -126,6 +126,7 @@ class FaultyAllReduceRunner(AllReduceRunner):
         (Fault.FAIL_SENDING, Fault.FAIL_SENDING),
         (Fault.FAIL_SENDING, Fault.FAIL_BEFORE),
         (Fault.FAIL_SENDING, Fault.FAIL_REDUCING),
+        (Fault.FAIL_REDUCING, Fault.FAIL_REDUCING),
         (Fault.NONE, Fault.CANCEL),
     ],
 )

--- a/tests/test_allreduce_fault_tolerance.py
+++ b/tests/test_allreduce_fault_tolerance.py
@@ -177,6 +177,8 @@ def test_fault_tolerance(fault0: Fault.NONE, fault1: Fault.NONE):
         if all(fault == Fault.FAIL_SENDING for fault in (fault0, fault1)):
             assert fault0 != Fault.FAIL_REDUCING and fault1 != Fault.FAIL_REDUCING
             assert abs(diff[: len(diff) // 2]).max() < 1e-5
+        elif any(fault == Fault.CANCEL for fault in (fault0, fault1)):
+            pass  # late cancel may result in an arbitrary mix of averaging results with and without the cancelled peer
         elif fault0 == Fault.NONE:  # only peer1 in client mode may have failed
             assert abs(diff).max() < 1e-5
         else:

--- a/tests/test_allreduce_fault_tolerance.py
+++ b/tests/test_allreduce_fault_tolerance.py
@@ -14,7 +14,7 @@ from hivemind.averaging.group_info import GroupInfo
 from hivemind.averaging.load_balancing import load_balance_peers
 from hivemind.averaging.matchmaking import MatchmakingException
 from hivemind.proto import averaging_pb2
-from hivemind.utils.asyncio import as_aiter, azip, enter_asynchronously, aenumerate
+from hivemind.utils.asyncio import aenumerate, as_aiter, azip, enter_asynchronously
 from hivemind.utils.logging import get_logger
 
 logger = get_logger(__name__)

--- a/tests/test_allreduce_fault_tolerance.py
+++ b/tests/test_allreduce_fault_tolerance.py
@@ -126,6 +126,7 @@ class FaultyAllReduceRunner(AllReduceRunner):
         (Fault.FAIL_SENDING, Fault.FAIL_SENDING),
         (Fault.FAIL_SENDING, Fault.FAIL_BEFORE),
         (Fault.FAIL_SENDING, Fault.FAIL_REDUCING),
+        (Fault.FAIL_REDUCING, Fault.FAIL_REDUCING),
         (Fault.NONE, Fault.CANCEL),
     ],
 )
@@ -181,6 +182,8 @@ def test_fault_tolerance(fault0: Fault, fault1: Fault):
         if all(fault == Fault.FAIL_SENDING for fault in (fault0, fault1)):
             assert fault0 != Fault.FAIL_REDUCING and fault1 != Fault.FAIL_REDUCING
             assert abs(diff[: len(diff) // 2]).max() < 1e-5
+        elif all(fault == Fault.FAIL_REDUCING for fault in (fault0, fault1)):
+            assert (abs(diff[: len(diff) // 2]) < 1e-5).numpy().mean() > 0.5
         elif any(fault == Fault.CANCEL for fault in (fault0, fault1)):
             pass  # late cancel may result in an arbitrary mix of averaging results with and without the cancelled peer
         elif fault0 == Fault.NONE:  # only peer1 in client mode may have failed


### PR DESCRIPTION
- [x] allow AllreduceRunner to tolerate clients that
   - [x] do not send some of their local tensors
   - [x] do not show up at at all after matchmaking is over
- [x] allow AllreduceRunner to tolerate full/aux peers that do not send some or all results
- [x] introduce timeout after which sender/reducer is considered failed
- [x] AllreduceRunner & DecentralizedAverager will no longer _send_error_to_peer
   - log spam is gone!
- report allreduce integrity
   - [x] TensorPartReducer will report the fraction of expected parts received if that fraction is not 1
   - [x] TensorPartContainer will report the fraction of parts that did not fail if that fraction is not 1
- miscellaneous improvements to Optimizer
  - [x] set good default sender/reducer timeouts
  - [x] pre-schedule state averaging ahead of time
  - [x] no longer block the entire peer if it is time to pre-schedule gradients but background state averaging is still underway

Test cases:
- [x] test with peers that fail early
- [x] test with peers that fail to send a certain part
- [x] test with peers that fail to reduce their part
- [x] test cancelling

Sanity checks:
- [x] run tests 100 times
- [x] benchmark_optimizer
- [x] test env 64+ nodes 4+ hours