### PR TITLE
Support torch.bfloat16 in hivemind.compression

### DIFF
--- a/hivemind/compression/base.py
+++ b/hivemind/compression/base.py
@@ -81,16 +81,14 @@ class NoCompression(CompressionBase):
 
     def compress(self, tensor: torch.Tensor, info: CompressionInfo, allow_inplace: bool = False) -> runtime_pb2.Tensor:
         tensor = tensor.detach()
+        dtype_name = str(tensor.dtype).lstrip("torch.")
         if tensor.dtype == torch.bfloat16:
-            array = tensor.to(torch.float32).numpy()
-            dtype_name = "bfloat16"
-        else:
-            array = tensor.numpy()
-            dtype_name = array.dtype.name
+            tensor = tensor.to(torch.float32)
+
         return runtime_pb2.Tensor(
             compression=self.compression_type,
-            buffer=array.tobytes(),
-            size=array.shape,
+            buffer=tensor.numpy().tobytes(),
+            size=tensor.shape,
             dtype=dtype_name,
             requires_grad=tensor.requires_grad,
         )

--- a/hivemind/compression/quantization.py
+++ b/hivemind/compression/quantization.py
@@ -180,5 +180,5 @@ class BlockwiseQuantization(Quantization):
             result = dequantize_blockwise(quantized, (absmax, codebook))  # Always returns a float32 tensor
         except NameError:
             raise ImportError(BNB_MISSING_MESSAGE)
-        result = result.to(getattr(torch, serialized_tensor.dtype))
+        result = result.to(dtype=getattr(torch, serialized_tensor.dtype))
         return result

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -51,7 +51,9 @@ def _check(tensor, compression, rtol=1e-5, atol=1e-8, chunk_size=30 * 1024):
     chunks = list(split_for_streaming(serialized_tensor, chunk_size))
     assert len(chunks) == (len(serialized_tensor.buffer) - 1) // chunk_size + 1
     restored = combine_from_streaming(chunks)
-    assert torch.allclose(deserialize_torch_tensor(restored), tensor, rtol=rtol, atol=atol)
+    result = deserialize_torch_tensor(restored)
+    assert torch.allclose(result, tensor, rtol=rtol, atol=atol)
+    assert result.dtype == tensor.dtype
 
 
 @pytest.mark.forked

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -72,7 +72,7 @@ def test_serialize_tensor():
 def test_serialize_bfloat16():
     tensor = torch.randn(4096, 16, dtype=torch.bfloat16)
     _check(tensor, CompressionType.NONE)
-    _check(tensor, CompressionType.BLOCKWISE_8BIT)
+    _check(tensor, CompressionType.BLOCKWISE_8BIT, rtol=0.1, atol=0.01, chunk_size=1024)
 
 
 @pytest.mark.forked

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -69,6 +69,7 @@ def test_serialize_tensor():
 def test_serialize_bfloat16():
     tensor = torch.randn(512, 12288, dtype=torch.bfloat16)
     _check(tensor, CompressionType.NONE)
+    _check(tensor, CompressionType.BLOCKWISE_8BIT)
 
 
 @pytest.mark.forked

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -69,7 +69,7 @@ def test_serialize_tensor():
 
 
 def test_serialize_bfloat16():
-    tensor = torch.randn(512, 12288, dtype=torch.bfloat16)
+    tensor = torch.randn(4096, 16, dtype=torch.bfloat16)
     _check(tensor, CompressionType.NONE)
     _check(tensor, CompressionType.BLOCKWISE_8BIT)
 

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -68,6 +68,7 @@ def test_serialize_tensor():
     _check(torch.tensor(1.0), CompressionType.FLOAT16)
 
 
+@pytest.mark.forked
 def test_serialize_bfloat16():
     tensor = torch.randn(4096, 16, dtype=torch.bfloat16)
     _check(tensor, CompressionType.NONE)


### PR DESCRIPTION
This PR implements bfloat16 support for `CompressionType.NONE` and `CompressionType.BLOCKWISE_8BIT`.

This is important for the Petals client, see https://github.com/bigscience-workshop/petals/issues/79