### PR TITLE
Require pydantic<2.0 unless it's supported

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ configargparse>=1.2.3
 multiaddr>=0.0.9
 pymultihash>=0.8.2
 cryptography>=3.4.6
-pydantic>=1.8.1
+pydantic>=1.8.1,<2.0


### PR DESCRIPTION
Pydantic 2.0 has been released yesterday and is not compatible with the current code.

Without this fix, tests fail with:
```python
  File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pydantic/_internal/_generate_schema.py", line 285, in _generate_schema_for_type
    schema = self._generate_schema(obj)
  File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pydantic/_internal/_generate_schema.py", line 537, in _generate_schema
    return self._arbitrary_type_schema(obj, obj)
  File "/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pydantic/_internal/_generate_schema.py", line 579, in _arbitrary_type_schema
    f'Unable to generate pydantic-core schema for {obj!r}. '
pydantic.errors.PydanticSchemaGenerationError: Unable to generate pydantic-core schema for <class 'hivemind.dht.schema.conbytes.<locals>.ConstrainedBytesWithRegex'>. Set `arbitrary_types_allowed=True` in the model_config to ignore this error or implement `__get_pydantic_core_schema__` on your type to fully support it.

If you got this error by calling handler(<some type>) within `__get_pydantic_core_schema__` then you likely need to call `handler.generate_schema(<some type>)` since we do not call `__get_pydantic_core_schema__` on `<some type>` otherwise to avoid infinite recursion.
```