### PR TITLE
Forbid protobuf 4.x in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ msgpack>=0.5.6
 sortedcontainers
 uvloop>=0.14.0
 grpcio-tools>=1.33.2
-protobuf>=3.12.2
+protobuf>=3.12.2,<4.0.0
 configargparse>=1.2.3
 multiaddr>=0.0.9
 pymultihash>=0.8.2


### PR DESCRIPTION
It was found that newer versions of protobuf (starting from 4.0) are incompatible with hivemind: more specifically, these versions prevent CI from passing. As a temporary solution, this PR constrains the version of protobuf to be smaller than 4.0.0.