### PR TITLE
Support circuit relay v2, add tests

### DIFF
--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -104,6 +104,8 @@ class P2P:
         use_relay_hop: Optional[bool] = None,
         use_relay_discovery: Optional[bool] = None,
         check_if_identity_free: bool = True,
+        no_listen: bool = False,
+        trustedRelays: Optional[Sequence[Union[Multiaddr, str]]] = ("",),
     ) -> "P2P":
         """
         Start a new p2pd process and connect to it.
@@ -171,10 +173,12 @@ class P2P:
             ("bootstrapPeers", initial_peers),
             ("hostAddrs", host_maddrs),
             ("announceAddrs", announce_maddrs),
+            ("trustedRelays", trustedRelays),
         ]:
             if value:
                 process_kwargs[param] = self._maddrs_to_str(value)
-
+        if no_listen:
+            process_kwargs["noListenAddrs"] = 1
         if identity_path is not None:
             if os.path.isfile(identity_path):
                 if check_if_identity_free and need_bootstrap:

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 
-P2PD_VERSION = "v0.3.15.dev1"
+P2PD_VERSION = "v0.3.15.dev3"
 
 P2PD_SOURCE_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/archive/refs/tags/{P2PD_VERSION}.tar.gz"
 P2PD_BINARY_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/releases/download/{P2PD_VERSION}/"
 
 # The value is sha256 of the binary from the release page
 EXECUTABLES = {
-    "p2pd": "451077b1f24105d168978812d32db4811ee84dd08b3760946fc6c4f2ff595b2f",
+    "p2pd": "b39259af2084968bbd7f81e7aa334b53ca49c29f085e2c276177524a87573c57",
 }
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ P2PD_BINARY_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/release
 
 # The value is sha256 of the binary from the release page
 EXECUTABLES = {
-    "p2pd": "51dbdc40657a955afc97aa58a8242e91b07b985f4f9299e2ae4a518e6e4887c4",
+    "p2pd": "cdeb174741558c58e1def0c2c20fa3419d0e9dc8d828ea90622466f8a2ab29ba",
 }
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 
-P2PD_VERSION = "v0.3.15.dev3"
+P2PD_VERSION = "v0.3.15.dev5"
 
 P2PD_SOURCE_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/archive/refs/tags/{P2PD_VERSION}.tar.gz"
 P2PD_BINARY_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/releases/download/{P2PD_VERSION}/"
 
 # The value is sha256 of the binary from the release page
 EXECUTABLES = {
-    "p2pd": "b39259af2084968bbd7f81e7aa334b53ca49c29f085e2c276177524a87573c57",
+    "p2pd": "51dbdc40657a955afc97aa58a8242e91b07b985f4f9299e2ae4a518e6e4887c4",
 }
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 
-P2PD_VERSION = "v0.3.14"
+P2PD_VERSION = "v0.3.15.dev1"
 
 P2PD_SOURCE_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/archive/refs/tags/{P2PD_VERSION}.tar.gz"
 P2PD_BINARY_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/releases/download/{P2PD_VERSION}/"
 
 # The value is sha256 of the binary from the release page
 EXECUTABLES = {
-    "p2pd": "c9e7cde84ca53925622ad52fef50e41f8fd8cb258bbd69d4ab560beb672bb255",
+    "p2pd": "451077b1f24105d168978812d32db4811ee84dd08b3760946fc6c4f2ff595b2f",
 }
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 
-P2PD_VERSION = "v0.3.16.dev1"
+P2PD_VERSION = "v0.3.16"
 
 P2PD_SOURCE_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/archive/refs/tags/{P2PD_VERSION}.tar.gz"
 P2PD_BINARY_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/releases/download/{P2PD_VERSION}/"
 
 # The value is sha256 of the binary from the release page
 EXECUTABLES = {
-    "p2pd": "5902dc2b0d2d17493b87fc9660edb8fd8bc0792c32ec7f69a034d7da784d04f5",
+    "p2pd": "057ec61edbe926cf049e9532d43ea9540da55db7b2d8c816d2bbdddce23f3cdf",
 }
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 
-P2PD_VERSION = "v0.3.15.dev5"
+P2PD_VERSION = "v0.3.15"
 
 P2PD_SOURCE_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/archive/refs/tags/{P2PD_VERSION}.tar.gz"
 P2PD_BINARY_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/releases/download/{P2PD_VERSION}/"

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 
-P2PD_VERSION = "v0.3.15"
+P2PD_VERSION = "v0.3.16.dev1"
 
 P2PD_SOURCE_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/archive/refs/tags/{P2PD_VERSION}.tar.gz"
 P2PD_BINARY_URL = f"https://github.com/learning-at-home/go-libp2p-daemon/releases/download/{P2PD_VERSION}/"
 
 # The value is sha256 of the binary from the release page
 EXECUTABLES = {
-    "p2pd": "cdeb174741558c58e1def0c2c20fa3419d0e9dc8d828ea90622466f8a2ab29ba",
+    "p2pd": "5902dc2b0d2d17493b87fc9660edb8fd8bc0792c32ec7f69a034d7da784d04f5",
 }
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/tests/test_relays.py
+++ b/tests/test_relays.py
@@ -1,0 +1,61 @@
+import time
+from functools import partial
+
+import pytest
+
+import hivemind
+
+
+async def ping_to_client(dht, node, peer_id: str):
+    return await node.protocol.call_ping(hivemind.PeerID.from_base58(str(peer_id)))
+
+
+@pytest.mark.parametrize(
+    "use_auto_relay,use_relay",
+    [
+        (True, True),
+        (False, False),
+    ],
+)
+def test_client_pinging(use_auto_relay: bool, use_relay: bool):
+    dht_first_peer = hivemind.DHT(
+        host_maddrs=["/ip4/0.0.0.0/tcp/31330"],
+        start=True,
+        use_auto_relay=True,
+        use_relay=True,
+        force_reachability="public",
+    )
+    dht_first_peer_id = dht_first_peer.peer_id
+    initial_peers = dht_first_peer.get_visible_maddrs()
+    assert dht_first_peer_id is not None
+
+    dht_second_peer = hivemind.DHT(
+        initial_peers=initial_peers,
+        host_maddrs=["/ip4/0.0.0.0/tcp/0"],
+        start=True,
+        client_mode=False,
+        no_listen=True,
+        use_relay=use_relay,
+        use_auto_relay=use_auto_relay,
+    )
+
+    dht_third_peer = hivemind.DHT(
+        initial_peers=initial_peers,
+        host_maddrs=["/ip4/0.0.0.0/tcp/0"],
+        start=True,
+        client_mode=False,
+        no_listen=True,
+        use_relay=use_relay,
+        use_auto_relay=use_auto_relay,
+    )
+
+    time.sleep(4*60)
+    assert dht_first_peer.is_alive() and dht_second_peer.is_alive() and dht_third_peer.is_alive()
+
+    reached_ip = dht_second_peer.run_coroutine(partial(ping_to_client, peer_id=dht_third_peer.peer_id))
+
+
+    if use_auto_relay and use_relay:
+        assert reached_ip is not None
+    else:
+        assert reached_ip is None


### PR DESCRIPTION
- switched to p2pd version 0.3.16
- added support for Circuit Relay V2 in all hivemind protocols
- added an option no_listen=False for testing purposes (hivemind.p2p.p2p_daemon)
- added a test that checks if a peer can connect to another peer through circuit relay
