### PR TITLE
Install setuptools+wheel in develop mode during CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -60,7 +60,7 @@ jobs:
           key: Key-v1-3.8-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
       - name: Build hivemind
@@ -88,7 +88,7 @@ jobs:
           key: Key-v1-3.8-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes


### PR DESCRIPTION
In recent builds, pip started issuing an error when trying to pass `--no-use-pep517` without setuptools and wheel installed (see [this build](https://github.com/learning-at-home/hivemind/actions/runs/6448925844/job/17506719837?pr=593#step:7:16) as an example). This PR addresses the issue by installing setuptools and wheel before calling `pip install`.