### PR TITLE
Improve handling of KeyboardInterrupt in CLI applications

### DIFF
--- a/hivemind/hivemind_cli/run_dht.py
+++ b/hivemind/hivemind_cli/run_dht.py
@@ -84,9 +84,14 @@ def main():
     )
     log_visible_maddrs(dht.get_visible_maddrs(), only_p2p=args.use_ipfs)
 
-    while True:
-        dht.run_coroutine(report_status, return_future=False)
-        time.sleep(args.refresh_period)
+    try:
+        while True:
+            dht.run_coroutine(report_status, return_future=False)
+            time.sleep(args.refresh_period)
+    except KeyboardInterrupt:
+        logger.info("Caught KeyboardInterrupt, shutting down")
+    finally:
+        dht.shutdown()
 
 
 if __name__ == "__main__":

--- a/hivemind/hivemind_cli/run_server.py
+++ b/hivemind/hivemind_cli/run_server.py
@@ -108,8 +108,6 @@ def main():
         server.join()
     except KeyboardInterrupt:
         logger.info("Caught KeyboardInterrupt, shutting down")
-    finally:
-        server.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, the `hivemind-dht` script does not handle Ctrl-C gracefully and thus exits with a traceback:

```
Jun 11 19:13:39.219 [INFO] Local storage contains 0 keys
^CTraceback (most recent call last):
  File "/home/mryab/miniconda3/envs/hivemind_env/bin/hivemind-dht", line 8, in <module>
    sys.exit(main())
  File "/home/mryab/hivemind/hivemind/hivemind_cli/run_dht.py", line 89, in main
    time.sleep(args.refresh_period)
KeyboardInterrupt
```

On the other hand, `hivemind-server` handles it twice (both [in run_server.py](https://github.com/learning-at-home/hivemind/blob/master/hivemind/hivemind_cli/run_server.py#L112) and in the `finally` clause of [Server.run](https://github.com/learning-at-home/hivemind/blob/master/hivemind/moe/server/server.py#L256)), which leads a to double call of Server.shutdown and a range of warnings because of shutting down ConnectionHandlers twice:

```
^CJun 11 19:16:42.435 [INFO] Caught KeyboardInterrupt, shutting down
Jun 11 19:16:42.463 [INFO] Shutting down
Jun 11 19:16:42.483 [INFO] Server shutdown successfully
Jun 11 19:16:42.484 [WARN] [hivemind.moe.server.connection_handler.shutdown:98] ConnectionHandler shutdown had no effect, the process is already dead
Jun 11 19:16:42.484 [INFO] Shutting down
Jun 11 19:16:42.484 [INFO] Server shutdown successfully
```

This PR addresses the issue by correctly handling the signal once in each case. 