### PR TITLE
Fix offloaded optimizer with single peer

### DIFF
--- a/hivemind/optim/optimizer.py
+++ b/hivemind/optim/optimizer.py
@@ -529,6 +529,7 @@ class Optimizer(torch.optim.Optimizer):
                 self._tag_along_with_zero_weight(self.scheduled_grads)
             else:
                 logger.log(self.status_loglevel, f"Skipping pre-scheduled averaging round: there are no other peers")
+                self.grad_averager.load_accumulators_into_averager_()
                 self.scheduled_grads.cancel()
             self.scheduled_grads = None
         return began_averaging_gradients

--- a/hivemind/optim/optimizer.py
+++ b/hivemind/optim/optimizer.py
@@ -620,8 +620,8 @@ class Optimizer(torch.optim.Optimizer):
 
     def _load_local_gradients_into_optimizer(self):
         """Fallback to using local gradients in the optimizer (instead of averaged gradients)"""
-        self.grad_averager.load_accumulators_into_averager_()
         logger.log(self.status_loglevel, f"Proceeding with local gradients")
+        self.grad_averager.load_accumulators_into_averager_()
         # note: we load gradients into grad_averager even though there is only one peer because of two reasons:
         # - if offload_optimizer, then we must load gradients onto the CPU gradient buffers used by the optimizer
         # - if not offload_optimizer, we must un-scale gradients (divide them by the number of accumulation steps)

--- a/hivemind/optim/optimizer.py
+++ b/hivemind/optim/optimizer.py
@@ -621,8 +621,7 @@ class Optimizer(torch.optim.Optimizer):
     def _load_local_gradients_into_optimizer(self):
         """Fallback to using local gradients in the optimizer (instead of averaged gradients)"""
         logger.log(self.status_loglevel, f"Proceeding with local gradients")
-        if self.offload_optimizer:
-            self.grad_averager.load_accumulators_into_averager_()
+        self.grad_averager.load_accumulators_into_averager_()
         self._load_averaged_gradients_into_optimizer_()
 
     def zero_grad(self, set_to_none: bool = False):

--- a/hivemind/optim/optimizer.py
+++ b/hivemind/optim/optimizer.py
@@ -622,6 +622,9 @@ class Optimizer(torch.optim.Optimizer):
         """Fallback to using local gradients in the optimizer (instead of averaged gradients)"""
         logger.log(self.status_loglevel, f"Proceeding with local gradients")
         self.grad_averager.load_accumulators_into_averager_()
+        # note: we load gradients into grad_averager even though there is only one peer because of two reasons:
+        # - if offload_optimizer, then we must load gradients onto the CPU gradient buffers used by the optimizer
+        # - if not offload_optimizer, we must un-scale gradients (divide them by the number of accumulation steps)
         self._load_averaged_gradients_into_optimizer_()
 
     def zero_grad(self, set_to_none: bool = False):

--- a/hivemind/optim/optimizer.py
+++ b/hivemind/optim/optimizer.py
@@ -620,8 +620,8 @@ class Optimizer(torch.optim.Optimizer):
 
     def _load_local_gradients_into_optimizer(self):
         """Fallback to using local gradients in the optimizer (instead of averaged gradients)"""
-        logger.log(self.status_loglevel, f"Proceeding with local gradients")
         self.grad_averager.load_accumulators_into_averager_()
+        logger.log(self.status_loglevel, f"Proceeding with local gradients")
         # note: we load gradients into grad_averager even though there is only one peer because of two reasons:
         # - if offload_optimizer, then we must load gradients onto the CPU gradient buffers used by the optimizer
         # - if not offload_optimizer, we must un-scale gradients (divide them by the number of accumulation steps)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-forked
-pytest-asyncio
+pytest-asyncio==0.16.0
 pytest-cov
 tqdm
 scikit-learn


### PR DESCRIPTION
The bug was originally found by @elricwan and @finger92 (seemingly independently) and reported in https://github.com/learning-at-home/hivemind/issues/447

Here's what was caused the issue:
> I investigated what went wrong in when training with only one trainer. Currently, hivemind.Optimizer is hard-wired to use the averaged gradients -- as in "averaged with peers".
> 
> If you are the only peer, gradients are not averaged, so optimizer runs with zero gradients all the time. This change should fix the problem in your specific case: [4ffd9ca](https://github.com/learning-at-home/hivemind/commit/4ffd9ca65c3e040c9599f4c64c0b960190c42250) I have seemingly introduced that bug myself in #440 . It only affects the github version of hivemind (i.e. not the pypi version)


The bug was introduced in #440 and affects the following setups (all 3 must be true):
- installed hivemind from github
- there is only one training peer in the swarm
- offload_optimizer is True

Here's the behavior after the fix is introduced:
![image](https://user-images.githubusercontent.com/3491902/150111853-76cd2b3d-4cb9-4651-aa57-a6daf49298f2.png)

