### PR TITLE
Fix using .lstrip() in hivemind.compression

### DIFF
--- a/hivemind/compression/base.py
+++ b/hivemind/compression/base.py
@@ -84,7 +84,7 @@ class NoCompression(CompressionBase):
     def compress(self, tensor: torch.Tensor, info: CompressionInfo, allow_inplace: bool = False) -> runtime_pb2.Tensor:
         tensor = tensor.detach()
         shape = tensor.shape
-        dtype_name = str(tensor.dtype).lstrip("torch.")
+        dtype_name = str(tensor.dtype).replace("torch.", "")
         raw_data = tensor
         if tensor.dtype == torch.bfloat16:
             if USE_LEGACY_BFLOAT16:  # legacy mode: convert to fp32

--- a/hivemind/compression/quantization.py
+++ b/hivemind/compression/quantization.py
@@ -140,7 +140,7 @@ class BlockwiseQuantization(Quantization):
 
     def compress(self, tensor: torch.Tensor, info: CompressionInfo, allow_inplace: bool = False) -> runtime_pb2.Tensor:
         tensor = tensor.detach()
-        dtype_name = str(tensor.dtype).lstrip("torch.")
+        dtype_name = str(tensor.dtype).replace("torch.", "")
         if tensor.dtype == torch.bfloat16:
             tensor = tensor.to(torch.float32)
 


### PR DESCRIPTION
`.lstrip()` doesn't do what I though it does. In fact, it would remove any prefixes with chars `{'t', 'o', 'r', 'c', 'h', '.'}`, which is not what we expect (even though it works here).