### PR TITLE
Fix errors in hivemind.p2p and hivemind.compression

### DIFF
--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -654,8 +654,9 @@ class P2P:
 
         self._alive = False
         if self._child is not None and self._child.returncode is None:
-            self._child.terminate()
-            logger.debug(f"Terminated p2pd with id = {self.peer_id}")
+            with suppress(ProcessLookupError):
+                self._child.terminate()
+                logger.debug(f"Terminated p2pd with id = {self.peer_id}")
 
             with suppress(FileNotFoundError):
                 os.remove(self._daemon_listen_maddr["unix"])

--- a/hivemind/p2p/p2p_daemon_bindings/p2pclient.py
+++ b/hivemind/p2p/p2p_daemon_bindings/p2pclient.py
@@ -47,7 +47,8 @@ class Client:
         return client
 
     def close(self) -> None:
-        self.control.close()
+        if self.control is not None:
+            self.control.close()
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
This PR:

1. Fixes warnings in hivemind.p2p destructors:

    ```python
    Exception ignored in: <function P2P.__del__ at 0x7fbec8be5f70>
    Traceback (most recent call last):
      File "/home/jheuristic/anaconda3/envs/py38_petals_borzunov/lib/python3.8/site-packages/hivemind/p2p/p2p_daemon.py", line 636, in __del__
        self._terminate()
      File "/home/jheuristic/anaconda3/envs/py38_petals_borzunov/lib/python3.8/site-packages/hivemind/p2p/p2p_daemon.py", line 657, in _terminate
        self._child.terminate()
      File "/home/jheuristic/anaconda3/envs/py38_petals_borzunov/lib/python3.8/asyncio/subprocess.py", line 141, in terminate
        self._transport.terminate()
      File "uvloop/handles/process.pyx", line 636, in uvloop.loop.UVProcessTransport.terminate
      File "uvloop/handles/process.pyx", line 378, in uvloop.loop.UVProcessTransport._check_proc
    ProcessLookupError:
    Exception ignored in: <function Client.__del__ at 0x7fbec8bd7a60>
    Traceback (most recent call last):
      File "/home/jheuristic/anaconda3/envs/py38_petals_borzunov/lib/python3.8/site-packages/hivemind/p2p/p2p_daemon_bindings/p2pclient.py", line 53, in __del__
        self.close()
      File "/home/jheuristic/anaconda3/envs/py38_petals_borzunov/lib/python3.8/site-packages/hivemind/p2p/p2p_daemon_bindings/p2pclient.py", line 50, in close
        self.control.close()
    AttributeError: 'NoneType' object has no attribute 'close'
    ```

2. Makes bfloat16 serialization in hivemind.compression forward- and backward-compatible. The code before this PR **(a)** didn't work in torch < 1.13.0 (hivemind requires torch >= 1.9.0) and **(b)** led to this warnings on torch >= 2.0:

    ```python
    /opt/conda/lib/python3.10/site-packages/hivemind/compression/base.py:115: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
      tensor = torch.as_tensor(storage, dtype=torch.bfloat16)
    ```

    The new code works without warnings in all versions of PyTorch.