### PR TITLE
Make test_averaging_cancel more robust

### DIFF
--- a/tests/test_averaging.py
+++ b/tests/test_averaging.py
@@ -530,7 +530,6 @@ def test_averaging_cancel(target_group_size):
             dht=dht,
             min_matchmaking_time=0.5,
             request_timeout=0.3,
-            min_group_size=2,
             client_mode=(i % 2 == 0),
             target_group_size=target_group_size,
             prefix="mygroup",


### PR DESCRIPTION
Currently, `test_averaging_cancel` is one of the few flaky tests in our codebase: see e.g. https://github.com/learning-at-home/hivemind/actions/runs/14024261668/job/40777059821, where it failed 3 times out of 5. 

Based on my investigation and discussion with @justheuristic, it looks like the problem is that it's very loosely defined: we start 4 averaging peers, cancel 2, and expect that the group size is 2 nonetheless. However, due to `target_group_size=None` by default, it's possible for the groups to have sizes of 3 and 1, which means that the `len(control.result()) == 2` will occasionally fail.

To fix this issue, the PR introduces a separate test case with a fixed `target_group_size`. To make sure that peers don't average before cancellation, it also uses the averaging triggers to arrange the groups without starting the averaging itself