### PR TITLE
Clarify the download location of p2pd in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ def download_p2p_daemon():
 
     if sha256(binary_path) != expected_hash:
         binary_url = os.path.join(P2PD_BINARY_URL, binary_name)
-        print(f"Downloading {binary_url}")
+        print(f"Downloading {binary_url} to {binary_path}")
 
         urllib.request.urlretrieve(binary_url, binary_path)
         os.chmod(binary_path, 0o777)

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ def download_p2p_daemon():
     if sha256(binary_path) != expected_hash:
         binary_url = os.path.join(P2PD_BINARY_URL, binary_name)
         print(f"Downloading {binary_url} to {binary_path}")
+        
 
         urllib.request.urlretrieve(binary_url, binary_path)
         os.chmod(binary_path, 0o777)

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,6 @@ def download_p2p_daemon():
     if sha256(binary_path) != expected_hash:
         binary_url = os.path.join(P2PD_BINARY_URL, binary_name)
         print(f"Downloading {binary_url} to {binary_path}")
-        
 
         urllib.request.urlretrieve(binary_url, binary_path)
         os.chmod(binary_path, 0o777)


### PR DESCRIPTION
Hi,

On some systems, `urllib` fails to make https connections unless certificates are installed in a certain place, or python is compiled a certain way, or the `certifi` package is installed, or a different package than `urllib` is used to make the request, or most commonly certificate verification is disabled. This can deter installation of hivemind, because it requires downloading of an auxiliary file downloaded with urllib during install.

I didn't immediately find information on troubleshooting the issue, although I have encountered it before. It ended up being easier for me to manually download the file, but I had to inspect the setup.py source to see where to place it.

This patch modifies the log message so that the user can easily see what path the file is being downloaded to.