### PR TITLE
Fix P2PDaemon's idle timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 
-P2PD_VERSION = "v0.3.11"
+P2PD_VERSION = "v0.3.12"
 
 P2PD_SOURCE_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/archive/refs/tags/{P2PD_VERSION}.tar.gz"
 P2PD_BINARY_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/releases/download/{P2PD_VERSION}/"
 
 # The value is sha256 of the binary from the release page
 EXECUTABLES = {
-    "p2pd": "1252a2a2095040cef8e317f5801df8b8c93559711783a2496a0aff2f3e177e39",
+    "p2pd": "2530c3b4afe7953a6c73878d718808edc51c1f0de814e6730d8e53fbbc30789c",
 }
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Before this PR, the P2P daemon was often killed after `idle_timeout` even if the persistent connection is opened due to a concurrency bug in go-libp2p-daemon that was just fixed: https://github.com/learning-at-home/go-libp2p-daemon/pull/21