### PR TITLE
Switch to p2pd v0.3.14, libp2p v0.24.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 
-P2PD_VERSION = "v0.3.13"
+P2PD_VERSION = "v0.3.14"
 
 P2PD_SOURCE_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/archive/refs/tags/{P2PD_VERSION}.tar.gz"
 P2PD_BINARY_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/releases/download/{P2PD_VERSION}/"
 
 # The value is sha256 of the binary from the release page
 EXECUTABLES = {
-    "p2pd": "c3bf9bffdf649ec295f515ed744882d7e197220846a21825e8f11c007f01dbc0",
+    "p2pd": "c9e7cde84ca53925622ad52fef50e41f8fd8cb258bbd69d4ab560beb672bb255",
 }
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This PR increments the version of p2pd, the corresponding go-libp2p version is 0.24.0.

Please note that the previous version (p2pd 0.3.13) had some performance issues under high load. This PR should *hopefully* fix these issues.