### PR TITLE
Fix version-file for the Ruff action

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
         with:
+          args: "--output-format github"
           version-file: "requirements-dev.txt"
       - uses: astral-sh/ruff-action@v3
         with:

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
         with:
-          args: "--output-format github"
           version-file: "requirements-dev.txt"
       - uses: astral-sh/ruff-action@v3
         with:

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -25,5 +25,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
         with:
+          version-file: "requirements-dev.txt"
+      - uses: astral-sh/ruff-action@v3
+        with:
           args: "format --check --diff"
-          version-file: "pyproject.toml"
+          version-file: "requirements-dev.txt"

--- a/tests/test_utils/custom_networks.py
+++ b/tests/test_utils/custom_networks.py
@@ -4,7 +4,6 @@ import torch.nn.functional as F
 
 from hivemind.moe import register_expert_class
 
-
 sample_input = lambda batch_size, hidden_dim: torch.empty((batch_size, hidden_dim))
 
 


### PR DESCRIPTION
ruff-action parses the version of Ruff from the specified dependency version: https://github.com/astral-sh/ruff-action/blob/main/src/utils/pyproject.ts#L26

As we specify our dependencies in pyproject.toml, the parsing [fails](https://github.com/learning-at-home/hivemind/actions/runs/14535717881/job/40783572003). This PR fixes the issue by pointing the action at pyproject.toml instead