### PR TITLE
Improve the process cleanup logic when running tests

### DIFF
--- a/tests/test_allreduce_fault_tolerance.py
+++ b/tests/test_allreduce_fault_tolerance.py
@@ -209,3 +209,4 @@ def test_fault_tolerance(fault0: Fault, fault1: Fault):
 
     for averager in averagers:
         averager.shutdown()
+    dht.shutdown()

--- a/tests/test_dht_experts.py
+++ b/tests/test_dht_experts.py
@@ -82,6 +82,10 @@ def test_beam_search(
         assert all(isinstance(e, hivemind.RemoteExpert) for experts in batch_experts for e in experts)
         assert all(len(experts) == beam_size for experts in batch_experts)
 
+    you.shutdown()
+    for dht_instance in dht_instances:
+        dht_instance.shutdown()
+
 
 @pytest.mark.forked
 def test_dht_single_node():
@@ -118,6 +122,8 @@ def test_dht_single_node():
 
     with pytest.raises(AssertionError):
         beam_search.get_active_successors(["e.1.2.", "e.2", "e.4.5."])
+
+    node.shutdown()
 
 
 def test_uid_patterns():


### PR DESCRIPTION
The current `cleanup_children` function attempts to terminate all child processes, even those that have already stopped. This PR makes the cleanup more robust and avoids terminating dead processes by using `psutil.wait_procs`, which can distinguish dead and alive processes