### PR TITLE
Fix All-Reduce fault-tolerance: catch Exception instead of BaseException

### DIFF
--- a/hivemind/utils/asyncio.py
+++ b/hivemind/utils/asyncio.py
@@ -118,7 +118,7 @@ async def amap_in_executor(
             async for args in azip(*iterables):
                 await queue.put(loop.run_in_executor(executor, func, *args))
             await queue.put(None)
-        except BaseException as e:
+        except Exception as e:
             future = asyncio.Future()
             future.set_exception(e)
             await queue.put(future)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3491902/145984175-50313f2d-6092-404f-845d-70b828ddea4b.png)
