### PR TITLE
Consider multiple CPU arch aliases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ multiaddr>=0.0.9
 pymultihash>=0.8.2
 cryptography>=3.4.6
 pydantic>=1.8.1,<2.0
+packaging>=20.9

--- a/setup.py
+++ b/setup.py
@@ -86,8 +86,12 @@ def build_p2p_daemon():
 def download_p2p_daemon():
     binary_path = os.path.join(here, "hivemind", "hivemind_cli", "p2pd")
     arch = platform.machine()
-    if arch == "x86_64":
+    # An architecture name may vary depending on the OS (e.g., the same CPU is arm64 on macOS and aarch64 on Linux).
+    # We consider multiple aliases here, see https://stackoverflow.com/questions/45125516/possible-values-for-uname-m
+    if arch in ("x86_64", "x64"):
         arch = "amd64"
+    if arch in ("aarch64", "aarch64_be", "armv8b", "armv8l"):
+        arch = "arm64"
     binary_name = f"p2pd-{platform.system().lower()}-{arch}"
 
     if binary_name not in P2P_BINARY_HASH:


### PR DESCRIPTION
The crucial things here is to map `aarch64` to `arm64` (the same CPU is arm64 on macOS and aarch64 on Linux). However, I've added a few other aliases to be sure :)