### PR TITLE
Enable push trigger only for the master branch

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -1,6 +1,9 @@
 name: Check style
 
-on: [ push ]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   black:

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -1,6 +1,6 @@
 name: Check style
 
-on: [ push, pull_request ]
+on: [ push ]
 
 jobs:
   black:

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches: [ master ]
 
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -1,7 +1,9 @@
 name: Benchmarks
 
-on: [ push ]
-
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   run_benchmarks:

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -1,6 +1,6 @@
 name: Benchmarks
 
-on: [ push, pull_request ]
+on: [ push ]
 
 
 jobs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,9 @@
 name: Tests
 
-on: [ push ]
-
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   run_tests:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [ push, pull_request ]
+on: [ push ]
 
 
 jobs:


### PR DESCRIPTION
This PR halves the number of CI jobs triggered by a pull request from non-forked branches while ensuring that the commits to master are still properly checked and that PRs from forks are still tested (see https://github.com/learning-at-home/hivemind/pull/434). 