### PR TITLE
Require TaskPoolBase to implement load_batch_to_runtime

### DIFF
--- a/hivemind/moe/server/runtime.py
+++ b/hivemind/moe/server/runtime.py
@@ -81,7 +81,7 @@ class Runtime(threading.Thread):
                 
                 batch_iterator = self.iterate_minibatches_from_pools()
                 if self.prefetch_batches > 0:
-                    batch_iterator = BackgroundGenerator(batch_iterator, self.prefetch_batches):
+                    batch_iterator = BackgroundGenerator(batch_iterator, self.prefetch_batches)
 
                 for pool, batch_index, batch in batch_iterator:
                     logger.debug(f"Processing batch {batch_index} from pool {pool.name}")

--- a/hivemind/moe/server/runtime.py
+++ b/hivemind/moe/server/runtime.py
@@ -78,7 +78,7 @@ class Runtime(threading.Thread):
                 if self.stats_report_interval is not None:
                     self.stats_reporter.start()
                 logger.info("Started")
-                
+
                 batch_iterator = self.iterate_minibatches_from_pools()
                 if self.prefetch_batches > 0:
                     batch_iterator = BackgroundGenerator(batch_iterator, self.prefetch_batches)
@@ -129,7 +129,7 @@ class Runtime(threading.Thread):
         self.shutdown_trigger.set()
 
     def iterate_minibatches_from_pools(self, timeout=None):
-        """ Iteratively select non-empty pool with highest priority and loads a batch from that pool """
+        """Iteratively select non-empty pool with highest priority and loads a batch from that pool"""
         with DefaultSelector() as selector:
             for pool in self.pools:
                 selector.register(pool.batch_receiver, EVENT_READ, pool)

--- a/hivemind/moe/server/runtime.py
+++ b/hivemind/moe/server/runtime.py
@@ -78,10 +78,12 @@ class Runtime(threading.Thread):
                 if self.stats_report_interval is not None:
                     self.stats_reporter.start()
                 logger.info("Started")
+                
+                batch_iterator = self.iterate_minibatches_from_pools()
+                if self.prefetch_batches > 0:
+                    batch_iterator = BackgroundGenerator(batch_iterator, self.prefetch_batches):
 
-                for pool, batch_index, batch in BackgroundGenerator(
-                    self.iterate_minibatches_from_pools(), self.prefetch_batches
-                ):
+                for pool, batch_index, batch in batch_iterator:
                     logger.debug(f"Processing batch {batch_index} from pool {pool.name}")
 
                     start = time()
@@ -127,9 +129,7 @@ class Runtime(threading.Thread):
         self.shutdown_trigger.set()
 
     def iterate_minibatches_from_pools(self, timeout=None):
-        """
-        Chooses pool according to priority, then copies exposed batch and frees the buffer
-        """
+        """ Iteratively select non-empty pool with highest priority and loads a batch from that pool """
         with DefaultSelector() as selector:
             for pool in self.pools:
                 selector.register(pool.batch_receiver, EVENT_READ, pool)

--- a/hivemind/moe/server/task_pool.py
+++ b/hivemind/moe/server/task_pool.py
@@ -230,7 +230,7 @@ class TaskPool(TaskPoolBase):
         return not self.batch_receiver.poll()
 
     def load_batch_to_runtime(self, timeout=None, device=None) -> Tuple[Any, List[torch.Tensor]]:
-        """receive next batch of numpy arrays"""
+        """receive next batch of tensors"""
         if not self.batch_receiver.poll(timeout):
             raise TimeoutError()
 

--- a/hivemind/moe/server/task_pool.py
+++ b/hivemind/moe/server/task_pool.py
@@ -38,7 +38,7 @@ class TaskPoolBase(mp.context.ForkProcess, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def load_batch_to_runtime(self, **kwargs) -> Tuple[Any, List[torch.Tensor]]:
+    def load_batch_to_runtime(self) -> Tuple[Any, List[torch.Tensor]]:
         pass
 
     @property

--- a/hivemind/moe/server/task_pool.py
+++ b/hivemind/moe/server/task_pool.py
@@ -38,7 +38,7 @@ class TaskPoolBase(mp.context.ForkProcess, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def iterate_minibatches(self, *args, **kwargs) -> Generator[List[Task], None, None]:
+    def load_batch_to_runtime(self, **kwargs) -> Tuple[Any, List[torch.Tensor]]:
         pass
 
     @property


### PR DESCRIPTION
The TaskPoolBase interface currently  requires iterate_minibatches to be implemented. However, this method is not called by anything except TaskPool (internally). Runtime actually calls load_batch_to_runtime. This PR changes the interface to reflect that.

While we're at it, i've also changed prefetch generator so that it actually does *not* prefetch batches when prefetch_batches = 0
Previously, 0 would silently mean "unlimited",