### PR TITLE
Fix deprecations and update dependencies for examples/albert

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -60,7 +60,7 @@ jobs:
           key: Key-v1-3.8-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
       - name: Build hivemind
@@ -88,7 +88,7 @@ jobs:
           key: Key-v1-3.8-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
       - name: Build bitsandbytes

--- a/examples/albert/arguments.py
+++ b/examples/albert/arguments.py
@@ -113,7 +113,7 @@ class DatasetArguments:
     )
     tokenizer_path: Optional[str] = field(default="data/tokenizer", metadata={"help": "Path to the tokenizer"})
     config_path: Optional[str] = field(
-        default="https://s3.amazonaws.com/models.huggingface.co/bert/albert-large-v2-config.json",
+        default="albert-large-v2",
         metadata={"help": "Path to the model config"},
     )
     cache_dir: Optional[str] = field(default="data", metadata={"help": "Path to the cache"})

--- a/examples/albert/requirements.txt
+++ b/examples/albert/requirements.txt
@@ -1,5 +1,5 @@
-transformers==4.6.0
-datasets==1.5.0
+transformers~=4.6
+datasets~=1.5
 torch_optimizer==0.1.0
 wandb==0.10.26
 sentencepiece

--- a/examples/albert/run_training_monitor.py
+++ b/examples/albert/run_training_monitor.py
@@ -46,7 +46,7 @@ class TrainingMonitorArguments(BaseTrainingArguments):
         default=5, metadata={"help": "Frequency (in steps) of fetching and saving state from peers"}
     )
     model_config_path: str = field(
-        default="https://s3.amazonaws.com/models.huggingface.co/bert/albert-large-v2-config.json",
+        default="albert-large-v2",
         metadata={"help": "Path to the model config"},
     )
     repo_path: Optional[str] = field(


### PR DESCRIPTION
The current Docker build fails due to old versions of transformers/datasets depending on an old version of tokenizers, which does not compile in the current environment of the Docker image. The easiest way to address the issue appears to be the bump of dependencies.

I have tested running the example on 2 peers with albert-base-v2, and the code runs and even starts to converge:
<img width="1397" alt="image" src="https://github.com/learning-at-home/hivemind/assets/16766985/302bf973-7ea6-42b7-968d-c0968bfcc36b">

Also, in recent builds, pip started issuing an error when trying to pass --no-use-pep517 without setuptools and wheel installed (see [this build](https://github.com/learning-at-home/hivemind/actions/runs/6448925844/job/17506719837?pr=593#step:7:16) as an example). This PR addresses the issue by installing setuptools and wheel before calling pip install.
 