### PR TITLE
Add support for quantization with bitsandbytes

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -28,9 +28,8 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          git clone https://github.com/TimDettmers/bitsandbytes.git
+          git clone --depth 1 --branch 0.32.1 https://github.com/TimDettmers/bitsandbytes.git
           cd bitsandbytes
-          git checkout cbb901ac51bd6c41e4243ffb936ef0e2f7ca8ada
           make cpuonly
           pip install .
           cd -

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -26,6 +26,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
+      - name: Build bitsandbytes
+        run: |
+          git clone https://github.com/TimDettmers/bitsandbytes.git
+          cd bitsandbytes
+          make cpuonly
+          pip install .
+          cd -
       - name: Build hivemind
         run: |
           pip install .

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -28,11 +28,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          git clone https://github.com/TimDettmers/bitsandbytes.git
-          cd bitsandbytes
-          make cpuonly
-          pip install .
-          cd -
+          pip install bitsandbytes==0.32.1
       - name: Build hivemind
         run: |
           pip install .

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -28,7 +28,12 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.31.8
+          git clone https://github.com/TimDettmers/bitsandbytes.git
+          git checkout cbb901ac51bd6c41e4243ffb936ef0e2f7ca8ada
+          cd bitsandbytes
+          make cpuonly
+          pip install .
+          cd -
       - name: Build hivemind
         run: |
           pip install .

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.32.1
+          pip install bitsandbytes==0.31.8
       - name: Build hivemind
         run: |
           pip install .

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.32.2
+          pip install bitsandbytes==0.32.3
       - name: Build hivemind
         run: |
           pip install .

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -28,12 +28,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          git clone https://github.com/TimDettmers/bitsandbytes.git
-          cd bitsandbytes
-          git checkout 4cd7ea62b2f51c68aacde2f62e7141765e476111
-          make cpuonly
-          pip install .
-          cd -
+          pip install bitsandbytes==0.32.2
       - name: Build hivemind
         run: |
           pip install .

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -28,8 +28,9 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          git clone --depth 1 --branch 0.32.1 https://github.com/TimDettmers/bitsandbytes.git
+          git clone https://github.com/TimDettmers/bitsandbytes.git
           cd bitsandbytes
+          git checkout 4cd7ea62b2f51c68aacde2f62e7141765e476111
           make cpuonly
           pip install .
           cd -

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Build bitsandbytes
         run: |
           git clone https://github.com/TimDettmers/bitsandbytes.git
-          git checkout cbb901ac51bd6c41e4243ffb936ef0e2f7ca8ada
           cd bitsandbytes
+          git checkout cbb901ac51bd6c41e4243ffb936ef0e2f7ca8ada
           make cpuonly
           pip install .
           cd -

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -91,8 +91,8 @@ jobs:
       - name: Build bitsandbytes
         run: |
           git clone https://github.com/TimDettmers/bitsandbytes.git
-          git checkout cbb901ac51bd6c41e4243ffb936ef0e2f7ca8ada
           cd bitsandbytes
+          git checkout cbb901ac51bd6c41e4243ffb936ef0e2f7ca8ada
           make cpuonly
           pip install .
           cd -

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,12 +31,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          git clone https://github.com/TimDettmers/bitsandbytes.git
-          cd bitsandbytes
-          git checkout 4cd7ea62b2f51c68aacde2f62e7141765e476111
-          make cpuonly
-          pip install .
-          cd -
+          pip install bitsandbytes==0.32.2
       - name: Build hivemind
         run: |
           pip install .
@@ -98,12 +93,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          git clone https://github.com/TimDettmers/bitsandbytes.git
-          cd bitsandbytes
-          git checkout 4cd7ea62b2f51c68aacde2f62e7141765e476111
-          make cpuonly
-          pip install .
-          cd -
+          pip install bitsandbytes==0.32.2
       - name: Build hivemind
         run: |
           pip install -e . --no-use-pep517

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.32.2
+          pip install bitsandbytes==0.32.3
       - name: Build hivemind
         run: |
           pip install .
@@ -93,7 +93,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.32.2
+          pip install bitsandbytes==0.32.3
       - name: Build hivemind
         run: |
           pip install -e . --no-use-pep517

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -88,6 +88,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
+      - name: Build bitsandbytes
+        run: |
+          git clone git@github.com:TimDettmers/bitsandbytes.git
+          cd bitsandbytes
+          make cpuonly
+          pip install .
+          cd -
       - name: Build hivemind
         run: |
           pip install -e . --no-use-pep517

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,7 +90,12 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.31.8
+          git clone https://github.com/TimDettmers/bitsandbytes.git
+          git checkout cbb901ac51bd6c41e4243ffb936ef0e2f7ca8ada
+          cd bitsandbytes
+          make cpuonly
+          pip install .
+          cd -
       - name: Build hivemind
         run: |
           pip install -e . --no-use-pep517

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,7 +90,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          git clone git@github.com:TimDettmers/bitsandbytes.git
+          git clone https://github.com/TimDettmers/bitsandbytes.git
           cd bitsandbytes
           make cpuonly
           pip install .

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,7 +90,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.32.1
+          pip install bitsandbytes==0.31.8
       - name: Build hivemind
         run: |
           pip install -e . --no-use-pep517

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,8 +90,9 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          git clone --depth 1 --branch 0.32.1 https://github.com/TimDettmers/bitsandbytes.git
+          git clone https://github.com/TimDettmers/bitsandbytes.git
           cd bitsandbytes
+          git checkout 4cd7ea62b2f51c68aacde2f62e7141765e476111
           make cpuonly
           pip install .
           cd -

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -60,6 +60,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
+      - name: Build bitsandbytes
+        run: |
+          git clone https://github.com/TimDettmers/bitsandbytes.git
+          cd bitsandbytes
+          git checkout 4cd7ea62b2f51c68aacde2f62e7141765e476111
+          make cpuonly
+          pip install .
+          cd -
       - name: Build hivemind
         run: |
           pip install . --global-option=build_py --global-option="--buildgo" --no-use-pep517

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,11 +90,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          git clone https://github.com/TimDettmers/bitsandbytes.git
-          cd bitsandbytes
-          make cpuonly
-          pip install .
-          cd -
+          pip install bitsandbytes==0.32.1
       - name: Build hivemind
         run: |
           pip install -e . --no-use-pep517

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,9 +90,8 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          git clone https://github.com/TimDettmers/bitsandbytes.git
+          git clone --depth 1 --branch 0.32.1 https://github.com/TimDettmers/bitsandbytes.git
           cd bitsandbytes
-          git checkout cbb901ac51bd6c41e4243ffb936ef0e2f7ca8ada
           make cpuonly
           pip install .
           cd -

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,6 +29,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
+      - name: Build bitsandbytes
+        run: |
+          git clone https://github.com/TimDettmers/bitsandbytes.git
+          cd bitsandbytes
+          git checkout 4cd7ea62b2f51c68aacde2f62e7141765e476111
+          make cpuonly
+          pip install .
+          cd -
       - name: Build hivemind
         run: |
           pip install .
@@ -60,14 +68,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-      - name: Build bitsandbytes
-        run: |
-          git clone https://github.com/TimDettmers/bitsandbytes.git
-          cd bitsandbytes
-          git checkout 4cd7ea62b2f51c68aacde2f62e7141765e476111
-          make cpuonly
-          pip install .
-          cd -
       - name: Build hivemind
         run: |
           pip install . --global-option=build_py --global-option="--buildgo" --no-use-pep517

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pip install hivemind
 
 Also, if you want to use blockwise 8-bit compression from [bitsandbytes](https://github.com/TimDettmers/bitsandbytes) 
 during data transfer, you can [build it from source](https://github.com/TimDettmers/bitsandbytes#compile-from-source) 
-or install it with `pip install "bitsandbytes>=0.31.8"` and use the `BlockwiseQuantization` class in [hivemind.compression](./hivemind/compression)
+or install it with `pip install "bitsandbytes==0.32.1` and use the `BlockwiseQuantization` class in [hivemind.compression](./hivemind/compression)
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ pip install hivemind
 
 Also, if you want to use blockwise 8-bit compression from [bitsandbytes](https://github.com/TimDettmers/bitsandbytes) 
 during data transfer, you can [build it from source](https://github.com/TimDettmers/bitsandbytes#compile-from-source) 
-or install it with `pip install "bitsandbytes==0.32.1` and use the `BlockwiseQuantization` class in [hivemind.compression](./hivemind/compression)
+(for CPU-only builds, use commit [`4cd7ea6`](https://github.com/TimDettmers/bitsandbytes/commit/4cd7ea62b2f51c68aacde2f62e7141765e476111)) 
+or install with `pip install "bitsandbytes==0.32.1`. After that, you can use the `BlockwiseQuantization` class in [hivemind.compression](./hivemind/compression)
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install hivemind
 Also, if you want to use blockwise 8-bit compression from [bitsandbytes](https://github.com/TimDettmers/bitsandbytes) 
 during data transfer, you can [build it from source](https://github.com/TimDettmers/bitsandbytes#compile-from-source) 
 (for CPU-only builds, use commit [`4cd7ea6`](https://github.com/TimDettmers/bitsandbytes/commit/4cd7ea62b2f51c68aacde2f62e7141765e476111)) 
-or install with `pip install "bitsandbytes==0.32.1`. After that, you can use the `BlockwiseQuantization` class in [hivemind.compression](./hivemind/compression)
+or install with `pip install bitsandbytes==0.32.1`. After that, you can use the `BlockwiseQuantization` class in [hivemind.compression](./hivemind/compression)
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,8 @@ pip install hivemind
 ```
 
 Also, if you want to use blockwise 8-bit compression from [bitsandbytes](https://github.com/TimDettmers/bitsandbytes) 
-during data transfer, you can [build it from source](https://github.com/TimDettmers/bitsandbytes#compile-from-source) 
-(for CPU-only builds, use commit [`4cd7ea6`](https://github.com/TimDettmers/bitsandbytes/commit/4cd7ea62b2f51c68aacde2f62e7141765e476111)) 
-or install with `pip install bitsandbytes==0.32.1`. After that, you can use the `BlockwiseQuantization` class in [hivemind.compression](./hivemind/compression)
+during data transfer, you can install it with `pip install hivemind[bitsandbytes]`. 
+After that, you can use the `BlockwiseQuantization` class in [hivemind.compression](./hivemind/compression)
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ If your versions of Python and PyTorch match the requirements, you can install h
 pip install hivemind
 ```
 
+Also, if you want to use blockwise 8-bit compression from [bitsandbytes](https://github.com/TimDettmers/bitsandbytes) 
+during data transfer, you can [build it from source](https://github.com/TimDettmers/bitsandbytes#compile-from-source) 
+or install it with `pip install "bitsandbytes==0.31.8"`` and use the `BlockwiseQuantization` class in [hivemind.compression](./hivemind/compression)
+
 ### From source
 
 To install hivemind from source, simply run the following:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pip install hivemind
 
 Also, if you want to use blockwise 8-bit compression from [bitsandbytes](https://github.com/TimDettmers/bitsandbytes) 
 during data transfer, you can [build it from source](https://github.com/TimDettmers/bitsandbytes#compile-from-source) 
-or install it with `pip install "bitsandbytes==0.31.8"`` and use the `BlockwiseQuantization` class in [hivemind.compression](./hivemind/compression)
+or install it with `pip install "bitsandbytes>=0.31.8"` and use the `BlockwiseQuantization` class in [hivemind.compression](./hivemind/compression)
 
 ### From source
 

--- a/benchmarks/benchmark_tensor_compression.py
+++ b/benchmarks/benchmark_tensor_compression.py
@@ -11,26 +11,35 @@ use_hivemind_log_handler("in_root_logger")
 logger = get_logger(__name__)
 
 
-def benchmark_compression(tensor: torch.Tensor, compression_type: CompressionType) -> float:
+def benchmark_compression(tensor: torch.Tensor, compression_type: CompressionType) -> [float, float, int]:
     t = time.time()
-    deserialize_torch_tensor(serialize_torch_tensor(tensor, compression_type))
-    return time.time() - t
+    serialized = serialize_torch_tensor(tensor, compression_type)
+    result = deserialize_torch_tensor(serialized)
+    return time.time() - t, (tensor - result).square().mean(), serialized.ByteSize()
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--size", type=int, default=10000000, required=False)
+    parser.add_argument("--size", type=int, default=10_000_000, required=False)
     parser.add_argument("--seed", type=int, default=7348, required=False)
     parser.add_argument("--num_iters", type=int, default=30, required=False)
 
     args = parser.parse_args()
 
     torch.manual_seed(args.seed)
-    X = torch.randn(args.size)
+    X = torch.randn(args.size, dtype=torch.float32)
 
     for name, compression_type in CompressionType.items():
-        tm = 0
+        total_time = 0
+        compression_error = 0
+        total_size = 0
         for i in range(args.num_iters):
-            tm += benchmark_compression(X, compression_type)
-        tm /= args.num_iters
-        logger.info(f"Compression type: {name}, time: {tm}")
+            iter_time, iter_distortion, size = benchmark_compression(X, compression_type)
+            total_time += iter_time
+            compression_error += iter_distortion
+            total_size += size
+        total_time /= args.num_iters
+        compression_error /= args.num_iters
+        total_size /= args.num_iters
+        logger.info(f"Compression type: {name}, time: {total_time:.5f}, compression error: {compression_error:.5f}, "
+                    f"size: {int(total_size):d}")

--- a/benchmarks/benchmark_tensor_compression.py
+++ b/benchmarks/benchmark_tensor_compression.py
@@ -41,5 +41,7 @@ if __name__ == "__main__":
         total_time /= args.num_iters
         compression_error /= args.num_iters
         total_size /= args.num_iters
-        logger.info(f"Compression type: {name}, time: {total_time:.5f}, compression error: {compression_error:.5f}, "
-                    f"size: {int(total_size):d}")
+        logger.info(
+            f"Compression type: {name}, time: {total_time:.5f}, compression error: {compression_error:.5f}, "
+            f"size: {int(total_size):d}"
+        )

--- a/hivemind/compression/__init__.py
+++ b/hivemind/compression/__init__.py
@@ -5,7 +5,7 @@ Compression strategies that reduce the network communication in .averaging, .opt
 from hivemind.compression.adaptive import PerTensorCompression, RoleAdaptiveCompression, SizeAdaptiveCompression
 from hivemind.compression.base import CompressionBase, CompressionInfo, NoCompression, TensorRole
 from hivemind.compression.floating import Float16Compression, ScaledFloat16Compression
-from hivemind.compression.quantization import Quantile8BitQuantization, Uniform8BitQuantization
+from hivemind.compression.quantization import BlockwiseQuantization, Quantile8BitQuantization, Uniform8BitQuantization
 from hivemind.compression.serialization import (
     deserialize_tensor_stream,
     deserialize_torch_tensor,

--- a/hivemind/compression/quantization.py
+++ b/hivemind/compression/quantization.py
@@ -1,6 +1,7 @@
 import importlib.util
 import math
 import os
+import warnings
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from typing import Tuple
@@ -9,6 +10,7 @@ import numpy as np
 import torch
 
 if importlib.util.find_spec("bitsandbytes") is not None:
+    warnings.filterwarnings("ignore", module="bitsandbytes", category=UserWarning)
     from bitsandbytes.functional import quantize_blockwise, dequantize_blockwise
 
 from hivemind.compression.base import CompressionBase, CompressionInfo

--- a/hivemind/compression/quantization.py
+++ b/hivemind/compression/quantization.py
@@ -118,6 +118,11 @@ def quantile_qq_approximation(array: np.ndarray, n_quantiles: int, min_chunk_siz
     return np.quantile(partition_quantiles, quantiles)
 
 
+BNB_MISSING_MESSAGE = """BlockwiseQuantization requires bitsandbytes to function properly. 
+Please install it with `pip install bitsandbytes` 
+or using the instruction from https://github.com/TimDettmers/bitsandbytes."""
+
+
 class BlockwiseQuantization(Quantization):
     compression_type = runtime_pb2.BLOCKWISE_8BIT
     codebook_dtype, indices_dtype = np.float32, np.uint8
@@ -128,11 +133,7 @@ class BlockwiseQuantization(Quantization):
         try:
             quantized, (absmax, codebook) = quantize_blockwise(tensor)
         except NameError:
-            raise ImportError(
-                "BlockwiseQuantization requires bitsandbytes to function. "
-                "Please install it using the following guide: "
-                "https://github.com/facebookresearch/bitsandbytes#requirements--installation"
-            )
+            raise ImportError(BNB_MISSING_MESSAGE)
         return quantized.numpy(), (absmax.numpy(), codebook.numpy())
 
     def compress(self, tensor: torch.Tensor, info: CompressionInfo, allow_inplace: bool = False) -> runtime_pb2.Tensor:
@@ -171,8 +172,4 @@ class BlockwiseQuantization(Quantization):
         try:
             return dequantize_blockwise(quantized, (absmax, codebook))
         except NameError:
-            raise ImportError(
-                "BlockwiseQuantization requires bitsandbytes to function. "
-                "Please install it using the following guide: "
-                "https://github.com/facebookresearch/bitsandbytes#requirements--installation"
-            )
+            raise ImportError(BNB_MISSING_MESSAGE)

--- a/hivemind/compression/serialization.py
+++ b/hivemind/compression/serialization.py
@@ -6,21 +6,22 @@ import torch
 
 from hivemind.compression.base import CompressionBase, CompressionInfo, NoCompression
 from hivemind.compression.floating import Float16Compression, ScaledFloat16Compression
-from hivemind.compression.quantization import Quantile8BitQuantization, Uniform8BitQuantization
+from hivemind.compression.quantization import BlockwiseQuantization, Quantile8BitQuantization, Uniform8BitQuantization
 from hivemind.proto import runtime_pb2
 from hivemind.utils.streaming import combine_from_streaming
 
-BASE_COMPRESSION_TYPES: Dict[str, CompressionBase] = dict(
+_BASE_COMPRESSION_TYPES: Dict[str, CompressionBase] = dict(
     NONE=NoCompression(),
     FLOAT16=Float16Compression(),
     MEANSTD_16BIT=ScaledFloat16Compression(),
     QUANTILE_8BIT=Quantile8BitQuantization(),
     UNIFORM_8BIT=Uniform8BitQuantization(),
+    BLOCKWISE_8BIT=BlockwiseQuantization(),
 )
 
 for key in runtime_pb2.CompressionType.keys():
-    assert key in BASE_COMPRESSION_TYPES, f"Compression type {key} does not have a registered deserializer"
-    actual_compression_type = BASE_COMPRESSION_TYPES[key].compression_type
+    assert key in _BASE_COMPRESSION_TYPES, f"Compression type {key} does not have a registered deserializer"
+    actual_compression_type = _BASE_COMPRESSION_TYPES[key].compression_type
     assert (
         runtime_pb2.CompressionType.Name(actual_compression_type) == key
     ), f"Compression strategy for {key} has inconsistent type"
@@ -35,14 +36,14 @@ def serialize_torch_tensor(
 ) -> runtime_pb2.Tensor:
     """Serialize a given tensor into a protobuf message using the specified compression strategy"""
     assert tensor.device == torch.device("cpu")
-    compression = BASE_COMPRESSION_TYPES[runtime_pb2.CompressionType.Name(compression_type)]
+    compression = _BASE_COMPRESSION_TYPES[runtime_pb2.CompressionType.Name(compression_type)]
     info = info or CompressionInfo.from_tensor(tensor, **kwargs)
     return compression.compress(tensor, info, allow_inplace)
 
 
 def deserialize_torch_tensor(serialized_tensor: runtime_pb2.Tensor) -> torch.Tensor:
     """Restore a pytorch tensor from a protobuf message"""
-    compression = BASE_COMPRESSION_TYPES[runtime_pb2.CompressionType.Name(serialized_tensor.compression)]
+    compression = _BASE_COMPRESSION_TYPES[runtime_pb2.CompressionType.Name(serialized_tensor.compression)]
     return compression.extract(serialized_tensor).requires_grad_(serialized_tensor.requires_grad)
 
 

--- a/hivemind/moe/server/module_backend.py
+++ b/hivemind/moe/server/module_backend.py
@@ -118,7 +118,9 @@ class ModuleBackend:
 
         with torch.enable_grad():
             args = [
-                tensor.detach().requires_grad_(True) if tensor.is_floating_point() else tensor.detach()
+                tensor.detach().requires_grad_(True)
+                if tensor.dtype in (torch.half, torch.float, torch.double)
+                else tensor.detach()
                 for tensor in args
             ]
             kwargs = {

--- a/hivemind/moe/server/module_backend.py
+++ b/hivemind/moe/server/module_backend.py
@@ -118,9 +118,7 @@ class ModuleBackend:
 
         with torch.enable_grad():
             args = [
-                tensor.detach().requires_grad_(True)
-                if tensor.dtype in (torch.half, torch.float, torch.double)
-                else tensor.detach()
+                tensor.detach().requires_grad_(True) if tensor.is_floating_point() else tensor.detach()
                 for tensor in args
             ]
             kwargs = {

--- a/hivemind/proto/runtime.proto
+++ b/hivemind/proto/runtime.proto
@@ -26,6 +26,7 @@ enum CompressionType{
   FLOAT16 = 2;
   QUANTILE_8BIT = 3;
   UNIFORM_8BIT = 4;
+  BLOCKWISE_8BIT = 5;
 }
 
 message Tensor {

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,9 @@ with open("requirements-dev.txt") as dev_requirements_file:
 with open("requirements-docs.txt") as docs_requirements_file:
     extras["docs"] = list(map(str, parse_requirements(docs_requirements_file)))
 
+if os.environ["CUDA_VERSION"] is not None:
+    extras["bitsandbytes"] = f"bitsandbytes-cuda{os.environ['CUDA_VERSION']}==0.26.0"
+
 extras["all"] = extras["dev"] + extras["docs"]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -140,8 +140,9 @@ with open("requirements-dev.txt") as dev_requirements_file:
 with open("requirements-docs.txt") as docs_requirements_file:
     extras["docs"] = list(map(str, parse_requirements(docs_requirements_file)))
 
-if os.environ["CUDA_VERSION"] is not None:
-    extras["bitsandbytes"] = f"bitsandbytes-cuda{os.environ['CUDA_VERSION']}==0.26.0"
+cuda_version = os.getenv("CUDA_VERSION")
+if cuda_version is not None:
+    extras["bitsandbytes"] = f"bitsandbytes-cuda{cuda_version}==0.26.0"
 
 extras["all"] = extras["dev"] + extras["docs"]
 

--- a/setup.py
+++ b/setup.py
@@ -140,11 +140,9 @@ with open("requirements-dev.txt") as dev_requirements_file:
 with open("requirements-docs.txt") as docs_requirements_file:
     extras["docs"] = list(map(str, parse_requirements(docs_requirements_file)))
 
-cuda_version = os.getenv("CUDA_VERSION")
-if cuda_version is not None:
-    extras["bitsandbytes"] = f"bitsandbytes-cuda{cuda_version}==0.26.0"
+extras["bitsandbytes"] = "bitsandbytes==0.32.2"
 
-extras["all"] = extras["dev"] + extras["docs"]
+extras["all"] = extras["dev"] + extras["docs"] + extras["bitsandbytes"]
 
 setup(
     name="hivemind",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ EXECUTABLES = {
     "p2pd": "1252a2a2095040cef8e317f5801df8b8c93559711783a2496a0aff2f3e177e39",
 }
 
-
 here = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -38,10 +37,10 @@ def proto_compile(output_path):
     import grpc_tools.protoc
 
     cli_args = [
-        "grpc_tools.protoc",
-        "--proto_path=hivemind/proto",
-        f"--python_out={output_path}",
-    ] + glob.glob("hivemind/proto/*.proto")
+                   "grpc_tools.protoc",
+                   "--proto_path=hivemind/proto",
+                   f"--python_out={output_path}",
+               ] + glob.glob("hivemind/proto/*.proto")
 
     code = grpc_tools.protoc.main(cli_args)
     if code:  # hint: if you get this error in jupyter, run in console for richer error message
@@ -140,7 +139,7 @@ with open("requirements-dev.txt") as dev_requirements_file:
 with open("requirements-docs.txt") as docs_requirements_file:
     extras["docs"] = list(map(str, parse_requirements(docs_requirements_file)))
 
-extras["bitsandbytes"] = "bitsandbytes==0.32.2"
+extras["bitsandbytes"] = ["bitsandbytes==0.32.2"]
 
 extras["all"] = extras["dev"] + extras["docs"] + extras["bitsandbytes"]
 
@@ -150,7 +149,7 @@ setup(
     cmdclass={"build_py": BuildPy, "develop": Develop},
     description="Decentralized deep learning in PyTorch",
     long_description="Decentralized deep learning in PyTorch. Built to train models on thousands of volunteers "
-    "across the world.",
+                     "across the world.",
     author="Learning@home & contributors",
     author_email="hivemind-team@hotmail.com",
     url="https://github.com/learning-at-home/hivemind",

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,10 @@ def proto_compile(output_path):
     import grpc_tools.protoc
 
     cli_args = [
-                   "grpc_tools.protoc",
-                   "--proto_path=hivemind/proto",
-                   f"--python_out={output_path}",
-               ] + glob.glob("hivemind/proto/*.proto")
+        "grpc_tools.protoc",
+        "--proto_path=hivemind/proto",
+        f"--python_out={output_path}",
+    ] + glob.glob("hivemind/proto/*.proto")
 
     code = grpc_tools.protoc.main(cli_args)
     if code:  # hint: if you get this error in jupyter, run in console for richer error message
@@ -149,7 +149,7 @@ setup(
     cmdclass={"build_py": BuildPy, "develop": Develop},
     description="Decentralized deep learning in PyTorch",
     long_description="Decentralized deep learning in PyTorch. Built to train models on thousands of volunteers "
-                     "across the world.",
+    "across the world.",
     author="Learning@home & contributors",
     author_email="hivemind-team@hotmail.com",
     url="https://github.com/learning-at-home/hivemind",

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ with open("requirements-dev.txt") as dev_requirements_file:
 with open("requirements-docs.txt") as docs_requirements_file:
     extras["docs"] = list(map(str, parse_requirements(docs_requirements_file)))
 
-extras["bitsandbytes"] = ["bitsandbytes==0.32.2"]
+extras["bitsandbytes"] = ["bitsandbytes==0.32.3"]
 
 extras["all"] = extras["dev"] + extras["docs"] + extras["bitsandbytes"]
 

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -15,10 +15,12 @@ def test_dht_connection_successful():
         encoding="utf-8",
     )
 
-    # skip bitsandbytes warning
-    _ = dht_proc.stderr.readline()
-    _ = dht_proc.stderr.readline()
     first_line = dht_proc.stderr.readline()
+    if "UserWarning: The installed version of bitsandbytes was compiled without GPU support" in first_line:
+        # skip the rest of the warning
+        _ = dht_proc.stderr.readline()
+        first_line = dht_proc.stderr.readline()
+
     second_line = dht_proc.stderr.readline()
     dht_pattern_match = DHT_START_PATTERN.search(first_line)
     assert dht_pattern_match is not None, first_line
@@ -33,9 +35,14 @@ def test_dht_connection_successful():
         encoding="utf-8",
     )
 
-    # skip first three lines with connectivity and bitsandbytes info
-    for _ in range(4):
+    first_line = dht_client_proc.stderr.readline()
+    if "UserWarning: The installed version of bitsandbytes was compiled without GPU support" in first_line:
+        # skip the rest of the warning and the first line with connectivity info
         dht_client_proc.stderr.readline()
+        dht_client_proc.stderr.readline()
+
+    # skip the line with connectivity info
+    dht_client_proc.stderr.readline()
     first_report_msg = dht_client_proc.stderr.readline()
 
     assert "2 DHT nodes (including this one) are in the local routing table" in first_report_msg, first_report_msg

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -30,7 +30,7 @@ def test_dht_connection_successful():
         encoding="utf-8",
     )
 
-    # skip two lines with connectivity info
+    # skip first two lines with connectivity info
     for _ in range(2):
         dht_client_proc.stderr.readline()
     first_report_msg = dht_client_proc.stderr.readline()

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -17,6 +17,7 @@ def test_dht_connection_successful():
 
     # skip bitsandbytes warning
     _ = dht_proc.stderr.readline()
+    _ = dht_proc.stderr.readline()
     first_line = dht_proc.stderr.readline()
     second_line = dht_proc.stderr.readline()
     dht_pattern_match = DHT_START_PATTERN.search(first_line)
@@ -33,11 +34,11 @@ def test_dht_connection_successful():
     )
 
     # skip first three lines with connectivity and bitsandbytes info
-    for _ in range(3):
+    for _ in range(4):
         dht_client_proc.stderr.readline()
     first_report_msg = dht_client_proc.stderr.readline()
 
-    assert "2 DHT nodes (including this one) are in the local routing table" in first_report_msg
+    assert "2 DHT nodes (including this one) are in the local routing table" in first_report_msg, first_report_msg
 
     # ensure we get the output of dht_proc after the start of dht_client_proc
     sleep(dht_refresh_period)

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -16,11 +16,6 @@ def test_dht_connection_successful():
     )
 
     first_line = dht_proc.stderr.readline()
-    if "UserWarning: The installed version of bitsandbytes was compiled without GPU support" in first_line:
-        # skip the rest of the warning
-        _ = dht_proc.stderr.readline()
-        first_line = dht_proc.stderr.readline()
-
     second_line = dht_proc.stderr.readline()
     dht_pattern_match = DHT_START_PATTERN.search(first_line)
     assert dht_pattern_match is not None, first_line
@@ -35,14 +30,9 @@ def test_dht_connection_successful():
         encoding="utf-8",
     )
 
-    first_line = dht_client_proc.stderr.readline()
-    if "UserWarning: The installed version of bitsandbytes was compiled without GPU support" in first_line:
-        # skip the rest of the warning and the first line with connectivity info
+    # skip two lines with connectivity info
+    for _ in range(2):
         dht_client_proc.stderr.readline()
-        dht_client_proc.stderr.readline()
-
-    # skip the line with connectivity info
-    dht_client_proc.stderr.readline()
     first_report_msg = dht_client_proc.stderr.readline()
 
     assert "2 DHT nodes (including this one) are in the local routing table" in first_report_msg, first_report_msg

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -15,6 +15,8 @@ def test_dht_connection_successful():
         encoding="utf-8",
     )
 
+    # skip bitsandbytes warning
+    _ = dht_proc.stderr.readline()
     first_line = dht_proc.stderr.readline()
     second_line = dht_proc.stderr.readline()
     dht_pattern_match = DHT_START_PATTERN.search(first_line)
@@ -30,8 +32,8 @@ def test_dht_connection_successful():
         encoding="utf-8",
     )
 
-    # skip first two lines with connectivity info
-    for _ in range(2):
+    # skip first three lines with connectivity and bitsandbytes info
+    for _ in range(3):
         dht_client_proc.stderr.readline()
     first_report_msg = dht_client_proc.stderr.readline()
 

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -38,6 +38,8 @@ def test_tensor_compression(size=(128, 128, 64), alpha=5e-08, beta=0.0008):
     assert error.square().mean() < beta
     error = deserialize_torch_tensor(serialize_torch_tensor(X, CompressionType.UNIFORM_8BIT)) - X
     assert error.square().mean() < beta
+    error = deserialize_torch_tensor(serialize_torch_tensor(X, CompressionType.BLOCKWISE_8BIT)) - X
+    assert error.square().mean() < beta
 
     zeros = torch.zeros(5, 5)
     for compression_type in CompressionType.values():

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -162,7 +162,7 @@ def test_remote_module_call(hidden_dim=16):
 
         # check that the server is still alive after processing a malformed request
         out3_yet_again = real_expert(dummy_x[1:])
-        assert torch.allclose(out3_yet_again, out3[1:])
+        assert torch.allclose(out3_yet_again, out3[1:], atol=1e-5, rtol=0)
 
 
 @pytest.mark.forked

--- a/tests/test_start_server.py
+++ b/tests/test_start_server.py
@@ -1,5 +1,6 @@
 import os
 import re
+from functools import partial
 from subprocess import PIPE, Popen
 from tempfile import TemporaryDirectory
 
@@ -31,11 +32,13 @@ def test_cli_run_server_identity_path():
             encoding="utf-8",
         )
 
-        # Skip line "UserWarning: The installed version of bitsandbytes was compiled without GPU support. <...>"
-        _ = server_1_proc.stderr.readline()
-        _ = server_1_proc.stderr.readline()
-        # Skip line "Generating new identity (libp2p private key) in {path to file}"
-        _ = server_1_proc.stderr.readline()
+        line = server_1_proc.stderr.readline()
+        if "UserWarning: The installed version of bitsandbytes was compiled without GPU support" in line:
+            # Skip the rest of the warning
+            server_1_proc.stderr.readline()
+            # Skip line "Generating new identity (libp2p private key) in {path to file}"
+            server_1_proc.stderr.readline()
+
         line = server_1_proc.stderr.readline()
         addrs_pattern_result = re.search(pattern, line)
         assert addrs_pattern_result is not None, line
@@ -51,10 +54,12 @@ def test_cli_run_server_identity_path():
             encoding="utf-8",
         )
 
-        # Skip line "UserWarning: The installed version of bitsandbytes was compiled without GPU support. <...>"
-        _ = server_2_proc.stderr.readline()
-        _ = server_2_proc.stderr.readline()
         line = server_2_proc.stderr.readline()
+        if "UserWarning: The installed version of bitsandbytes was compiled without GPU support" in line:
+            # skip the rest of the warning
+            server_2_proc.stderr.readline()
+            line = server_2_proc.stderr.readline()
+
         addrs_pattern_result = re.search(pattern, line)
         assert addrs_pattern_result is not None, line
         addrs_2 = set(addrs_pattern_result.group(1).split(", "))
@@ -69,10 +74,12 @@ def test_cli_run_server_identity_path():
             encoding="utf-8",
         )
 
-        # Skip line "UserWarning: The installed version of bitsandbytes was compiled without GPU support. <...>"
-        _ = server_3_proc.stderr.readline()
-        _ = server_3_proc.stderr.readline()
         line = server_3_proc.stderr.readline()
+        if "UserWarning: The installed version of bitsandbytes was compiled without GPU support" in line:
+            # skip the rest of the warning
+            server_3_proc.stderr.readline()
+            line = server_3_proc.stderr.readline()
+
         addrs_pattern_result = re.search(pattern, line)
         assert addrs_pattern_result is not None, line
         addrs_3 = set(addrs_pattern_result.group(1).split(", "))

--- a/tests/test_start_server.py
+++ b/tests/test_start_server.py
@@ -32,8 +32,10 @@ def test_cli_run_server_identity_path():
             encoding="utf-8",
         )
 
+        # Skip line "UserWarning: The installed version of bitsandbytes was compiled without GPU support. <...>"
+        _ = server_1_proc.stderr.readline()
         # Skip line "Generating new identity (libp2p private key) in {path to file}"
-        line = server_1_proc.stderr.readline()
+        _ = server_1_proc.stderr.readline()
         line = server_1_proc.stderr.readline()
         addrs_1 = set(re.search(pattern, line).group(1).split(", "))
         ids_1 = set(a.split("/")[-1] for a in addrs_1)
@@ -47,6 +49,8 @@ def test_cli_run_server_identity_path():
             encoding="utf-8",
         )
 
+        # Skip line "UserWarning: The installed version of bitsandbytes was compiled without GPU support. <...>"
+        _ = server_2_proc.stderr.readline()
         line = server_2_proc.stderr.readline()
         addrs_2 = set(re.search(pattern, line).group(1).split(", "))
         ids_2 = set(a.split("/")[-1] for a in addrs_2)
@@ -60,6 +64,8 @@ def test_cli_run_server_identity_path():
             encoding="utf-8",
         )
 
+        # Skip line "UserWarning: The installed version of bitsandbytes was compiled without GPU support. <...>"
+        _ = server_3_proc.stderr.readline()
         line = server_3_proc.stderr.readline()
         addrs_3 = set(re.search(pattern, line).group(1).split(", "))
         ids_3 = set(a.split("/")[-1] for a in addrs_3)

--- a/tests/test_start_server.py
+++ b/tests/test_start_server.py
@@ -34,13 +34,8 @@ def test_cli_run_server_identity_path():
             encoding="utf-8",
         )
 
-        line = server_1_proc.stderr.readline()
-        if "UserWarning: The installed version of bitsandbytes was compiled without GPU support" in line:
-            # Skip the rest of the warning
-            server_1_proc.stderr.readline()
-            # Skip line "Generating new identity (libp2p private key) in {path to file}"
-            server_1_proc.stderr.readline()
-
+        # Skip line "Generating new identity (libp2p private key) in {path to file}"
+        server_1_proc.stderr.readline()
         line = server_1_proc.stderr.readline()
         addrs_pattern_result = re.search(pattern, line)
         assert addrs_pattern_result is not None, line
@@ -57,11 +52,6 @@ def test_cli_run_server_identity_path():
         )
 
         line = server_2_proc.stderr.readline()
-        if "UserWarning: The installed version of bitsandbytes was compiled without GPU support" in line:
-            # skip the rest of the warning
-            server_2_proc.stderr.readline()
-            line = server_2_proc.stderr.readline()
-
         addrs_pattern_result = re.search(pattern, line)
         assert addrs_pattern_result is not None, line
         addrs_2 = set(addrs_pattern_result.group(1).split(", "))
@@ -77,11 +67,6 @@ def test_cli_run_server_identity_path():
         )
 
         line = server_3_proc.stderr.readline()
-        if "UserWarning: The installed version of bitsandbytes was compiled without GPU support" in line:
-            # skip the rest of the warning
-            server_3_proc.stderr.readline()
-            line = server_3_proc.stderr.readline()
-
         addrs_pattern_result = re.search(pattern, line)
         assert addrs_pattern_result is not None, line
         addrs_3 = set(addrs_pattern_result.group(1).split(", "))

--- a/tests/test_start_server.py
+++ b/tests/test_start_server.py
@@ -11,9 +11,11 @@ def test_background_server_identity_path():
     with TemporaryDirectory() as tempdir:
         id_path = os.path.join(tempdir, "id")
 
-        with background_server(num_experts=1, identity_path=id_path) as server_info_1, background_server(
-            num_experts=1, identity_path=id_path
-        ) as server_info_2, background_server(num_experts=1, identity_path=None) as server_info_3:
+        server_runner = partial(background_server, num_experts=1, device="cpu", hidden_dim=1)
+
+        with server_runner(identity_path=id_path) as server_info_1, server_runner(
+            identity_path=id_path
+        ) as server_info_2, server_runner(identity_path=None) as server_info_3:
             assert server_info_1.peer_id == server_info_2.peer_id
             assert server_info_1.peer_id != server_info_3.peer_id
             assert server_info_3.peer_id == server_info_3.peer_id

--- a/tests/test_start_server.py
+++ b/tests/test_start_server.py
@@ -13,7 +13,6 @@ def test_background_server_identity_path():
         with background_server(num_experts=1, identity_path=id_path) as server_info_1, background_server(
             num_experts=1, identity_path=id_path
         ) as server_info_2, background_server(num_experts=1, identity_path=None) as server_info_3:
-
             assert server_info_1.peer_id == server_info_2.peer_id
             assert server_info_1.peer_id != server_info_3.peer_id
             assert server_info_3.peer_id == server_info_3.peer_id
@@ -34,10 +33,13 @@ def test_cli_run_server_identity_path():
 
         # Skip line "UserWarning: The installed version of bitsandbytes was compiled without GPU support. <...>"
         _ = server_1_proc.stderr.readline()
+        _ = server_1_proc.stderr.readline()
         # Skip line "Generating new identity (libp2p private key) in {path to file}"
         _ = server_1_proc.stderr.readline()
         line = server_1_proc.stderr.readline()
-        addrs_1 = set(re.search(pattern, line).group(1).split(", "))
+        addrs_pattern_result = re.search(pattern, line)
+        assert addrs_pattern_result is not None, line
+        addrs_1 = set(addrs_pattern_result.group(1).split(", "))
         ids_1 = set(a.split("/")[-1] for a in addrs_1)
 
         assert len(ids_1) == 1
@@ -51,8 +53,11 @@ def test_cli_run_server_identity_path():
 
         # Skip line "UserWarning: The installed version of bitsandbytes was compiled without GPU support. <...>"
         _ = server_2_proc.stderr.readline()
+        _ = server_2_proc.stderr.readline()
         line = server_2_proc.stderr.readline()
-        addrs_2 = set(re.search(pattern, line).group(1).split(", "))
+        addrs_pattern_result = re.search(pattern, line)
+        assert addrs_pattern_result is not None, line
+        addrs_2 = set(addrs_pattern_result.group(1).split(", "))
         ids_2 = set(a.split("/")[-1] for a in addrs_2)
 
         assert len(ids_2) == 1
@@ -66,8 +71,11 @@ def test_cli_run_server_identity_path():
 
         # Skip line "UserWarning: The installed version of bitsandbytes was compiled without GPU support. <...>"
         _ = server_3_proc.stderr.readline()
+        _ = server_3_proc.stderr.readline()
         line = server_3_proc.stderr.readline()
-        addrs_3 = set(re.search(pattern, line).group(1).split(", "))
+        addrs_pattern_result = re.search(pattern, line)
+        assert addrs_pattern_result is not None, line
+        addrs_3 = set(addrs_pattern_result.group(1).split(", "))
         ids_3 = set(a.split("/")[-1] for a in addrs_3)
 
         assert len(ids_3) == 1


### PR DESCRIPTION
This PR integrates blockwise quantization from [bitsandbytes](https://github.com/facebookresearch/bitsandbytes) as a new compression mechanism of Hivemind. The important part is that it is an *optional* compression protocol: the user should only install an external library if they are going to need it, and hence the "conditional import"/"extra dependency" parts.

The code on the Hivemind side is pretty simple, but it'd be cool to have a way to include a CPU-only build of bitsandbytes as a dependency, so that we'll be able to both include it without checking for a CUDA version and to test the integration in GHA. @TimDettmers has granted me access to the bitsandbytes repo, so I'm going to work on that first before making this PR as ready to merge.