### PR TITLE
Remove stale PeerIDs in hivemind-dht's routing table

### DIFF
--- a/hivemind/hivemind_cli/run_dht.py
+++ b/hivemind/hivemind_cli/run_dht.py
@@ -1,5 +1,6 @@
 import time
 from argparse import ArgumentParser
+from secrets import token_hex
 
 from hivemind.dht import DHT, DHTNode
 from hivemind.utils.logging import get_logger, use_hivemind_log_handler
@@ -17,6 +18,9 @@ async def report_status(dht: DHT, node: DHTNode):
     logger.debug(f"Routing table contents: {node.protocol.routing_table}")
     logger.info(f"Local storage contains {len(node.protocol.storage)} keys")
     logger.debug(f"Local storage contents: {node.protocol.storage}")
+
+    # Send a heartbeat to keep routing table healthy (this way, stale PeerIDs will be removed)
+    await dht.get(f"heartbeat_{token_hex(16)}")
 
 
 def main():

--- a/hivemind/hivemind_cli/run_dht.py
+++ b/hivemind/hivemind_cli/run_dht.py
@@ -20,7 +20,7 @@ async def report_status(dht: DHT, node: DHTNode):
     logger.debug(f"Local storage contents: {node.protocol.storage}")
 
     # Contact peers and keep the routing table healthy (remove stale PeerIDs)
-    await dht.get(f"heartbeat_{token_hex(16)}")
+    await node.get(f"heartbeat_{token_hex(16)}")
 
 
 def main():

--- a/hivemind/hivemind_cli/run_dht.py
+++ b/hivemind/hivemind_cli/run_dht.py
@@ -20,7 +20,7 @@ async def report_status(dht: DHT, node: DHTNode):
     logger.debug(f"Local storage contents: {node.protocol.storage}")
 
     # Contact peers and keep the routing table healthy (remove stale PeerIDs)
-    await node.get(f"heartbeat_{token_hex(16)}")
+    await node.get(f"heartbeat_{token_hex(16)}", latest=True)
 
 
 def main():

--- a/hivemind/hivemind_cli/run_dht.py
+++ b/hivemind/hivemind_cli/run_dht.py
@@ -19,7 +19,7 @@ async def report_status(dht: DHT, node: DHTNode):
     logger.info(f"Local storage contains {len(node.protocol.storage)} keys")
     logger.debug(f"Local storage contents: {node.protocol.storage}")
 
-    # Send a heartbeat to keep routing table healthy (this way, stale PeerIDs will be removed)
+    # Contact peers and keep the routing table healthy (remove stale PeerIDs)
     await dht.get(f"heartbeat_{token_hex(16)}")
 
 


### PR DESCRIPTION
Before this PR, hivemind-dht-based initial peers collected lots of stale PeerIDs and other peers could not actually make DHT queries anymore.