### PR TITLE
Limit Protobuf version by 5.28.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ msgpack>=0.5.6
 sortedcontainers
 uvloop>=0.14.0
 grpcio-tools>=1.33.2
-protobuf>=3.12.2
+protobuf>=3.12.2,<5.28.0
 configargparse>=1.2.3
 py-multihash>=0.2.3
 multiaddr @ git+https://github.com/multiformats/py-multiaddr.git@e01dbd38f2c0464c0f78b556691d655265018cce


### PR DESCRIPTION
We are getting [errors in CI](https://github.com/learning-at-home/hivemind/actions/runs/11415810087/job/31766281394?pr=620) due to the following:
```
UserWarning: Protobuf gencode version 5.27.2 is older than the runtime version 5.28.2 at p2pd.proto. Please avoid checked-in Protobuf gencode that can be obsolete.
```
The warning was introduced in [Protobuf 5.28.0](https://github.com/protocolbuffers/protobuf/issues/18096) and will be fixed soon. For the time being, we can limit the version of Protobuf to avoid this warning