### PR TITLE
Make DHT ignore SIGINT

### DIFF
--- a/hivemind/dht/dht.py
+++ b/hivemind/dht/dht.py
@@ -55,9 +55,6 @@ class DHT(mp.Process):
         await_ready: bool = True,
         **kwargs,
     ):
-        # Set SIG_IGN handler tp SIGINT
-        original_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
-
         self._parent_pid = os.getpid()
         self._origin_pid = os.getpid()
         super().__init__()
@@ -90,9 +87,6 @@ class DHT(mp.Process):
         if start:
             self.run_in_background(await_ready=await_ready)
 
-        # Set the original SIGINT handler back
-        signal.signal(signal.SIGINT, original_handler)
-
     def run(self) -> None:
         """Serve DHT forever. This function will not return until DHT node is shut down"""
 
@@ -101,6 +95,9 @@ class DHT(mp.Process):
         loop.add_reader(self._inner_pipe.fileno(), pipe_semaphore.release)
 
         async def _run():
+            # Set SIG_IGN handler to SIGINT
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+
             try:
                 if self._daemon_listen_maddr is not None:
                     replicated_p2p = await P2P.replicate(self._daemon_listen_maddr)

--- a/hivemind/dht/dht.py
+++ b/hivemind/dht/dht.py
@@ -54,6 +54,9 @@ class DHT(mp.Process):
         await_ready: bool = True,
         **kwargs,
     ):
+        # Set SIG_IGN handler tp SIGINT
+        original_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
+
         self._parent_pid = os.getpid()
         self._origin_pid = os.getpid()
         super().__init__()
@@ -85,6 +88,9 @@ class DHT(mp.Process):
 
         if start:
             self.run_in_background(await_ready=await_ready)
+
+        # Set the original SIGINT handler back
+        signal.signal(signal.SIGINT, original_handler)
 
     def run(self) -> None:
         """Serve DHT forever. This function will not return until DHT node is shut down"""

--- a/hivemind/dht/dht.py
+++ b/hivemind/dht/dht.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import multiprocessing as mp
 import os
+import signal
 from functools import partial
 from typing import Awaitable, Callable, Iterable, List, Optional, Sequence, TypeVar, Union
 

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 
-P2PD_VERSION = "v0.3.9"
+P2PD_VERSION = "v0.3.10"
 
 P2PD_SOURCE_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/archive/refs/tags/{P2PD_VERSION}.tar.gz"
 P2PD_BINARY_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/releases/download/{P2PD_VERSION}/"
 
 # The value is sha256 of the binary from the release page
 EXECUTABLES = {
-    "p2pd": "8f9434f4717f6e851430f75f07e283d5ddeb2c7cde1b3648e677d813703f4e40",
+    "p2pd": "a9728685fd020dd5f0292e64b82740ac1643bbe9f793ec6d0b765c7efc28bcec",
 }
 
 


### PR DESCRIPTION
If someone uses hivemind from the Python interactive console/Jupyter notebooks, the keyboard interrupts (Ctrl+C) are propagated to children processes including the DHT process and the DHT gets killed. This PR fixes this behavior, so the DHT continues to run in background.

**See also:** https://github.com/learning-at-home/go-libp2p-daemon/pull/19