### PR TITLE
address race condition in DHT initialization

### DIFF
--- a/hivemind/dht/dht.py
+++ b/hivemind/dht/dht.py
@@ -144,6 +144,7 @@ class DHT(mp.context.ForkProcess):
         is ready to process incoming requests or for :timeout: seconds max.
         """
         self.start()
+        self.get_visible_maddrs(True)
         if await_ready:
             self.wait_until_ready(timeout)
 


### PR DESCRIPTION
This PR is an attempt to address some kind of race condition that can occur [during expert bootstrapping](https://github.com/learning-at-home/hivemind/issues/634). I spent several hours trying to identify the source of the problem, only to fall-back to an easy solution - which doesn't actually address the underlying problem.

For some reason, calling `dht.get_visible_maddrs(True)` on the DHT node fixes the issue. So, that's what we do now - every time the DHT node is started.

Since using [get_visible_maddrs](https://github.com/learning-at-home/hivemind/blob/65d7be5c862e78d799ec0bf3736b087e5f9c8ae8/hivemind/p2p/p2p_daemon.py#L319) apparently fixes the problem, we can assume that **something** this method does is important to expert initialization. Yet, the **only** thing this method does is use `Multiaddr`; and so, I can only assume that there must be some kind of failure in `Multiaddr`, somewhere else in the code.

This is far outside my area of expertise, and I spent a lot of time troubleshooting already - so this is the best solution I could figure out, for now.