### PR TITLE
Enable GitHub Actions for tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   run_tests:
-
+    if: github.repository != 'learning-at-home/hivemind'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -45,6 +45,7 @@ jobs:
           export HIVEMIND_MEMORY_SHARING_STRATEGY=file_descriptor
           pytest --durations=0 --durations-min=1.0 -v
   build_and_test_p2pd:
+    if: github.repository != 'learning-at-home/hivemind'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -76,7 +77,7 @@ jobs:
           export HIVEMIND_MEMORY_SHARING_STRATEGY=file_descriptor
           pytest -k "p2p" -v
   codecov_in_develop_mode:
-
+    if: github.repository != 'learning-at-home/hivemind'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,8 @@
 name: Tests
 
-# Tests in GHA only run manually, see run-tests-on-modal.yml for the same tests in CI
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -13,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
       fail-fast: false
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Modal tests do not run in forked repositories, because they require access to secrets. As a different measure, we'll enable tests both via Modal and GHA to ensure that pull requests from external contributors can still be tested