### PR TITLE
Measure coverage of subprocesses, exclude protobuf compiled files

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -100,6 +100,6 @@ jobs:
       - name: Test
         run: |
           export HIVEMIND_MEMORY_SHARING_STRATEGY=file_descriptor
-          pytest --cov hivemind -v tests
+          pytest --cov hivemind --cov-config=pyproject.toml -v tests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,8 @@ line_length = 119
 combine_as_imports = true
 combine_star = true
 known_local_folder = ["arguments", "test_utils", "tests", "utils"]
+
+[tool.coverage.run]
+concurrency = ["thread", "multiprocessing"]
+omit = ["hivemind/proto/*"]
+source = ["hivemind"]


### PR DESCRIPTION
This PR makes test coverage measurements more precise by taking the code executed with multiprocessing into account