### PR TITLE
Fix dependency versions in examples/albert

### DIFF
--- a/examples/albert/requirements.txt
+++ b/examples/albert/requirements.txt
@@ -1,7 +1,7 @@
-transformers>=4.6.0
-datasets>=1.5.0
-torch_optimizer>=0.1.0
-wandb>=0.10.26
+transformers==4.6.0
+datasets==1.5.0
+torch_optimizer==0.1.0
+wandb==0.10.26
 sentencepiece
 requests
-nltk>=3.6.2
+nltk==3.6.2


### PR DESCRIPTION
This should save us from:

- A bug in the latest nltk version: https://github.com/nltk/nltk/issues/2925
- Incompatibilities introduced by `transformers` and `datasets` updates