### PR TITLE
Bump Black to 22.3.0, pin Golang version

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --diff"
-          version: "22.1.0"
+          version: "22.3.0"
   isort:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,9 +39,13 @@ jobs:
           pytest --durations=0 --durations-min=1.0 -v
   build_and_test_p2pd:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.16'
+          check-latest: true
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,7 +39,7 @@ jobs:
           pytest --durations=0 --durations-min=1.0 -v
   build_and_test_p2pd:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ By default, hivemind uses the precompiled binary of
 the [go-libp2p-daemon](https://github.com/learning-at-home/go-libp2p-daemon) library. If you face compatibility issues
 or want to build the binary yourself, you can recompile it by running `pip install . --global-option="--buildgo"`.
 Before running the compilation, please ensure that your machine has a recent version
-of [Go toolchain](https://golang.org/doc/install) (1.15 or higher).
+of [Go toolchain](https://golang.org/doc/install) (1.15 or 1.16 are supported).
 
 ### System requirements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 119
-required-version = "22.1.0"
+required-version = "22.3.0"
 
 [tool.isort]
 profile = "black"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,6 @@ coverage==6.0.2  # see https://github.com/pytest-dev/pytest-cov/issues/520
 tqdm
 scikit-learn
 torchvision
-black==22.1.0
+black==22.3.0
 isort==5.10.1
 psutil


### PR DESCRIPTION
Investigating https://github.com/learning-at-home/hivemind/runs/6103918757?check_suite_focus=true led to a finding that the recent Black version is incompatible with `click==8.1.0` (see https://github.com/psf/black/issues/2964), which leads to a failing CI. As per the recommendation from the issue, this PR updates the version of Black to 22.3.0.

Also, currently the tests for the libp2p daemon build appear to fail/hang on master; this is most likely related to the version of Go not being pinned in the workflow environment. This PR fixes the issue by pinning the version of Golang to the latest supported by the current libp2p version and mentioning it in the README.