### PR TITLE
[minor] allow overriding args/kwargs behavior in Runtime

### DIFF
--- a/hivemind/moe/server/runtime.py
+++ b/hivemind/moe/server/runtime.py
@@ -7,7 +7,7 @@ from queue import SimpleQueue
 from selectors import EVENT_READ, DefaultSelector
 from statistics import mean
 from time import perf_counter
-from typing import Dict, NamedTuple, Optional
+from typing import Any, Dict, NamedTuple, Optional, Tuple
 
 import torch
 from prefetch_generator import BackgroundGenerator
@@ -105,7 +105,7 @@ class Runtime(threading.Thread):
                     self.shutdown()
 
     def process_batch(self, pool: TaskPoolBase, batch_index: int, *batch: torch.Tensor) -> Tuple[Any, int]:
-        """process one batch of tasks from a given pool, return a batch of results and task size (complexity)"""
+        """process one batch of tasks from a given pool, return a batch of results and total batch size"""
         outputs = pool.process_func(*batch)
         return outputs, outputs[0].size(0)
 

--- a/hivemind/moe/server/runtime.py
+++ b/hivemind/moe/server/runtime.py
@@ -90,10 +90,11 @@ class Runtime(threading.Thread):
                     try:
                         outputs, batch_size = self.process_batch(pool, batch_index, *batch)
                         batch_processing_time = perf_counter() - start
-                        output_sender_pool.apply_async(pool.send_outputs_from_runtime, args=[batch_index, outputs])
                         logger.debug(f"Pool {pool.name}: batch {batch_index} processed, size {batch_size}")
                         if self.stats_report_interval is not None:
                             self.stats_reporter.report_stats(pool.name, batch_size, batch_processing_time)
+
+                        output_sender_pool.apply_async(pool.send_outputs_from_runtime, args=[batch_index, outputs])
                     except KeyboardInterrupt:
                         raise
                     except BaseException as exception:


### PR DESCRIPTION
This PR extracts a part of runtime that is responsible for calling pool's process func.
This is to allow developer to extend this behavior in ~~petals~~ downstream applications without having to rewrite the whole runtime.run method.