### PR TITLE
Simplify running loop in DHT and Averager

### DIFF
--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -306,6 +306,8 @@ class DecentralizedAverager(mp.Process, ServicerBase):
 
             while True:
                 await pipe_semaphore.acquire()
+                if not self._inner_pipe.poll():
+                    continue
                 try:
                     method, args, kwargs = self._inner_pipe.recv()
                 except (OSError, ConnectionError, RuntimeError) as e:

--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -310,7 +310,8 @@ class DecentralizedAverager(mp.Process, ServicerBase):
                     method, args, kwargs = self._inner_pipe.recv()
                 except (OSError, ConnectionError, RuntimeError) as e:
                     logger.exception(e)
-                    break
+                    await asyncio.sleep(self.request_timeout)
+                    continue
                 task = asyncio.create_task(getattr(self, method)(*args, **kwargs))
                 if method == "_shutdown":
                     await task

--- a/hivemind/dht/dht.py
+++ b/hivemind/dht/dht.py
@@ -124,7 +124,8 @@ class DHT(mp.Process):
                     method, args, kwargs = self._inner_pipe.recv()
                 except (OSError, ConnectionError, RuntimeError) as e:
                     logger.exception(e)
-                    break
+                    await asyncio.sleep(self._node.protocol.wait_timeout)
+                    continue
                 task = asyncio.create_task(getattr(self, method)(*args, **kwargs))
                 if method == "_shutdown":
                     await task

--- a/hivemind/dht/dht.py
+++ b/hivemind/dht/dht.py
@@ -119,18 +119,12 @@ class DHT(mp.Process):
             self._ready.set_result(None)
 
             while True:
-                try:
-                    await asyncio.wait_for(pipe_semaphore.acquire(), timeout=self._node.protocol.wait_timeout)
-                except asyncio.TimeoutError:
-                    pass
-                if not self._inner_pipe.poll():
-                    continue
+                await pipe_semaphore.acquire()
                 try:
                     method, args, kwargs = self._inner_pipe.recv()
                 except (OSError, ConnectionError, RuntimeError) as e:
                     logger.exception(e)
-                    await asyncio.sleep(self._node.protocol.wait_timeout)
-                    continue
+                    break
                 task = asyncio.create_task(getattr(self, method)(*args, **kwargs))
                 if method == "_shutdown":
                     await task

--- a/hivemind/dht/dht.py
+++ b/hivemind/dht/dht.py
@@ -120,6 +120,8 @@ class DHT(mp.Process):
 
             while True:
                 await pipe_semaphore.acquire()
+                if not self._inner_pipe.poll():
+                    continue
                 try:
                     method, args, kwargs = self._inner_pipe.recv()
                 except (OSError, ConnectionError, RuntimeError) as e:


### PR DESCRIPTION
I think there's no need to double-check that we didn't miss anything and the pipe is available to read when asyncio wakes us up. `loop.add_reader` guarantees that we will be awaken iff the pipe has new info.