### PR TITLE
Fix edge cases in (de)serialize_torch_tensor

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.37.0
+          pip install bitsandbytes==0.41.1
       - name: Build hivemind
         run: |
           pip install .

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.37.0
+          pip install bitsandbytes==0.41.1
       - name: Build hivemind
         run: |
           pip install .
@@ -93,7 +93,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes
         run: |
-          pip install bitsandbytes==0.37.0
+          pip install bitsandbytes==0.41.1
       - name: Build hivemind
         run: |
           pip install -e . --no-use-pep517

--- a/hivemind/compression/base.py
+++ b/hivemind/compression/base.py
@@ -82,6 +82,7 @@ class NoCompression(CompressionBase):
     compression_type = runtime_pb2.CompressionType.NONE
 
     def compress(self, tensor: torch.Tensor, info: CompressionInfo, allow_inplace: bool = False) -> runtime_pb2.Tensor:
+        requires_grad = tensor.requires_grad
         tensor = tensor.detach()
         shape = tensor.shape
         dtype_name = str(tensor.dtype).replace("torch.", "")
@@ -98,7 +99,7 @@ class NoCompression(CompressionBase):
             buffer=raw_data.numpy().tobytes(),
             size=shape,
             dtype=dtype_name,
-            requires_grad=tensor.requires_grad,
+            requires_grad=requires_grad,
         )
 
     def extract(self, serialized_tensor: runtime_pb2.Tensor) -> torch.Tensor:

--- a/hivemind/compression/floating.py
+++ b/hivemind/compression/floating.py
@@ -12,7 +12,8 @@ class Float16Compression(CompressionBase):
     FP16_MIN, FP16_MAX = torch.finfo(torch.float16).min, torch.finfo(torch.float16).max
 
     def compress(self, tensor: torch.Tensor, info: CompressionInfo, allow_inplace: bool = False) -> runtime_pb2.Tensor:
-        assert torch.is_floating_point(tensor) and tensor.dtype != torch.bfloat16
+        if not torch.is_floating_point(tensor) or tensor.dtype == torch.bfloat16:
+            raise ValueError(f"{self.__class__.__name__} does not support {tensor.dtype} tensors")
         requires_grad = tensor.requires_grad
         tensor = tensor.detach().cpu()
         dtype_name = tensor.numpy().dtype.name
@@ -47,7 +48,8 @@ class ScaledFloat16Compression(Float16Compression):
     FP32_EPS = torch.finfo(torch.float32).eps
 
     def compress(self, tensor: torch.Tensor, info: CompressionInfo, allow_inplace: bool = False) -> runtime_pb2.Tensor:
-        assert torch.is_floating_point(tensor) and tensor.dtype != torch.bfloat16
+        if not torch.is_floating_point(tensor) or tensor.dtype == torch.bfloat16:
+            raise ValueError(f"{self.__class__.__name__} does not support {tensor.dtype} tensors")
         requires_grad = tensor.requires_grad
         tensor = tensor.detach().cpu()
         dtype_name = tensor.numpy().dtype.name

--- a/hivemind/compression/quantization.py
+++ b/hivemind/compression/quantization.py
@@ -25,12 +25,13 @@ class Quantization(CompressionBase, ABC):
         ...
 
     def compress(self, tensor: torch.Tensor, info: CompressionInfo, allow_inplace: bool = False) -> runtime_pb2.Tensor:
+        assert torch.is_floating_point(tensor)
         quantized, codebook = self.quantize(tensor.detach(), allow_inplace=allow_inplace)
         return runtime_pb2.Tensor(
             compression=self.compression_type,
             buffer=b"".join((np.int64(len(codebook)).tobytes(), codebook.tobytes(), quantized.tobytes())),
             size=tensor.shape,
-            dtype=tensor.numpy().dtype.name,
+            dtype=tensor.data.numpy().dtype.name if tensor.dtype != torch.bfloat16 else "bfloat16",
             requires_grad=tensor.requires_grad,
         )
 
@@ -39,7 +40,7 @@ class Quantization(CompressionBase, ABC):
         codebook = np.frombuffer(serialized_tensor.buffer, offset=8, count=codebook_size, dtype=self.codebook_dtype)
         quantized = np.frombuffer(serialized_tensor.buffer, offset=8 + codebook.nbytes, dtype=self.indices_dtype)
         quantized = torch.as_tensor(quantized, dtype=torch.int64).reshape(tuple(serialized_tensor.size))
-        codebook = torch.as_tensor(np.asarray(codebook, dtype=serialized_tensor.dtype))
+        codebook = torch.as_tensor(codebook).to(dtype=getattr(torch, serialized_tensor.dtype))
         return codebook[quantized].requires_grad_(serialized_tensor.requires_grad)
 
     def estimate_compression_ratio(self, info: CompressionInfo) -> float:
@@ -59,8 +60,10 @@ class Uniform8BitQuantization(Quantization):
     compression_type = runtime_pb2.UNIFORM_8BIT
 
     def quantize(self, tensor: torch.Tensor, allow_inplace: bool = False) -> Tuple[np.ndarray, np.ndarray]:
+        assert torch.is_floating_point(tensor)
         offset = self.n_bins // 2
         shift = tensor.mean()
+        tensor = tensor.to(dtype=torch.float32, copy=not allow_inplace)
         centered_tensor = tensor.sub_(shift) if allow_inplace else tensor - shift
         std_unbiased = centered_tensor.norm() / math.sqrt(centered_tensor.numel() - 1)
         scale = self.RANGE_IN_SIGMAS * std_unbiased / self.n_bins
@@ -135,15 +138,15 @@ class BlockwiseQuantization(Quantization):
         except ImportError:
             raise ImportError(BNB_MISSING_MESSAGE)
 
-        quantized, (absmax, codebook) = quantize_blockwise(tensor)
+        quantized, (absmax, codebook, *extra_params) = quantize_blockwise(tensor, blocksize=4096, nested=False)
+        assert tuple(extra_params) == (4096, False, tensor.dtype, None, None)  # blocksize, nested, dtype, offset, s2
         return quantized.numpy(), (absmax.numpy(), codebook.numpy())
 
     def compress(self, tensor: torch.Tensor, info: CompressionInfo, allow_inplace: bool = False) -> runtime_pb2.Tensor:
         requires_grad = tensor.requires_grad
         tensor = tensor.detach()
         dtype_name = str(tensor.dtype).replace("torch.", "")
-        if tensor.dtype == torch.bfloat16:
-            tensor = tensor.to(torch.float32)
+        tensor = tensor.to(torch.float32)
 
         quantized, (absmax, codebook) = self.quantize(tensor, allow_inplace=allow_inplace)
 
@@ -182,6 +185,5 @@ class BlockwiseQuantization(Quantization):
         absmax = torch.as_tensor(absmax)
         codebook = torch.as_tensor(codebook)
         quantized = torch.as_tensor(quantized).reshape(tuple(serialized_tensor.size))
-        result = dequantize_blockwise(quantized, (absmax, codebook))  # Always returns a float32 tensor
-        result = result.to(dtype=getattr(torch, serialized_tensor.dtype)).requires_grad_(serialized_tensor.requires_grad)
-        return result
+        result = dequantize_blockwise(quantized, (absmax, codebook, 4096, False, torch.float32, None, None))
+        return result.to(getattr(torch, serialized_tensor.dtype)).requires_grad_(serialized_tensor.requires_grad)

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ with open("requirements-dev.txt") as dev_requirements_file:
 with open("requirements-docs.txt") as docs_requirements_file:
     extras["docs"] = list(map(str, parse_requirements(docs_requirements_file)))
 
-extras["bitsandbytes"] = ["bitsandbytes~=0.37.0"]
+extras["bitsandbytes"] = ["bitsandbytes~=0.41.1"]
 
 extras["all"] = extras["dev"] + extras["docs"] + extras["bitsandbytes"]
 

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -54,18 +54,24 @@ def _check(tensor, compression, rtol=1e-5, atol=1e-8, chunk_size=30 * 1024):
     result = deserialize_torch_tensor(restored)
     assert torch.allclose(result, tensor, rtol=rtol, atol=atol)
     assert result.dtype == tensor.dtype
+    assert result.requires_grad == tensor.requires_grad
 
 
+@pytest.mark.parametrize("requires_grad", [False, True])
 @pytest.mark.forked
-def test_serialize_tensor():
-    tensor = torch.randn(512, 12288)
+def test_serialize_tensor(requires_grad: bool):
+    tensor = torch.randn(512, 12288, requires_grad=requires_grad)
+    for compression_type in CompressionType.values():
+        _check(tensor, compression_type, atol=0.1)
+
     for chunk_size in [1024, 64 * 1024, 64 * 1024 + 1, 10**9]:
         _check(tensor, CompressionType.NONE, chunk_size=chunk_size)
 
     _check(tensor, CompressionType.FLOAT16, rtol=0.0, atol=1e-2)
     _check(torch.randint(0, 100, (512, 1, 1)), CompressionType.NONE)
-    _check(torch.tensor(1.0), CompressionType.NONE)
-    _check(torch.tensor(1.0), CompressionType.FLOAT16)
+    _check(torch.tensor(1.0, requires_grad=requires_grad), CompressionType.NONE)
+    _check(torch.tensor(1.0, requires_grad=requires_grad), CompressionType.FLOAT16)
+    _check(torch.tensor(1.0,requires_grad=requires_grad), CompressionType.MEANSTD_FLOAT16)
 
 
 @pytest.mark.parametrize("use_legacy_bfloat16", [True, False])


### PR DESCRIPTION
During an earlier patch, we lost the requires_grad property during serialize_torch_tensor. This PR adds it back.