### PR TITLE
Rewrite MPFuture to use native SharedMemory

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Test
         run: |
           cd tests
-          export HIVEMIND_MEMORY_SHARING_STRATEGY=file_descriptor
           pytest --durations=0 --durations-min=1.0 -v
   build_and_test_p2pd:
     runs-on: ubuntu-latest
@@ -72,7 +71,6 @@ jobs:
       - name: Test
         run: |
           cd tests
-          export HIVEMIND_MEMORY_SHARING_STRATEGY=file_descriptor
           pytest -k "p2p" -v
   codecov_in_develop_mode:
     runs-on: ubuntu-latest
@@ -101,7 +99,6 @@ jobs:
           pip install -e . --no-use-pep517
       - name: Test
         run: |
-          export HIVEMIND_MEMORY_SHARING_STRATEGY=file_descriptor
           pytest --cov hivemind --cov-config=pyproject.toml -v tests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -698,7 +698,7 @@ class P2P:
                 except (asyncio.CancelledError, RuntimeError):
                     # Task was cancelled or event loop closed
                     break
-                
+
             if not ready.done():
                 ready.set_exception(P2PDaemonError(f"Daemon failed to start: {last_line}"))
         except (asyncio.CancelledError, RuntimeError):

--- a/hivemind/p2p/p2p_daemon.py
+++ b/hivemind/p2p/p2p_daemon.py
@@ -684,18 +684,26 @@ class P2P:
 
     async def _read_outputs(self, ready: asyncio.Future) -> None:
         last_line = None
-        while True:
-            line = await self._child.stdout.readline()
-            if not line:  # Stream closed
-                break
-            last_line = line.rstrip().decode(errors="ignore")
+        try:
+            while True:
+                try:
+                    line = await self._child.stdout.readline()
+                    if not line:  # Stream closed
+                        break
+                    last_line = line.rstrip().decode(errors="ignore")
 
-            self._log_p2pd_message(last_line)
-            if last_line.startswith("Peer ID:"):
-                ready.set_result(None)
-
-        if not ready.done():
-            ready.set_exception(P2PDaemonError(f"Daemon failed to start: {last_line}"))
+                    self._log_p2pd_message(last_line)
+                    if last_line.startswith("Peer ID:"):
+                        ready.set_result(None)
+                except (asyncio.CancelledError, RuntimeError):
+                    # Task was cancelled or event loop closed
+                    break
+                
+            if not ready.done():
+                ready.set_exception(P2PDaemonError(f"Daemon failed to start: {last_line}"))
+        except (asyncio.CancelledError, RuntimeError):
+            # Task was cancelled or event loop closed during cleanup
+            pass
 
     @staticmethod
     def _log_p2pd_message(line: str) -> None:

--- a/hivemind/p2p/p2p_daemon_bindings/control.py
+++ b/hivemind/p2p/p2p_daemon_bindings/control.py
@@ -212,12 +212,11 @@ class ControlClient:
     async def _write_to_persistent_conn(self, writer: asyncio.StreamWriter):
         try:
             while True:
-                try:
-                    msg = await self._pending_messages.get()
-                    await write_pbmsg(writer, msg)
-                except (asyncio.CancelledError, RuntimeError):
-                    # Task was cancelled or event loop closed
-                    break
+                msg = await self._pending_messages.get()
+                await write_pbmsg(writer, msg)
+        except (asyncio.CancelledError, RuntimeError):
+            # Task was cancelled or event loop closed
+            pass
         finally:
             # Close writer safely, avoiding "Event loop is closed" errors
             try:

--- a/hivemind/p2p/p2p_daemon_bindings/control.py
+++ b/hivemind/p2p/p2p_daemon_bindings/control.py
@@ -5,7 +5,7 @@ Author: Kevin Mai-Husan Chia
 """
 
 import asyncio
-from contextlib import asynccontextmanager, closing
+from contextlib import asynccontextmanager
 from typing import AsyncIterator, Awaitable, Callable, Dict, Iterable, Optional, Sequence, Tuple
 from uuid import UUID, uuid4
 

--- a/hivemind/p2p/p2p_daemon_bindings/control.py
+++ b/hivemind/p2p/p2p_daemon_bindings/control.py
@@ -170,46 +170,63 @@ class ControlClient:
             yield self
 
     async def _read_from_persistent_conn(self, reader: asyncio.StreamReader):
-        while True:
-            resp = p2pd_pb.PersistentConnectionResponse()
-            try:
-                await read_pbmsg_safe(reader, resp)
-            except asyncio.IncompleteReadError:
-                break
+        try:
+            while True:
+                resp = p2pd_pb.PersistentConnectionResponse()
+                try:
+                    await read_pbmsg_safe(reader, resp)
+                except asyncio.IncompleteReadError:
+                    break
 
-            call_id = UUID(bytes=resp.callId)
+                call_id = UUID(bytes=resp.callId)
 
-            if resp.HasField("callUnaryResponse"):
-                if call_id in self._pending_calls and resp.callUnaryResponse.HasField("response"):
-                    self._pending_calls[call_id].set_result(resp.callUnaryResponse.response)
-                elif call_id in self._pending_calls and resp.callUnaryResponse.HasField("error"):
-                    remote_exc = P2PHandlerError(resp.callUnaryResponse.error.decode(errors="ignore"))
-                    self._pending_calls[call_id].set_exception(remote_exc)
+                if resp.HasField("callUnaryResponse"):
+                    if call_id in self._pending_calls and resp.callUnaryResponse.HasField("response"):
+                        self._pending_calls[call_id].set_result(resp.callUnaryResponse.response)
+                    elif call_id in self._pending_calls and resp.callUnaryResponse.HasField("error"):
+                        remote_exc = P2PHandlerError(resp.callUnaryResponse.error.decode(errors="ignore"))
+                        self._pending_calls[call_id].set_exception(remote_exc)
+                    else:
+                        logger.debug(f"Received unexpected unary call: {resp}")
+
+                elif resp.HasField("requestHandling"):
+                    handler_task = asyncio.create_task(self._handle_persistent_request(call_id, resp.requestHandling))
+                    self._handler_tasks[call_id] = handler_task
+
+                elif call_id in self._handler_tasks and resp.HasField("cancel"):
+                    cancel_task_if_running(self._handler_tasks[call_id])
+
+                elif call_id in self._pending_calls and resp.HasField("daemonError"):
+                    daemon_exc = P2PDaemonError(resp.daemonError.message)
+                    self._pending_calls[call_id].set_exception(daemon_exc)
+
+                elif call_id in self._pending_calls:
+                    self._pending_calls[call_id].set_result(None)
+
                 else:
-                    logger.debug(f"Received unexpected unary call: {resp}")
-
-            elif resp.HasField("requestHandling"):
-                handler_task = asyncio.create_task(self._handle_persistent_request(call_id, resp.requestHandling))
-                self._handler_tasks[call_id] = handler_task
-
-            elif call_id in self._handler_tasks and resp.HasField("cancel"):
-                cancel_task_if_running(self._handler_tasks[call_id])
-
-            elif call_id in self._pending_calls and resp.HasField("daemonError"):
-                daemon_exc = P2PDaemonError(resp.daemonError.message)
-                self._pending_calls[call_id].set_exception(daemon_exc)
-
-            elif call_id in self._pending_calls:
-                self._pending_calls[call_id].set_result(None)
-
-            else:
-                logger.debug(f"Received unexpected response from daemon: {resp}")
+                    logger.debug(f"Received unexpected response from daemon: {resp}")
+        except asyncio.CancelledError:
+            # Task was cancelled, clean up gracefully
+            pass
 
     async def _write_to_persistent_conn(self, writer: asyncio.StreamWriter):
-        with closing(writer):
+        try:
             while True:
-                msg = await self._pending_messages.get()
-                await write_pbmsg(writer, msg)
+                try:
+                    msg = await self._pending_messages.get()
+                    await write_pbmsg(writer, msg)
+                except (asyncio.CancelledError, RuntimeError):
+                    # Task was cancelled or event loop closed
+                    break
+        finally:
+            # Close writer safely, avoiding "Event loop is closed" errors
+            try:
+                if not writer.is_closing():
+                    writer.close()
+                    await writer.wait_closed()
+            except (RuntimeError, ConnectionError):
+                # Event loop might be closed or connection already closed
+                pass
 
     async def _handle_persistent_request(self, call_id: UUID, request: p2pd_pb.CallUnaryRequest):
         if request.proto not in self.unary_handlers:

--- a/hivemind/utils/asyncio.py
+++ b/hivemind/utils/asyncio.py
@@ -205,6 +205,6 @@ def cancel_task_if_running(task: Optional[asyncio.Task]) -> None:
             if loop.is_running():
                 task.cancel()
         except RuntimeError as e:
-            # Only ignore event loop closure errors
-            if "Event loop is closed" not in str(e):
+            # Ignore event loop closure and missing event loop errors
+            if "Event loop is closed" not in str(e) and "There is no current event loop" not in str(e):
                 raise

--- a/hivemind/utils/mpfuture.py
+++ b/hivemind/utils/mpfuture.py
@@ -9,7 +9,7 @@ import uuid
 from concurrent.futures import InvalidStateError
 from contextlib import nullcontext
 from enum import Enum, auto
-from multiprocessing import shared_memory
+from multiprocessing.shared_memory import SharedMemory
 from typing import Any, Callable, Dict, Generic, Optional, TypeVar
 from weakref import ref
 
@@ -61,7 +61,7 @@ class MPFuture(base.Future, Generic[ResultType]):
         self._origin_pid, self._uid = os.getpid(), uuid.uuid4().int
 
         # Create a dedicated 1-byte shared memory for this future's state
-        self._shared_memory = shared_memory.SharedMemory(create=True, size=1)
+        self._shared_memory = SharedMemory(create=True, size=1)
         self._shared_state_code = memoryview(self._shared_memory.buf)
         self._shared_memory_name = self._shared_memory.name
         self._state_cache: Dict[State, State] = {}
@@ -323,7 +323,7 @@ class MPFuture(base.Future, Generic[ResultType]):
             if self._shared_memory_name:
                 try:
                     # Reconnect to existing shared memory (don't store reference since we don't own it)
-                    reconnected_mem = shared_memory.SharedMemory(name=self._shared_memory_name)
+                    reconnected_mem = SharedMemory(name=self._shared_memory_name)
                     self._shared_state_code = memoryview(reconnected_mem.buf)
                 except FileNotFoundError:
                     # Shared memory no longer exists, fall back to local copy

--- a/modal_ci.py
+++ b/modal_ci.py
@@ -81,15 +81,10 @@ def setup_environment(*, build_p2pd=False):
 
     subprocess.run(install_cmd, check=True)
 
-    environment = os.environ.copy()
-    environment["HIVEMIND_MEMORY_SHARING_STRATEGY"] = "file_descriptor"
-
-    return environment
-
 
 @app.function(image=image, timeout=600, cpu=8, memory=8192)
 def run_tests():
-    environment = setup_environment(build_p2pd=False)
+    setup_environment(build_p2pd=False)
 
     subprocess.run(
         [
@@ -102,13 +97,12 @@ def run_tests():
             "tests",
         ],
         check=True,
-        env=environment,
     )
 
 
 @app.function(image=image, timeout=900, cpu=8, memory=8192, secrets=[codecov_secret])
 def run_codecov():
-    environment = setup_environment(build_p2pd=False)
+    setup_environment(build_p2pd=False)
 
     subprocess.run(
         [
@@ -120,10 +114,10 @@ def run_codecov():
             "tests",
         ],
         check=True,
-        env=environment,
     )
 
     # Forward GitHub Actions environment variables to the codecov command
+    environment = os.environ.copy()
     environment.update(
         {
             "CODECOV_TOKEN": os.environ["CODECOV_TOKEN"],
@@ -149,7 +143,7 @@ def run_codecov():
 
 @app.function(image=image_with_golang, timeout=600, cpu=1, memory=4096)
 def build_and_test_p2pd():
-    environment = setup_environment(build_p2pd=True)
+    setup_environment(build_p2pd=True)
 
     subprocess.run(
         [
@@ -160,5 +154,4 @@ def build_and_test_p2pd():
             "tests",
         ],
         check=True,
-        env=environment,
     )


### PR DESCRIPTION
This PR rewrites hivemind.utils.MPFuture to use native SharedMemory from Python standard library, available since Python 3.8. As a result, we can reduce the codebase's reliance on PyTorch and make MPFuture easier to maintain