### PR TITLE
Check if identity is already taken

### DIFF
--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -8,7 +8,6 @@ from collections.abc import AsyncIterable as AsyncIterableABC
 from contextlib import closing, suppress
 from dataclasses import dataclass
 from datetime import datetime
-from hivemind.p2p.p2p_daemon_bindings.utils import ControlFailure
 from importlib.resources import path
 from typing import Any, AsyncIterator, Awaitable, Callable, List, Optional, Sequence, Tuple, Type, TypeVar, Union
 
@@ -19,6 +18,7 @@ import hivemind.hivemind_cli as cli
 import hivemind.p2p.p2p_daemon_bindings.p2pclient as p2pclient
 from hivemind.p2p.p2p_daemon_bindings.control import DEFAULT_MAX_MSG_SIZE, P2PDaemonError, P2PHandlerError
 from hivemind.p2p.p2p_daemon_bindings.datastructures import PeerID, PeerInfo, StreamInfo
+from hivemind.p2p.p2p_daemon_bindings.utils import ControlFailure
 from hivemind.proto import crypto_pb2
 from hivemind.proto.p2pd_pb2 import RPCError
 from hivemind.utils.asyncio import as_aiter, asingle
@@ -186,7 +186,7 @@ class P2P:
                         use_ipfs=use_ipfs,
                         use_relay=use_relay,
                     ):
-                        raise P2PDaemonError("Identity from `{identity_path}` is already taken by another peer")
+                        raise P2PDaemonError(f"Identity from `{identity_path}` is already taken by another peer")
             else:
                 logger.info(f"Generating new identity to be saved in `{identity_path}`")
                 self.generate_identity(identity_path)
@@ -246,7 +246,7 @@ class P2P:
         use_auto_relay: bool,
         use_ipfs: bool,
         use_relay: bool,
-    ) -> None:
+    ) -> bool:
         with open(identity_path, "rb") as f:
             peer_id = PeerID.from_identity(f.read())
 

--- a/hivemind/p2p/p2p_daemon_bindings/datastructures.py
+++ b/hivemind/p2p/p2p_daemon_bindings/datastructures.py
@@ -91,6 +91,12 @@ class PeerID:
 
     @classmethod
     def from_identity(cls, data: bytes) -> "PeerID":
+        """
+        See [1] for the specification of how this conversion should happen.
+
+        [1] https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#peer-ids
+        """
+
         key_data = crypto_pb2.PrivateKey.FromString(data).data
         private_key = serialization.load_der_private_key(key_data, password=None)
 

--- a/hivemind/p2p/p2p_daemon_bindings/datastructures.py
+++ b/hivemind/p2p/p2p_daemon_bindings/datastructures.py
@@ -9,9 +9,10 @@ from typing import Any, Sequence, Union
 
 import base58
 import multihash
+from cryptography.hazmat.primitives import serialization
 from multiaddr import Multiaddr, protocols
 
-from hivemind.proto import p2pd_pb2
+from hivemind.proto import crypto_pb2, p2pd_pb2
 
 # NOTE: On inlining...
 # See: https://github.com/libp2p/specs/issues/138
@@ -87,6 +88,26 @@ class PeerID:
     def from_base58(cls, base58_id: str) -> "PeerID":
         peer_id_bytes = base58.b58decode(base58_id)
         return cls(peer_id_bytes)
+
+    @classmethod
+    def from_identity(cls, data: bytes) -> "PeerID":
+        key_data = crypto_pb2.PrivateKey.FromString(data).data
+        private_key = serialization.load_der_private_key(key_data, password=None)
+
+        encoded_public_key = private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        encoded_public_key = crypto_pb2.PublicKey(
+            key_type=crypto_pb2.RSA,
+            data=encoded_public_key,
+        ).SerializeToString()
+
+        algo = multihash.Func.sha2_256
+        if ENABLE_INLINING and len(encoded_public_key) <= MAX_INLINE_KEY_LENGTH:
+            algo = IDENTITY_MULTIHASH_CODE
+        encoded_digest = multihash.digest(encoded_public_key, algo).encode()
+        return cls(encoded_digest)
 
 
 def sha256_digest(data: Union[str, bytes]) -> bytes:

--- a/tests/test_p2p_daemon.py
+++ b/tests/test_p2p_daemon.py
@@ -73,6 +73,32 @@ async def test_identity():
         P2P.generate_identity(id1_path)
 
 
+@pytest.mark.asyncio
+async def test_check_if_identity_free():
+    with tempfile.TemporaryDirectory() as tempdir:
+        id1_path = os.path.join(tempdir, "id1")
+        id2_path = os.path.join(tempdir, "id2")
+
+        p2ps = [await P2P.create(identity_path=id1_path)]
+        initial_peers = p2ps[0].get_visible_maddrs()
+
+        p2ps.append(await P2P.create(initial_peers=initial_peers))
+        p2ps.append(await P2P.create(initial_peers=initial_peers, identity_path=id2_path))
+
+        with pytest.raises(P2PDaemonError, match=r"Identity.+is already taken by another peer"):
+            await P2P.create(initial_peers=initial_peers, identity_path=id1_path)
+        with pytest.raises(P2PDaemonError, match=r"Identity.+is already taken by another peer"):
+            await P2P.create(initial_peers=initial_peers, identity_path=id2_path)
+
+        # Must work if a P2P with a certain identity is restarted
+        await p2ps[-1].shutdown()
+        p2ps.pop()
+        p2ps.append(await P2P.create(initial_peers=initial_peers, identity_path=id2_path))
+
+        for instance in p2ps:
+            await instance.shutdown()
+
+
 @pytest.mark.parametrize(
     "host_maddrs",
     [

--- a/tests/test_p2p_daemon.py
+++ b/tests/test_p2p_daemon.py
@@ -80,7 +80,7 @@ async def test_check_if_identity_free():
         id2_path = os.path.join(tempdir, "id2")
 
         p2ps = [await P2P.create(identity_path=id1_path)]
-        initial_peers = p2ps[0].get_visible_maddrs()
+        initial_peers = await p2ps[0].get_visible_maddrs()
 
         p2ps.append(await P2P.create(initial_peers=initial_peers))
         p2ps.append(await P2P.create(initial_peers=initial_peers, identity_path=id2_path))

--- a/tests/test_start_server.py
+++ b/tests/test_start_server.py
@@ -34,8 +34,9 @@ def test_cli_run_server_identity_path():
             encoding="utf-8",
         )
 
-        # Skip line "Generating new identity (libp2p private key) in {path to file}"
-        server_1_proc.stderr.readline()
+        line = server_1_proc.stderr.readline()
+        assert "Generating new identity" in line
+
         line = server_1_proc.stderr.readline()
         addrs_pattern_result = re.search(pattern, line)
         assert addrs_pattern_result is not None, line

--- a/tests/test_start_server.py
+++ b/tests/test_start_server.py
@@ -53,6 +53,9 @@ def test_cli_run_server_identity_path():
         )
 
         line = server_2_proc.stderr.readline()
+        assert re.search(r"Checking that identity.+is not used by other peers", line) is not None
+
+        line = server_2_proc.stderr.readline()
         addrs_pattern_result = re.search(pattern, line)
         assert addrs_pattern_result is not None, line
         addrs_2 = set(addrs_pattern_result.group(1).split(", "))


### PR DESCRIPTION
While using scripts built with hivemind, users often run two peers with the same identity by accident (e.g., if they forget to change the CLI command or copied the same identity file to another host via `scp`). Now, this leads to undefined behavior of libp2p.

This PR makes `hivemind.P2P` check if the identity is already taken, thus solving this issue in all applications at once. See the example below:

<img width="899" alt="Screenshot 2022-10-08 at 05 22 11" src="https://user-images.githubusercontent.com/8748943/194680614-1bf1f049-709c-4c64-aa4b-acf9c58938bf.png">
