### PR TITLE
Force DHT to be mp.context.ForkProcess

### DIFF
--- a/hivemind/dht/dht.py
+++ b/hivemind/dht/dht.py
@@ -20,7 +20,7 @@ logger = get_logger(__name__)
 ReturnType = TypeVar("ReturnType")
 
 
-class DHT(mp.Process):
+class DHT(mp.context.ForkProcess):
     """
     A high-level interface to a hivemind DHT that runs a single DHT node in a background process.
     * hivemind servers periodically announce their experts via declare_experts (dht_handler.py)


### PR DESCRIPTION
This doesn't change anything on Linux but helps macOS users. Specifically, it's helps to:

- Avoid [this error](https://github.com/bigscience-workshop/petals/issues/405#issuecomment-1699185359) for people who don't use `if __name__ == "__main__"` in simple scripts on macOS (that uses spawn for processes by default).
- Make DHT consistent with other code that inherits from `mp.context.ForkProcess` directly.