### PR TITLE
Update bitsandbytes, relax its version constraint

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.32.3
+          pip install bitsandbytes==0.34.0
       - name: Build hivemind
         run: |
           pip install .

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.32.3
+          pip install bitsandbytes==0.34.0
       - name: Build hivemind
         run: |
           pip install .
@@ -93,7 +93,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.32.3
+          pip install bitsandbytes==0.34.0
       - name: Build hivemind
         run: |
           pip install -e . --no-use-pep517

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ with open("requirements-dev.txt") as dev_requirements_file:
 with open("requirements-docs.txt") as docs_requirements_file:
     extras["docs"] = list(map(str, parse_requirements(docs_requirements_file)))
 
-extras["bitsandbytes"] = ["bitsandbytes==0.32.3"]
+extras["bitsandbytes"] = ["bitsandbytes~=0.34.0"]
 
 extras["all"] = extras["dev"] + extras["docs"] + extras["bitsandbytes"]
 


### PR DESCRIPTION
It was reported that the current version of bitsandbytes used in `hivemind[bitsandbytes]` has an error that prevents it from working properly. The first tested release that we can rely on is 0.34.0, which is what I use in this PR. Also, to provide a bit more compatibility with future patches of this release, I've changed the dependency specification from strict equality to compatibility with future patches of `0.34`.

Notably, if a user wants to use newer versions of bitsandbytes in their applications, they can simply install hivemind (without `[bitsandbytes]`) and bitsandbytes separately: this way, there will be no version conflicts.