### PR TITLE
Bump torch to >=1.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
-torch>=1.6.0
+torch>=1.9.0
 numpy>=1.17
 scipy>=1.2.1
 prefetch_generator>=1.0.1


### PR DESCRIPTION
This is necessary for #521 to work. The minimal version where `torch.inference_mode()` works is [1.9.0](https://pytorch.org/docs/1.9.0/generated/torch.inference_mode.html).