### PR TITLE
Update Dockerfile, fix compatibility with PyTorch>=2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04
+FROM nvcr.io/nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
 LABEL maintainer="Learning@home"
 LABEL repository="hivemind"
 
@@ -21,7 +21,7 @@ RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -
   bash install_miniconda.sh -b -p /opt/conda && rm install_miniconda.sh
 ENV PATH="/opt/conda/bin:${PATH}"
 
-RUN conda install python~=3.8 pip && \
+RUN conda install python~=3.11.0 pip && \
     pip install --no-cache-dir torch torchvision torchaudio && \
     conda clean --all
 

--- a/hivemind/optim/grad_scaler.py
+++ b/hivemind/optim/grad_scaler.py
@@ -4,8 +4,17 @@ from copy import deepcopy
 from typing import Dict, Optional
 
 import torch
-from torch.cuda.amp import GradScaler as TorchGradScaler
-from torch.cuda.amp.grad_scaler import OptState, _refresh_per_optimizer_state
+from packaging import version
+
+torch_version = torch.__version__.split("+")[0]
+
+if version.parse(torch_version) >= version.parse("2.3.0"):
+    from torch.amp import GradScaler as TorchGradScaler
+    from torch.amp.grad_scaler import OptState, _refresh_per_optimizer_state
+else:
+    from torch.cuda.amp import GradScaler as TorchGradScaler
+    from torch.cuda.amp.grad_scaler import OptState, _refresh_per_optimizer_state
+
 from torch.optim import Optimizer as TorchOptimizer
 
 import hivemind


### PR DESCRIPTION
The current Dockerfile is based on an outdated version of CUDA, and the Python dependency specification allows Python 3.12 to be installed (which is not supported by Hivemind at the moment). Lastly, this PR fixes an error in `hivemind.optim.grad_scaler` that emerged to a change in the API of PyTorch by using either `torch.amp` or `torch.cuda.amp` depending on the version of PyTorch.

This PR fixes all three issues: to make all of CI workflows pass, both the Python version fix and the `torch.amp` fix are necessary.