### PR TITLE
Fix tests hanging with pytest-asyncio==0.17.* 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-forked
-pytest-asyncio
+pytest-asyncio==0.16.0
 pytest-cov
 tqdm
 scikit-learn


### PR DESCRIPTION
Sorry, I'm too lazy to investigate it deeper, I hope the developers of `pytest-asyncio` would be able to find and fix the bug without our help