### PR TITLE
Fix OptimizerWrapper creation, test gradient clipping

### DIFF
--- a/hivemind/moe/server/layers/optim.py
+++ b/hivemind/moe/server/layers/optim.py
@@ -1,11 +1,10 @@
 import torch
 
 
-class OptimizerWrapper(torch.optim.Optimizer):
+class OptimizerWrapper:
     """A wrapper for pytorch.optim.Optimizer that forwards all methods to the wrapped optimizer"""
 
     def __init__(self, optim: torch.optim.Optimizer):
-        super().__init__(optim.param_groups, optim.defaults)
         self.optim = optim
 
     @property

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -20,7 +20,12 @@ def test_training(max_steps: int = 100, threshold: float = 0.9):
     SGD = partial(torch.optim.SGD, lr=0.05)
 
     with background_server(
-        num_experts=2, device="cpu", optim_cls=SGD, hidden_dim=64, num_handlers=1
+        num_experts=2,
+        device="cpu",
+        optim_cls=SGD,
+        hidden_dim=64,
+        num_handlers=1,
+        clip_grad_norm=1.0,
     ) as server_peer_info:
         dht = DHT(initial_peers=server_peer_info.addrs, start=True)
         expert1, expert2 = create_remote_experts(


### PR DESCRIPTION
Currently, OptimizerWrapper fails when creating an optimizer: it attempts to assign the property `defaults` which has no setter defined. The easiest way to address this is to remove inheritance from OptimizerWrapper while keeping the same API for functions required by hivemind.server: as this is an internal component, downstream users are unlikely to be negatively affected.

Fixes https://github.com/learning-at-home/hivemind/issues/592