### PR TITLE
Make DecentralizedAverager resistant to KeyboardInterrupt

### DIFF
--- a/hivemind/averaging/averager.py
+++ b/hivemind/averaging/averager.py
@@ -8,6 +8,7 @@ import ctypes
 import multiprocessing as mp
 import os
 import random
+import signal
 import threading
 import weakref
 from dataclasses import asdict
@@ -329,6 +330,7 @@ class DecentralizedAverager(mp.Process, ServicerBase):
         Starts averager in a background process. if await_ready, this method will wait until background dht
         is ready to process incoming requests or for :timeout: seconds max.
         """
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
         self.start()
         if await_ready:
             self.wait_until_ready(timeout)


### PR DESCRIPTION
Very simple one line change, using the same approach as taken by the DHT. Resolves https://github.com/learning-at-home/hivemind/issues/382.

Tested working: 

![Screenshot from 2022-12-07 19-04-07](https://user-images.githubusercontent.com/13459320/206349425-f91706fe-a749-48eb-b2a6-03f0af88616f.png)
