### PR TITLE
Use PeerID exclusively to address MoE experts

### DIFF
--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -48,9 +48,8 @@ def client_process(
     can_start.wait()
 
     p2p = RemoteExpertWorker.run_coroutine(P2P.create(initial_peers=server_maddrs))
-    peer_info = PeerInfo(server_peer_id, server_maddrs)
     experts = [
-        RemoteExpert(expert_info=RemoteExpertInfo(uid=f"expert.{i}", peer_info=peer_info), p2p=p2p)
+        RemoteExpert(expert_info=RemoteExpertInfo(uid=f"expert.{i}", peer_id=server_peer_id), p2p=p2p)
         for i in range(num_experts)
     ]
 

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -7,11 +7,12 @@ import time
 import torch
 
 from hivemind.dht import DHT
-from hivemind.moe.client.expert import RemoteExpert, RemoteExpertInfo
+from hivemind.moe.client.expert import RemoteExpert
 from hivemind.moe.client.remote_expert_worker import RemoteExpertWorker
+from hivemind.moe.expert_uid import ExpertInfo
 from hivemind.moe.server import ExpertBackend, Server
 from hivemind.moe.server.layers import name_to_block
-from hivemind.p2p import P2P, PeerInfo
+from hivemind.p2p import P2P
 from hivemind.utils.limits import increase_file_limit
 from hivemind.utils.logging import get_logger, use_hivemind_log_handler
 from hivemind.utils.tensor_descr import BatchTensorDescriptor
@@ -49,7 +50,7 @@ def client_process(
 
     p2p = RemoteExpertWorker.run_coroutine(P2P.create(initial_peers=server_maddrs))
     experts = [
-        RemoteExpert(expert_info=RemoteExpertInfo(uid=f"expert.{i}", peer_id=server_peer_id), p2p=p2p)
+        RemoteExpert(expert_info=ExpertInfo(uid=f"expert.{i}", peer_id=server_peer_id), p2p=p2p)
         for i in range(num_experts)
     ]
 

--- a/hivemind/dht/dht.py
+++ b/hivemind/dht/dht.py
@@ -275,7 +275,11 @@ class DHT(mp.Process):
     @property
     def peer_id(self) -> PeerID:
         if self._peer_id is None:
-            self._peer_id = self.run_coroutine(DHT._get_peer_id)
+            if os.getpid() == self.pid:
+                self._peer_id = self._node.peer_id
+            else:
+                # note: we cannot run_coroutine from the same pid because it would deadlock the event loop
+                self._peer_id = self.run_coroutine(DHT._get_peer_id)
         return self._peer_id
 
     @staticmethod

--- a/hivemind/dht/dht.py
+++ b/hivemind/dht/dht.py
@@ -169,6 +169,7 @@ class DHT(mp.Process):
         :param kwargs: parameters forwarded to DHTNode.get_many_by_id
         :returns: (value, expiration time); if value was not found, returns None
         """
+        assert os.getpid() != self.pid, "calling *external* DHT interface from inside DHT will result in a deadlock"
         future = MPFuture()
         self._outer_pipe.send(("_get", [], dict(key=key, latest=latest, future=future, **kwargs)))
         return future if return_future else future.result()
@@ -202,6 +203,7 @@ class DHT(mp.Process):
         :param return_future: if False (default), return when finished. Otherwise return MPFuture and run in background.
         :returns: True if store succeeds, False if it fails (due to no response or newer value)
         """
+        assert os.getpid() != self.pid, "calling *external* DHT interface from inside DHT will result in a deadlock"
         future = MPFuture()
         self._outer_pipe.send(
             (
@@ -246,6 +248,7 @@ class DHT(mp.Process):
           or use asyncio.get_event_loop().run_in_executor(...) to prevent coroutine from blocking background DHT tasks
         :note: when run_coroutine is called with return_future=False, MPFuture can be cancelled to interrupt the task.
         """
+        assert os.getpid() != self.pid, "calling *external* DHT interface from inside DHT will result in a deadlock"
         future = MPFuture()
         self._outer_pipe.send(("_run_coroutine", [], dict(coro=coro, future=future)))
         return future if return_future else future.result()

--- a/hivemind/moe/client/beam_search.py
+++ b/hivemind/moe/client/beam_search.py
@@ -199,7 +199,7 @@ class MoEBeamSearcher:
             coord: ExpertInfo(uid=match.value[0], peer_id=PeerID.from_base58(match.value[1]))
             for coord, match in entry.value.items()
             if isinstance(coord, Coordinate)
-            and (0 <= coord < grid_size or grid_size is None)
+            and (grid_size is None or 0 <= coord < grid_size)
             and isinstance(match, ValueWithExpiration)
             and isinstance(match.value, tuple)
             and len(match.value) == 2

--- a/hivemind/moe/client/beam_search.py
+++ b/hivemind/moe/client/beam_search.py
@@ -313,8 +313,6 @@ class MoEBeamSearcher:
                 ),
             )
 
-            if not best_active_pairs:
-                break
             _, best_uid_prefixes = zip(*best_active_pairs)
 
             # search DHT for next step suffixes

--- a/hivemind/moe/client/beam_search.py
+++ b/hivemind/moe/client/beam_search.py
@@ -151,6 +151,7 @@ class MoEBeamSearcher:
                         for coord, match in maybe_prefix_data.value.items()
                         if isinstance(coord, Coordinate)
                         and isinstance(match, ValueWithExpiration)
+                        and isinstance(match.value, tuple)
                         and len(match.value) == 2
                         and is_valid_uid(match.value[0])
                         and isinstance(match.value[1], str)
@@ -221,6 +222,7 @@ class MoEBeamSearcher:
                     if isinstance(coord, Coordinate)
                     and 0 <= coord < grid_size
                     and isinstance(match, ValueWithExpiration)
+                    and isinstance(match.value, tuple)
                     and len(match.value) == 2
                     and is_valid_uid(match.value[0])
                     and isinstance(match.value[1], str)
@@ -293,11 +295,11 @@ class MoEBeamSearcher:
         unique_experts: Set[ExpertUID] = set()
 
         for dim_index in range(1, len(grid_scores) - 1):
-            for score, uid_endpoint in cls._iterate_matching_experts(beam, grid_scores):
-                if uid_endpoint.uid not in unique_experts:
+            for score, expert_info in cls._iterate_matching_experts(beam, grid_scores):
+                if expert_info.uid not in unique_experts:
                     push_and_maybe_pop = heapq.heappush if len(best_experts_heap) < beam_size else heapq.heappushpop
-                    push_and_maybe_pop(best_experts_heap, (score, uid_endpoint))
-                    unique_experts.add(uid_endpoint.uid)
+                    push_and_maybe_pop(best_experts_heap, (score, expert_info))
+                    unique_experts.add(expert_info.uid)
 
             # form new beam using successors from the current beam
             dim_scores = grid_scores[dim_index]
@@ -331,11 +333,11 @@ class MoEBeamSearcher:
                 break
 
         # add best experts from the final beam
-        for score, uid_endpoint in cls._iterate_matching_experts(beam, grid_scores):
-            if uid_endpoint.uid not in unique_experts:
+        for score, expert_info in cls._iterate_matching_experts(beam, grid_scores):
+            if expert_info.uid not in unique_experts:
                 push_and_maybe_pop = heapq.heappush if len(best_experts_heap) < beam_size else heapq.heappushpop
-                push_and_maybe_pop(best_experts_heap, (score, uid_endpoint))
-                unique_experts.add(uid_endpoint.uid)
+                push_and_maybe_pop(best_experts_heap, (score, expert_info))
+                unique_experts.add(expert_info.uid)
 
         return [expert_info for _, expert_info in sorted(best_experts_heap, reverse=True)]
 

--- a/hivemind/moe/client/beam_search.py
+++ b/hivemind/moe/client/beam_search.py
@@ -237,11 +237,7 @@ class MoEBeamSearcher:
         return successors
 
     def find_best_experts(
-        self,
-        grid_scores: Sequence[Sequence[float]],
-        beam_size: int,
-        num_workers: Optional[int] = None,
-        return_future: bool = False,
+        self, grid_scores: Sequence[Sequence[float]], beam_size: int, return_future: bool = False
     ) -> Union[List[RemoteExpert], MPFuture[List[RemoteExpert]]]:
         """
         Find and return :beam_size: active experts with highest scores, use both local cache and DHT
@@ -252,12 +248,10 @@ class MoEBeamSearcher:
          After time_budget is reached, beam search won't search for more experts and instead fall back on local cache
          Please note that any queries that fall outside the budget will still be performed in background and cached
          for subsequent iterations as long as DHTNode.cache_locally is True
-        :param num_workers: use up to this many concurrent workers to search DHT
         :param return_future: if set to True, returns MPFuture that can be awaited to get the actual result
         :returns: a list that contains *up to* k_best RemoteExpert instances
         """
         assert len(grid_scores) == len(self.grid_size) and beam_size > 0
-        num_workers = num_workers if num_workers is not None else self.num_workers
         result = self.dht.run_coroutine(
             partial(
                 self._find_best_experts,
@@ -266,7 +260,7 @@ class MoEBeamSearcher:
                 grid_scores=list(grid_scores),
                 negative_caching=self.negative_caching,
                 cache_expiration=self.cache_expiration,
-                num_workers=num_workers,
+                num_workers=self.num_workers,
             ),
             return_future,
         )

--- a/hivemind/moe/client/expert.py
+++ b/hivemind/moe/client/expert.py
@@ -12,7 +12,7 @@ from hivemind import moe
 from hivemind.compression import deserialize_tensor_stream, deserialize_torch_tensor, serialize_torch_tensor
 from hivemind.dht import DHT
 from hivemind.moe.client.remote_expert_worker import RemoteExpertWorker
-from hivemind.p2p import P2P, StubBase, PeerID
+from hivemind.p2p import P2P, PeerID, StubBase
 from hivemind.p2p.p2p_daemon import DEFAULT_MAX_MSG_SIZE
 from hivemind.proto import runtime_pb2
 from hivemind.utils.asyncio import amap_in_executor, iter_as_aiter
@@ -20,7 +20,6 @@ from hivemind.utils.mpfuture import MPFuture
 from hivemind.utils.nested import nested_compare, nested_flatten, nested_pack
 from hivemind.utils.serializer import MSGPackSerializer
 from hivemind.utils.streaming import split_for_streaming
-
 
 DUMMY = torch.empty(0, requires_grad=True)  # dummy tensor that triggers autograd in RemoteExpert
 

--- a/hivemind/moe/client/expert.py
+++ b/hivemind/moe/client/expert.py
@@ -50,7 +50,7 @@ class RemoteExpert(nn.Module):
         return self._info.uid
 
     @property
-    def server_peer_id(self):
+    def server_peer_id(self) -> PeerID:
         return self._info.peer_id
 
     @property

--- a/hivemind/moe/client/expert.py
+++ b/hivemind/moe/client/expert.py
@@ -50,12 +50,12 @@ class RemoteExpert(nn.Module):
         return self._info.uid
 
     @property
-    def server_peer_id(self) -> PeerID:
+    def peer_id(self) -> PeerID:
         return self._info.peer_id
 
     @property
     def stub(self) -> StubBase:
-        return get_server_stub(self.p2p, self.server_peer_id)
+        return get_server_stub(self.p2p, self.peer_id)
 
     def forward(self, *args, **kwargs):
         """Call RemoteExpert for the specified inputs and return its output(s). Compatible with pytorch.autograd."""
@@ -82,7 +82,7 @@ class RemoteExpert(nn.Module):
         return self._rpc_info
 
     def extra_repr(self):
-        return f"uid={self.uid}, server_peer_id={self.server_peer_id}"
+        return f"uid={self.uid}, server_peer_id={self.peer_id}"
 
 
 def _create_remote_experts(infos: Sequence[Optional[ExpertInfo]], p2p: P2P) -> List[Optional[RemoteExpert]]:

--- a/hivemind/moe/client/moe.py
+++ b/hivemind/moe/client/moe.py
@@ -14,7 +14,7 @@ from hivemind.dht import DHT
 from hivemind.moe.client.beam_search import MoEBeamSearcher
 from hivemind.moe.client.expert import DUMMY, RemoteExpert, expert_backward, expert_forward, get_server_stub
 from hivemind.moe.client.remote_expert_worker import RemoteExpertWorker
-from hivemind.moe.server.expert_uid import UID_DELIMITER
+from hivemind.moe.expert_uid import UID_DELIMITER
 from hivemind.p2p.p2p_daemon_bindings.control import P2PDaemonError
 from hivemind.utils import nested_flatten, nested_map, nested_pack
 from hivemind.utils.logging import get_logger

--- a/hivemind/moe/client/moe.py
+++ b/hivemind/moe/client/moe.py
@@ -12,7 +12,7 @@ from torch.autograd.function import once_differentiable
 from hivemind.compression import serialize_torch_tensor
 from hivemind.dht import DHT
 from hivemind.moe.client.beam_search import MoEBeamSearcher
-from hivemind.moe.client.expert import DUMMY, RemoteExpert, expert_backward, expert_forward, get_expert_stub
+from hivemind.moe.client.expert import DUMMY, RemoteExpert, expert_backward, expert_forward, get_server_stub
 from hivemind.moe.client.remote_expert_worker import RemoteExpertWorker
 from hivemind.moe.server.expert_uid import UID_DELIMITER
 from hivemind.p2p.p2p_daemon_bindings.control import P2PDaemonError
@@ -227,7 +227,7 @@ class _RemoteCallMany(torch.autograd.Function):
         pending_tasks: Dict[Future, Tuple[int, int]] = {}
         for i in range(num_samples):
             for j, expert in enumerate(experts_per_sample[i]):
-                stub = get_expert_stub(expert.p2p, expert.server_peer_info)
+                stub = get_server_stub(expert.p2p, expert.server_peer_id)
                 serialized_tensors = (
                     serialize_torch_tensor(tensor, proto.compression)
                     for tensor, proto in zip(flat_inputs_per_sample[i], nested_flatten(info["forward_schema"]))
@@ -321,7 +321,7 @@ class _RemoteCallMany(torch.autograd.Function):
             alive_ii.cpu().numpy(), alive_jj.cpu().numpy(), inputs_per_expert, grad_outputs_per_expert
         ):
             expert: RemoteExpert = expert_per_sample[i.item()][j.item()]
-            stub = get_expert_stub(expert.p2p, expert.server_peer_info)
+            stub = get_server_stub(expert.p2p, expert.server_peer_id)
             inputs_and_grad_outputs = tuple(nested_flatten((inputs_ij, grad_outputs_ij)))
             serialized_tensors = (
                 serialize_torch_tensor(tensor, proto.compression)

--- a/hivemind/moe/client/moe.py
+++ b/hivemind/moe/client/moe.py
@@ -227,7 +227,7 @@ class _RemoteCallMany(torch.autograd.Function):
         pending_tasks: Dict[Future, Tuple[int, int]] = {}
         for i in range(num_samples):
             for j, expert in enumerate(experts_per_sample[i]):
-                stub = get_server_stub(expert.p2p, expert.server_peer_id)
+                stub = get_server_stub(expert.p2p, expert.peer_id)
                 serialized_tensors = (
                     serialize_torch_tensor(tensor, proto.compression)
                     for tensor, proto in zip(flat_inputs_per_sample[i], nested_flatten(info["forward_schema"]))
@@ -321,7 +321,7 @@ class _RemoteCallMany(torch.autograd.Function):
             alive_ii.cpu().numpy(), alive_jj.cpu().numpy(), inputs_per_expert, grad_outputs_per_expert
         ):
             expert: RemoteExpert = expert_per_sample[i.item()][j.item()]
-            stub = get_server_stub(expert.p2p, expert.server_peer_id)
+            stub = get_server_stub(expert.p2p, expert.peer_id)
             inputs_and_grad_outputs = tuple(nested_flatten((inputs_ij, grad_outputs_ij)))
             serialized_tensors = (
                 serialize_torch_tensor(tensor, proto.compression)

--- a/hivemind/moe/client/switch_moe.py
+++ b/hivemind/moe/client/switch_moe.py
@@ -6,7 +6,7 @@ import torch
 
 from hivemind.moe.client.expert import DUMMY, RemoteExpert
 from hivemind.moe.client.moe import RemoteMixtureOfExperts, _RemoteCallMany
-from hivemind.moe.server.expert_uid import UID_DELIMITER
+from hivemind.moe.expert_uid import UID_DELIMITER
 from hivemind.p2p.p2p_daemon_bindings.control import P2PDaemonError
 from hivemind.utils import nested_flatten, nested_pack
 from hivemind.utils.logging import get_logger

--- a/hivemind/moe/expert_uid.py
+++ b/hivemind/moe/expert_uid.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import re
 from typing import NamedTuple, Tuple, Union
 
-from hivemind.p2p.p2p_daemon_bindings.datastructures import PeerInfo
+from hivemind.p2p import PeerID
 
 ExpertUID, ExpertPrefix, Coordinate, Score = str, str, int, float
-UidEndpoint = NamedTuple("UidEndpoint", [("uid", ExpertUID), ("peer_info", PeerInfo)])
+ExpertInfo = NamedTuple("ExpertInfo", [("uid", ExpertUID), ("peer_id", PeerID)])
 UID_DELIMITER = "."  # when declaring experts, DHT store all prefixes of that expert's uid, split over this prefix
 FLAT_EXPERT = -1  # grid prefix reserved for storing 1d expert uids. Used to speed up find_best_experts in 1d case.
 UID_PATTERN = re.compile("^(([^.])+)([.](?:[0]|([1-9]([0-9]*))))+$")  # e.g. ffn_expert.98.76.54 - prefix + some dims

--- a/hivemind/moe/server/dht_handler.py
+++ b/hivemind/moe/server/dht_handler.py
@@ -14,7 +14,7 @@ from hivemind.moe.server.expert_uid import (
     is_valid_uid,
     split_uid,
 )
-from hivemind.p2p import PeerID, PeerInfo
+from hivemind.p2p import PeerID
 from hivemind.utils import MPFuture, get_dht_time
 
 
@@ -56,13 +56,14 @@ async def _declare_experts(
     num_workers = len(uids) if dht.num_workers is None else min(len(uids), dht.num_workers)
     expiration_time = get_dht_time() + expiration
     data_to_store: Dict[Tuple[ExpertPrefix, Optional[Coordinate]], DHTValue] = {}
-    peer_id_bytes = dht.peer_id.to_base58()
+    peer_id_raw = dht.peer_id.to_base58()
+
     for uid in uids:
-        data_to_store[uid, None] = peer_id_bytes
+        data_to_store[uid, None] = peer_id_raw
         prefix = uid if uid.count(UID_DELIMITER) > 1 else f"{uid}{UID_DELIMITER}{FLAT_EXPERT}"
         for i in range(prefix.count(UID_DELIMITER) - 1):
             prefix, last_coord = split_uid(prefix)
-            data_to_store[prefix, last_coord] = (uid, peer_id_bytes)
+            data_to_store[prefix, last_coord] = (uid, peer_id_raw)
 
     keys, maybe_subkeys, values = zip(*((key, subkey, value) for (key, subkey), value in data_to_store.items()))
     store_ok = await node.store_many(keys, values, expiration_time, subkeys=maybe_subkeys, num_workers=num_workers)
@@ -94,6 +95,6 @@ async def _get_experts(
     experts: List[Optional[RemoteExpertInfo]] = [None] * len(uids)
     for i, uid in enumerate(uids):
         expert_server_peer_id = found[uid]
-        if expert_server_peer_id is not None and isinstance(expert_server_peer_id.value, bytes):
+        if expert_server_peer_id is not None and isinstance(expert_server_peer_id.value, str):
             experts[i] = RemoteExpertInfo(uid, PeerID.from_base58(expert_server_peer_id.value))
     return experts

--- a/hivemind/moe/server/dht_handler.py
+++ b/hivemind/moe/server/dht_handler.py
@@ -3,12 +3,13 @@ from functools import partial
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 from hivemind.dht import DHT, DHTExpiration, DHTNode, DHTValue
-from hivemind.moe.client.expert import RemoteExpert, RemoteExpertInfo, create_remote_experts
-from hivemind.moe.server.expert_uid import (
+from hivemind.moe.client.expert import RemoteExpert, create_remote_experts
+from hivemind.moe.expert_uid import (
     FLAT_EXPERT,
     UID_DELIMITER,
     UID_PATTERN,
     Coordinate,
+    ExpertInfo,
     ExpertPrefix,
     ExpertUID,
     is_valid_uid,
@@ -87,15 +88,15 @@ def get_experts(
 
 async def _get_experts(
     dht: DHT, node: DHTNode, uids: List[ExpertUID], expiration_time: Optional[DHTExpiration]
-) -> List[Optional[RemoteExpertInfo]]:
+) -> List[Optional[ExpertInfo]]:
     if expiration_time is None:
         expiration_time = get_dht_time()
     num_workers = len(uids) if dht.num_workers is None else min(len(uids), dht.num_workers)
     found: Dict[ExpertUID, DHTValue] = await node.get_many(uids, expiration_time, num_workers=num_workers)
 
-    experts: List[Optional[RemoteExpertInfo]] = [None] * len(uids)
+    experts: List[Optional[ExpertInfo]] = [None] * len(uids)
     for i, uid in enumerate(uids):
         expert_server_peer_id = found[uid]
         if expert_server_peer_id is not None and isinstance(expert_server_peer_id.value, str):
-            experts[i] = RemoteExpertInfo(uid, PeerID.from_base58(expert_server_peer_id.value))
+            experts[i] = ExpertInfo(uid, PeerID.from_base58(expert_server_peer_id.value))
     return experts

--- a/hivemind/moe/server/dht_handler.py
+++ b/hivemind/moe/server/dht_handler.py
@@ -58,14 +58,14 @@ async def _declare_experts(
     num_workers = len(uids) if dht.num_workers is None else min(len(uids), dht.num_workers)
     expiration_time = get_dht_time() + expiration
     data_to_store: Dict[Tuple[ExpertPrefix, Optional[Coordinate]], DHTValue] = {}
-    peer_id_raw = dht.peer_id.to_base58()
+    peer_id_base58 = dht.peer_id.to_base58()
 
     for uid in uids:
-        data_to_store[uid, None] = peer_id_raw
+        data_to_store[uid, None] = peer_id_base58
         prefix = uid if uid.count(UID_DELIMITER) > 1 else f"{uid}{UID_DELIMITER}{FLAT_EXPERT}"
         for i in range(prefix.count(UID_DELIMITER) - 1):
             prefix, last_coord = split_uid(prefix)
-            data_to_store[prefix, last_coord] = (uid, peer_id_raw)
+            data_to_store[prefix, last_coord] = (uid, peer_id_base58)
 
     keys, maybe_subkeys, values = zip(*((key, subkey, value) for (key, subkey), value in data_to_store.items()))
     store_ok = await node.store_many(keys, values, expiration_time, subkeys=maybe_subkeys, num_workers=num_workers)
@@ -96,7 +96,7 @@ async def _get_experts(
 
     experts: List[Optional[ExpertInfo]] = [None] * len(uids)
     for i, uid in enumerate(uids):
-        expert_server_peer_id = found[uid]
-        if expert_server_peer_id is not None and isinstance(expert_server_peer_id.value, str):
-            experts[i] = ExpertInfo(uid, PeerID.from_base58(expert_server_peer_id.value))
+        server_peer_id = found[uid]
+        if server_peer_id is not None and isinstance(server_peer_id.value, str):
+            experts[i] = ExpertInfo(uid, PeerID.from_base58(server_peer_id.value))
     return experts

--- a/hivemind/moe/server/dht_handler.py
+++ b/hivemind/moe/server/dht_handler.py
@@ -52,7 +52,8 @@ def declare_experts(
 
 
 async def _declare_experts(
-        dht: DHT, node: DHTNode, uids: List[ExpertUID], expiration: DHTExpiration) -> Dict[ExpertUID, bool]:
+    dht: DHT, node: DHTNode, uids: List[ExpertUID], expiration: DHTExpiration
+) -> Dict[ExpertUID, bool]:
     num_workers = len(uids) if dht.num_workers is None else min(len(uids), dht.num_workers)
     expiration_time = get_dht_time() + expiration
     data_to_store: Dict[Tuple[ExpertPrefix, Optional[Coordinate]], DHTValue] = {}

--- a/hivemind/moe/server/server.py
+++ b/hivemind/moe/server/server.py
@@ -6,17 +6,16 @@ import threading
 from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import torch
-from multiaddr import Multiaddr
 
 from hivemind.dht import DHT
+from hivemind.moe.expert_uid import UID_DELIMITER
 from hivemind.moe.server.checkpoints import CheckpointSaver, is_directory, load_experts
 from hivemind.moe.server.connection_handler import ConnectionHandler
 from hivemind.moe.server.dht_handler import DHTHandlerThread, get_experts
 from hivemind.moe.server.expert_backend import ExpertBackend
-from hivemind.moe.server.expert_uid import UID_DELIMITER
 from hivemind.moe.server.layers import (
     add_custom_models_from_file,
     name_to_block,

--- a/hivemind/p2p/p2p_daemon_bindings/datastructures.py
+++ b/hivemind/p2p/p2p_daemon_bindings/datastructures.py
@@ -128,12 +128,6 @@ class PeerInfo:
         addrs = [Multiaddr(addr) for addr in peer_info_pb.addrs]
         return PeerInfo(peer_id, addrs)
 
-    @classmethod
-    def from_tuple(cls, value: Tuple[str, Sequence[str]]) -> "PeerInfo":
-        peer_id = PeerID.from_base58(value[0])
-        addrs = [Multiaddr(addr) for addr in value[1]]
-        return PeerInfo(peer_id, addrs)
-
     def __str__(self):
         return f"{self.peer_id.pretty()} {','.join(str(a) for a in self.addrs)}"
 

--- a/tests/test_custom_experts.py
+++ b/tests/test_custom_experts.py
@@ -4,7 +4,8 @@ import pytest
 import torch
 
 from hivemind.dht import DHT
-from hivemind.moe.client.expert import RemoteExpertInfo, create_remote_experts
+from hivemind.moe.client.expert import create_remote_experts
+from hivemind.moe.expert_uid import ExpertInfo
 from hivemind.moe.server import background_server
 
 CUSTOM_EXPERTS_PATH = os.path.join(os.path.dirname(__file__), "test_utils", "custom_networks.py")
@@ -23,8 +24,8 @@ def test_custom_expert(hid_dim=16):
         dht = DHT(initial_peers=server_peer_info.addrs, start=True)
         expert0, expert1 = create_remote_experts(
             [
-                RemoteExpertInfo(uid="expert.0", peer_info=server_peer_info),
-                RemoteExpertInfo(uid="expert.1", peer_info=server_peer_info),
+                ExpertInfo(uid="expert.0", peer_info=server_peer_info),
+                ExpertInfo(uid="expert.1", peer_info=server_peer_info),
             ],
             dht=dht,
         )
@@ -54,8 +55,8 @@ def test_multihead_expert(hid_dim=16):
         dht = DHT(initial_peers=server_peer_info.addrs, start=True)
         expert0, expert1 = create_remote_experts(
             [
-                RemoteExpertInfo(uid="expert.0", peer_info=server_peer_info),
-                RemoteExpertInfo(uid="expert.1", peer_info=server_peer_info),
+                ExpertInfo(uid="expert.0", peer_info=server_peer_info),
+                ExpertInfo(uid="expert.1", peer_info=server_peer_info),
             ],
             dht=dht,
         )

--- a/tests/test_custom_experts.py
+++ b/tests/test_custom_experts.py
@@ -24,8 +24,8 @@ def test_custom_expert(hid_dim=16):
         dht = DHT(initial_peers=server_peer_info.addrs, start=True)
         expert0, expert1 = create_remote_experts(
             [
-                ExpertInfo(uid="expert.0", peer_info=server_peer_info),
-                ExpertInfo(uid="expert.1", peer_info=server_peer_info),
+                ExpertInfo(uid="expert.0", peer_id=server_peer_info.peer_id),
+                ExpertInfo(uid="expert.1", peer_id=server_peer_info.peer_id),
             ],
             dht=dht,
         )
@@ -55,8 +55,8 @@ def test_multihead_expert(hid_dim=16):
         dht = DHT(initial_peers=server_peer_info.addrs, start=True)
         expert0, expert1 = create_remote_experts(
             [
-                ExpertInfo(uid="expert.0", peer_info=server_peer_info),
-                ExpertInfo(uid="expert.1", peer_info=server_peer_info),
+                ExpertInfo(uid="expert.0", peer_id=server_peer_info.peer_id),
+                ExpertInfo(uid="expert.1", peer_id=server_peer_info.peer_id),
             ],
             dht=dht,
         )

--- a/tests/test_dht_experts.py
+++ b/tests/test_dht_experts.py
@@ -34,7 +34,7 @@ def test_store_get_experts(n_peers=10):
     declare_experts(other_peer, [other_expert])
     first_notfound, first_found = get_experts(first_peer, ["foobar", other_expert])
     assert isinstance(first_found, hivemind.RemoteExpert)
-    assert first_found.server_peer_id == other_peer.peer_id
+    assert first_found.peer_id == other_peer.peer_id
     assert first_notfound is None
 
     # test graceful shutdown
@@ -44,7 +44,7 @@ def test_store_get_experts(n_peers=10):
     remaining_peer1 = random.choice([peer for peer in peers if peer.is_alive()])
     remaining_peer2 = random.choice([peer for peer in peers if peer.is_alive()])
     assert all(declare_experts(remaining_peer1, ["new_expert.1"]))
-    assert get_experts(remaining_peer2, ["new_expert.1"])[0].server_peer_id == remaining_peer1.peer_id
+    assert get_experts(remaining_peer2, ["new_expert.1"])[0].peer_id == remaining_peer1.peer_id
 
 
 @pytest.mark.forked
@@ -95,7 +95,7 @@ def test_dht_single_node():
     assert len(declare_experts(node, ["e.1.2.3", "e.1.2.5", "e.2.0"])) == 7
 
     for expert in get_experts(node, ["expert.3", "expert.2"]):
-        assert expert.server_peer_id == node.peer_id
+        assert expert.peer_id == node.peer_id
 
     assert all(declare_experts(node, ["expert.5", "expert.2"]).values())
     found_experts = beam_search.find_best_experts([(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0)], beam_size=2)

--- a/tests/test_dht_experts.py
+++ b/tests/test_dht_experts.py
@@ -8,9 +8,8 @@ import pytest
 import hivemind
 from hivemind.dht import DHTNode
 from hivemind.moe.client.beam_search import MoEBeamSearcher
+from hivemind.moe.expert_uid import ExpertInfo, is_valid_prefix, is_valid_uid, split_uid
 from hivemind.moe.server import declare_experts, get_experts
-from hivemind.moe.server.expert_uid import UidEndpoint, is_valid_prefix, is_valid_uid, split_uid
-from hivemind.p2p import PeerInfo
 
 
 @pytest.mark.forked
@@ -35,7 +34,7 @@ def test_store_get_experts(n_peers=10):
     declare_experts(other_peer, [other_expert])
     first_notfound, first_found = get_experts(first_peer, ["foobar", other_expert])
     assert isinstance(first_found, hivemind.RemoteExpert)
-    assert first_found.server_peer_id.peer_id == other_peer.peer_id
+    assert first_found.server_peer_id == other_peer.peer_id
     assert first_notfound is None
 
     # test graceful shutdown
@@ -45,7 +44,7 @@ def test_store_get_experts(n_peers=10):
     remaining_peer1 = random.choice([peer for peer in peers if peer.is_alive()])
     remaining_peer2 = random.choice([peer for peer in peers if peer.is_alive()])
     assert all(declare_experts(remaining_peer1, ["new_expert.1"]))
-    assert get_experts(remaining_peer2, ["new_expert.1"])[0].server_peer_id.peer_id == remaining_peer1.peer_id
+    assert get_experts(remaining_peer2, ["new_expert.1"])[0].server_peer_id == remaining_peer1.peer_id
 
 
 @pytest.mark.forked
@@ -96,7 +95,7 @@ def test_dht_single_node():
     assert len(declare_experts(node, ["e.1.2.3", "e.1.2.5", "e.2.0"])) == 7
 
     for expert in get_experts(node, ["expert.3", "expert.2"]):
-        assert expert.server_peer_id.peer_id == node.peer_id
+        assert expert.server_peer_id == node.peer_id
 
     assert all(declare_experts(node, ["expert.5", "expert.2"]).values())
     found_experts = beam_search.find_best_experts([(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0)], beam_size=2)
@@ -105,11 +104,9 @@ def test_dht_single_node():
     successors = beam_search.get_active_successors(["e.1.2.", "e.2.", "e.4.5."])
     assert len(successors["e.1.2."]) == 2
 
-    peer_info = PeerInfo(node.peer_id, [a.decapsulate("/p2p/" + a.get("p2p")) for a in node.get_visible_maddrs()])
-
-    assert successors["e.1.2."][3] == UidEndpoint("e.1.2.3", peer_info)
-    assert successors["e.1.2."][5] == UidEndpoint("e.1.2.5", peer_info)
-    assert len(successors["e.2."]) == 1 and successors["e.2."][0] == UidEndpoint("e.2.0", peer_info)
+    assert successors["e.1.2."][3] == ExpertInfo("e.1.2.3", node.peer_id)
+    assert successors["e.1.2."][5] == ExpertInfo("e.1.2.5", node.peer_id)
+    assert len(successors["e.2."]) == 1 and successors["e.2."][0] == ExpertInfo("e.2.0", node.peer_id)
     assert successors["e.4.5."] == {}
 
     initial_beam = beam_search.get_initial_beam((3, 2, 1, 0, -1, -2, -3), beam_size=3)

--- a/tests/test_dht_experts.py
+++ b/tests/test_dht_experts.py
@@ -35,7 +35,7 @@ def test_store_get_experts(n_peers=10):
     declare_experts(other_peer, [other_expert])
     first_notfound, first_found = get_experts(first_peer, ["foobar", other_expert])
     assert isinstance(first_found, hivemind.RemoteExpert)
-    assert first_found.server_peer_info.peer_id == other_peer.peer_id
+    assert first_found.server_peer_id.peer_id == other_peer.peer_id
     assert first_notfound is None
 
     # test graceful shutdown
@@ -45,7 +45,7 @@ def test_store_get_experts(n_peers=10):
     remaining_peer1 = random.choice([peer for peer in peers if peer.is_alive()])
     remaining_peer2 = random.choice([peer for peer in peers if peer.is_alive()])
     assert all(declare_experts(remaining_peer1, ["new_expert.1"]))
-    assert get_experts(remaining_peer2, ["new_expert.1"])[0].server_peer_info.peer_id == remaining_peer1.peer_id
+    assert get_experts(remaining_peer2, ["new_expert.1"])[0].server_peer_id.peer_id == remaining_peer1.peer_id
 
 
 @pytest.mark.forked
@@ -96,7 +96,7 @@ def test_dht_single_node():
     assert len(declare_experts(node, ["e.1.2.3", "e.1.2.5", "e.2.0"])) == 7
 
     for expert in get_experts(node, ["expert.3", "expert.2"]):
-        assert expert.server_peer_info.peer_id == node.peer_id
+        assert expert.server_peer_id.peer_id == node.peer_id
 
     assert all(declare_experts(node, ["expert.5", "expert.2"]).values())
     found_experts = beam_search.find_best_experts([(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0)], beam_size=2)

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -78,7 +78,7 @@ def test_call_many(hidden_dim=16):
 
         dht = DHT(initial_peers=server_peer_info.addrs, start=True)
         e0, e1, e2, e3, e4 = create_remote_experts(
-            [ExpertInfo(uid=f"expert.{i}", peer_info=server_peer_info) for i in range(5)],
+            [ExpertInfo(uid=f"expert.{i}", peer_id=server_peer_info.peer_id) for i in range(5)],
             dht,
         )
         e5 = RemoteExpert(ExpertInfo(f"thisshouldnotexist", server_peer_info), None)
@@ -138,8 +138,8 @@ def test_remote_module_call(hidden_dim=16):
         dht = DHT(initial_peers=server_peer_info.addrs, start=True)
         real_expert, fake_expert = create_remote_experts(
             [
-                ExpertInfo(uid="expert.0", peer_info=server_peer_info),
-                ExpertInfo(uid="oiasfjiasjf", peer_info=server_peer_info),
+                ExpertInfo(uid="expert.0", peer_id=server_peer_info.peer_id),
+                ExpertInfo(uid="oiasfjiasjf", peer_id=server_peer_info.peer_id),
             ],
             dht=dht,
         )
@@ -206,7 +206,7 @@ def test_determinism(hidden_dim=16):
     ) as server_peer_info:
         dht = DHT(initial_peers=server_peer_info.addrs, start=True)
         expert = create_remote_experts(
-            [ExpertInfo(uid="expert.0", peer_info=server_peer_info)],
+            [ExpertInfo(uid="expert.0", peer_id=server_peer_info.peer_id)],
             dht=dht,
         )[0]
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -27,8 +27,8 @@ def test_training(max_steps: int = 100, threshold: float = 0.9):
         dht = DHT(initial_peers=server_peer_info.addrs, start=True)
         expert1, expert2 = create_remote_experts(
             [
-                ExpertInfo(uid="expert.0", peer_info=server_peer_info),
-                ExpertInfo(uid="expert.1", peer_info=server_peer_info),
+                ExpertInfo(uid="expert.0", peer_id=server_peer_info.peer_id),
+                ExpertInfo(uid="expert.1", peer_id=server_peer_info.peer_id),
             ],
             dht=dht,
         )

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -9,7 +9,8 @@ from sklearn.datasets import load_digits
 
 from hivemind import DHT
 from hivemind.moe.client import RemoteMixtureOfExperts, RemoteSwitchMixtureOfExperts
-from hivemind.moe.client.expert import RemoteExpertInfo, create_remote_experts
+from hivemind.moe.client.expert import create_remote_experts
+from hivemind.moe.expert_uid import ExpertInfo
 from hivemind.moe.server import background_server
 from hivemind.optim import DecentralizedAdam, DecentralizedSGD
 
@@ -26,8 +27,8 @@ def test_training(max_steps: int = 100, threshold: float = 0.9):
         dht = DHT(initial_peers=server_peer_info.addrs, start=True)
         expert1, expert2 = create_remote_experts(
             [
-                RemoteExpertInfo(uid="expert.0", peer_info=server_peer_info),
-                RemoteExpertInfo(uid="expert.1", peer_info=server_peer_info),
+                ExpertInfo(uid="expert.0", peer_info=server_peer_info),
+                ExpertInfo(uid="expert.1", peer_info=server_peer_info),
             ],
             dht=dht,
         )


### PR DESCRIPTION
This PR changes declare_experts / RemoteExpert to use only p2p peer ID, not the whole multiaddress.
This slightly reduces the code complexity and gives you an easier time sharing experts with dynamic IP.

It also fixes one DHT edge case i've discovered when working on it.

Minor changes:
- fixed an edge case: previously, DHT would **freeze** if accessing DHT.peer_id or otherwise calling .run_coroutine from inside another run_coroutine
- merged RemoteExpertInfo and UidEndpoint into one structure (ExpertInfo), now in expert_uid.py
- extracted expert_uid.py from hivemind.moe.server to hivemind.moe in order to avoid circular imports
- renamed get_expert_stub into get_server_stub since it is not expert-specific
