### PR TITLE
Update p2pd to v0.3.13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: '1.18.8'
           check-latest: true
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 
-P2PD_VERSION = "v0.3.12"
+P2PD_VERSION = "v0.3.13"
 
 P2PD_SOURCE_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/archive/refs/tags/{P2PD_VERSION}.tar.gz"
 P2PD_BINARY_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/releases/download/{P2PD_VERSION}/"
 
 # The value is sha256 of the binary from the release page
 EXECUTABLES = {
-    "p2pd": "2530c3b4afe7953a6c73878d718808edc51c1f0de814e6730d8e53fbbc30789c",
+    "p2pd": "c3bf9bffdf649ec295f515ed744882d7e197220846a21825e8f11c007f01dbc0",
 }
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This version contains relevant changes that improve work of libp2p relays, see https://github.com/learning-at-home/go-libp2p-daemon/pull/22.

Co-authored-by: @GreenFatGuy 